### PR TITLE
feat(mcp): add elicitation interrupt support

### DIFF
--- a/libs/langchain_v1/langchain/mcp/callbacks.py
+++ b/libs/langchain_v1/langchain/mcp/callbacks.py
@@ -3,10 +3,10 @@
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
+from mcp.client.session import ClientRequestContext as MCPRequestContext
 from mcp.client.session import ElicitationFnT as MCPElicitationFnT
 from mcp.client.session import LoggingFnT as MCPLoggingFnT
-from mcp.shared.context import RequestContext as MCPRequestContext
-from mcp.shared.session import ProgressFnT as MCPProgressFnT
+from mcp.client.session import ProgressFnT as MCPProgressFnT
 from mcp.types import (
     ElicitRequestParams as MCPElicitRequestParams,
 )
@@ -51,7 +51,7 @@ class LoggingMessageCallback(Protocol):
 
 @runtime_checkable
 class ProgressCallback(Protocol):
-    """Light wrapper around the mcp.shared.session.ProgressFnT.
+    """Light wrapper around the mcp.client.session.ProgressFnT.
 
     Injects callback context as the last argument.
     """

--- a/libs/langchain_v1/langchain/mcp/callbacks.py
+++ b/libs/langchain_v1/langchain/mcp/callbacks.py
@@ -17,6 +17,8 @@ from mcp.types import (
     LoggingMessageNotificationParams as MCPLoggingMessageNotificationParams,
 )
 
+from langchain.mcp.elicitation import ElicitationMode, interrupt_for_elicitation
+
 # Type aliases to avoid direct MCP type dependencies
 LoggingFnT = MCPLoggingFnT
 ProgressFnT = MCPProgressFnT
@@ -101,11 +103,28 @@ class Callbacks:
     on_progress: ProgressCallback | None = None
     on_elicitation: ElicitationCallback | None = None
 
-    def to_mcp_format(self, *, context: CallbackContext) -> _MCPCallbacks:
-        """Convert the LangChain MCP client callbacks to MCP SDK callbacks.
+    def to_mcp_format(
+        self,
+        *,
+        context: CallbackContext,
+        elicitation: ElicitationMode | None = None,
+    ) -> _MCPCallbacks:
+        """Convert LangChain callbacks to MCP SDK callbacks.
 
-        Injects the LangChain CallbackContext as the last argument.
+        Args:
+            context: Provenance to pass to LangChain callbacks.
+            elicitation: If `"interrupt"`, surface elicitation through a LangGraph
+                interrupt rather than a custom callback.
+
+        Returns:
+            MCP SDK-compatible callbacks.
+
+        Raises:
+            ValueError: If a custom elicitation callback and interrupt handling are both set.
         """
+        if elicitation == "interrupt" and self.on_elicitation is not None:
+            msg = 'Set either `on_elicitation` or `elicitation="interrupt"`, not both.'
+            raise ValueError(msg)
         if (on_logging_message := self.on_logging_message) is not None:
 
             async def mcp_logging_callback(
@@ -124,7 +143,14 @@ class Callbacks:
         else:
             mcp_progress_callback = None
 
-        if (on_elicitation := self.on_elicitation) is not None:
+        if elicitation == "interrupt":
+
+            async def mcp_elicitation_callback(
+                mcp_context: MCPRequestContext,  # noqa: ARG001
+                params: ElicitRequestParams,
+            ) -> MCPElicitResult:
+                return interrupt_for_elicitation(params, context)
+        elif (on_elicitation := self.on_elicitation) is not None:
 
             async def mcp_elicitation_callback(
                 mcp_context: MCPRequestContext,

--- a/libs/langchain_v1/langchain/mcp/client.py
+++ b/libs/langchain_v1/langchain/mcp/client.py
@@ -20,14 +20,7 @@ from langchain.mcp.callbacks import CallbackContext, Callbacks
 from langchain.mcp.interceptors import ToolCallInterceptor
 from langchain.mcp.prompts import load_mcp_prompt
 from langchain.mcp.resources import load_mcp_resources
-from langchain.mcp.sessions import (
-    Connection,
-    McpHttpClientFactory,
-    SSEConnection,
-    StdioConnection,
-    StreamableHttpConnection,
-    create_session,
-)
+from langchain.mcp.sessions import Connection, create_session
 from langchain.mcp.tools import load_mcp_tools
 
 ASYNC_CONTEXT_MANAGER_ERROR = (
@@ -110,17 +103,11 @@ class MultiServerMCPClient:
         self.tool_name_prefix = tool_name_prefix
 
     @asynccontextmanager
-    async def session(
-        self,
-        server_name: str,
-        *,
-        auto_initialize: bool = True,
-    ) -> AsyncIterator[ClientSession]:
+    async def session(self, server_name: str) -> AsyncIterator[ClientSession]:
         """Connect to an MCP server and initialize a session.
 
         Args:
             server_name: Name to identify this server connection
-            auto_initialize: Whether to automatically initialize the session
 
         Raises:
             ValueError: If the server name is not found in the connections
@@ -143,8 +130,6 @@ class MultiServerMCPClient:
         async with create_session(
             self.connections[server_name], mcp_callbacks=mcp_callbacks
         ) as session:
-            if auto_initialize:
-                await session.initialize()
             yield session
 
     async def get_tools(self, *, server_name: str | None = None) -> list[BaseTool]:
@@ -278,9 +263,6 @@ class MultiServerMCPClient:
 
 __all__ = [
     "Callbacks",
-    "McpHttpClientFactory",
+    "Connection",
     "MultiServerMCPClient",
-    "SSEConnection",
-    "StdioConnection",
-    "StreamableHttpConnection",
 ]

--- a/libs/langchain_v1/langchain/mcp/client.py
+++ b/libs/langchain_v1/langchain/mcp/client.py
@@ -26,7 +26,6 @@ from langchain.mcp.sessions import (
     SSEConnection,
     StdioConnection,
     StreamableHttpConnection,
-    WebsocketConnection,
     create_session,
 )
 from langchain.mcp.tools import load_mcp_tools
@@ -284,5 +283,4 @@ __all__ = [
     "SSEConnection",
     "StdioConnection",
     "StreamableHttpConnection",
-    "WebsocketConnection",
 ]

--- a/libs/langchain_v1/langchain/mcp/client.py
+++ b/libs/langchain_v1/langchain/mcp/client.py
@@ -17,6 +17,7 @@ from mcp import ClientSession
 from typing_extensions import Self
 
 from langchain.mcp.callbacks import CallbackContext, Callbacks
+from langchain.mcp.elicitation import ElicitationMode
 from langchain.mcp.interceptors import ToolCallInterceptor
 from langchain.mcp.prompts import load_mcp_prompt
 from langchain.mcp.resources import load_mcp_resources
@@ -47,6 +48,7 @@ class MultiServerMCPClient:
         *,
         callbacks: Callbacks | None = None,
         tool_interceptors: list[ToolCallInterceptor] | None = None,
+        elicitation: ElicitationMode | None = None,
         tool_name_prefix: bool = False,
     ) -> None:
         """Initialize a `MultiServerMCPClient` with MCP servers connections.
@@ -57,6 +59,9 @@ class MultiServerMCPClient:
             callbacks: Optional callbacks for handling notifications and events.
             tool_interceptors: Optional list of tool call interceptors for modifying
                 requests and responses.
+            elicitation: If `"interrupt"`, surface server elicitation through LangGraph
+                interrupts when invoking tools. Legacy MCP server-initiated elicitation
+                requires the connection to use `mode="legacy"`.
             tool_name_prefix: If `True`, tool names are prefixed with the server name
                 using an underscore separator (e.g., `"weather_search"` instead of
                 `"search"`). This helps avoid conflicts when multiple servers have tools
@@ -100,6 +105,7 @@ class MultiServerMCPClient:
         self.connections: dict[str, Connection] = connections if connections is not None else {}
         self.callbacks = callbacks or Callbacks()
         self.tool_interceptors = tool_interceptors or []
+        self.elicitation = elicitation
         self.tool_name_prefix = tool_name_prefix
 
     @asynccontextmanager
@@ -124,7 +130,8 @@ class MultiServerMCPClient:
             raise ValueError(msg)
 
         mcp_callbacks = self.callbacks.to_mcp_format(
-            context=CallbackContext(server_name=server_name)
+            context=CallbackContext(server_name=server_name),
+            elicitation=self.elicitation,
         )
 
         async with create_session(
@@ -160,6 +167,7 @@ class MultiServerMCPClient:
                 callbacks=self.callbacks,
                 server_name=server_name,
                 tool_interceptors=self.tool_interceptors,
+                elicitation=self.elicitation,
                 tool_name_prefix=self.tool_name_prefix,
             )
 
@@ -173,6 +181,7 @@ class MultiServerMCPClient:
                     callbacks=self.callbacks,
                     server_name=name,
                     tool_interceptors=self.tool_interceptors,
+                    elicitation=self.elicitation,
                     tool_name_prefix=self.tool_name_prefix,
                 )
             )

--- a/libs/langchain_v1/langchain/mcp/elicitation.py
+++ b/libs/langchain_v1/langchain/mcp/elicitation.py
@@ -1,0 +1,196 @@
+"""Bridge MCP elicitation callbacks to LangGraph interrupts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast
+
+from langchain_core.tools import ToolException
+from langgraph.types import interrupt
+from mcp.types import ElicitRequestParams as _ElicitRequestParams
+from mcp.types import ElicitResult as _ElicitResult
+from typing_extensions import TypedDict
+
+if TYPE_CHECKING:
+    from langchain.mcp.callbacks import CallbackContext
+
+ElicitationMode: TypeAlias = Literal["interrupt"]
+"""How MCP tools surface server-initiated elicitation requests."""
+
+
+class MCPFormElicitation(TypedDict):
+    """A structured form an MCP server asks the application to present."""
+
+    type: Literal["mcp_elicitation"]
+    mode: Literal["form"]
+    server: str
+    message: str
+    response_schema: dict[str, Any]
+
+
+class MCPUrlElicitation(TypedDict):
+    """A URL an MCP server asks the application to present for consent."""
+
+    type: Literal["mcp_elicitation"]
+    mode: Literal["url"]
+    server: str
+    message: str
+    url: str
+
+
+MCPElicitation: TypeAlias = MCPFormElicitation | MCPUrlElicitation
+"""A discriminated MCP elicitation interrupt payload."""
+
+
+MCPFormValue: TypeAlias = str | int | float | bool | list[str] | None
+"""A primitive value permitted by MCP form-mode elicitation."""
+
+MCPFormContent: TypeAlias = dict[str, MCPFormValue]
+"""The flat object content accepted by an MCP form-mode elicitation request."""
+
+
+class MCPFormElicitationAcceptedResponse(TypedDict):
+    """An accepted form response with values matching the response schema."""
+
+    action: Literal["accept"]
+    content: MCPFormContent
+
+
+class MCPUrlElicitationAcceptedResponse(TypedDict):
+    """Consent to a URL-mode interaction without passing user data to the server."""
+
+    action: Literal["accept"]
+
+
+class MCPElicitationDeclinedResponse(TypedDict):
+    """An explicit user refusal of an elicitation request."""
+
+    action: Literal["decline"]
+
+
+class MCPElicitationCancelledResponse(TypedDict):
+    """A user dismissal of an elicitation request without a decision."""
+
+    action: Literal["cancel"]
+
+
+MCPFormElicitationResponse: TypeAlias = (
+    MCPFormElicitationAcceptedResponse
+    | MCPElicitationDeclinedResponse
+    | MCPElicitationCancelledResponse
+)
+"""A valid response to a form-mode elicitation interrupt."""
+
+MCPUrlElicitationResponse: TypeAlias = (
+    MCPUrlElicitationAcceptedResponse
+    | MCPElicitationDeclinedResponse
+    | MCPElicitationCancelledResponse
+)
+"""A valid response to a URL-mode elicitation interrupt."""
+
+MCPElicitationResponse: TypeAlias = MCPFormElicitationResponse | MCPUrlElicitationResponse
+"""A valid response to an MCP elicitation interrupt of either mode."""
+
+MCPElicitationResume: TypeAlias = MCPElicitationResponse | dict[str, MCPElicitationResponse]
+"""One elicitation response or a map of responses keyed by MCP input request ID."""
+
+
+def interrupt_for_elicitation(
+    params: _ElicitRequestParams,
+    context: CallbackContext,
+) -> _ElicitResult:
+    """Pause a tool execution for a server-initiated MCP elicitation request.
+
+    Args:
+        params: The elicitation request received from the MCP server.
+        context: Provenance for the server and tool issuing the request.
+
+    Returns:
+        The MCP result constructed from the value passed to `Command(resume=...)`.
+
+    Raises:
+        ToolException: If the server request or resumed user response is invalid.
+    """
+    mode = getattr(params, "mode", "form")
+    if mode == "form":
+        response_schema = getattr(params, "requested_schema", None)
+        if not isinstance(response_schema, dict):
+            msg = "MCP form elicitation must include an object response schema."
+            raise ToolException(msg)
+        payload: MCPElicitation = {
+            "type": "mcp_elicitation",
+            "mode": "form",
+            "server": context.server_name,
+            "message": params.message,
+            "response_schema": response_schema,
+        }
+    elif mode == "url":
+        url = getattr(params, "url", None)
+        if url is None:
+            msg = "MCP URL elicitation must include a URL."
+            raise ToolException(msg)
+        payload = {
+            "type": "mcp_elicitation",
+            "mode": "url",
+            "server": context.server_name,
+            "message": params.message,
+            "url": str(url),
+        }
+    else:
+        msg = f"MCP elicitation mode {mode!r} is not supported."
+        raise ToolException(msg)
+
+    resume_value = cast("MCPElicitationResponse", interrupt(payload))
+    return _to_mcp_result(resume_value, mode=mode)
+
+
+def _validate_form_content(content: Mapping[object, object]) -> MCPFormContent:
+    """Validate content against the primitive MCP form-mode value subset."""
+    validated: MCPFormContent = {}
+    for key, value in content.items():
+        if not isinstance(key, str):
+            msg = "MCP form elicitation content keys must be strings."
+            raise ToolException(msg)
+        if (
+            value is None
+            or isinstance(value, str | int | float | bool)
+            or (isinstance(value, list) and all(isinstance(item, str) for item in value))
+        ):
+            validated[key] = value
+        else:
+            msg = "MCP form elicitation content contains an unsupported value."
+            raise ToolException(msg)
+    return validated
+
+
+def _to_mcp_result(resume_value: MCPElicitationResponse, *, mode: str) -> _ElicitResult:
+    """Validate a cast LangGraph resume value and convert it to an MCP result."""
+    if not isinstance(resume_value, Mapping):
+        msg = "Resume an MCP elicitation with an action response object."
+        raise ToolException(msg)
+
+    action = resume_value.get("action")
+    if action == "accept":
+        if mode == "form":
+            content = resume_value.get("content")
+            if not isinstance(content, Mapping):
+                msg = "Accepted MCP form elicitation requires object content."
+                raise ToolException(msg)
+            return _ElicitResult(action="accept", content=_validate_form_content(content))
+        if "content" in resume_value:
+            msg = "Accepted MCP URL elicitation must not include content."
+            raise ToolException(msg)
+        return _ElicitResult(action="accept")
+    if action == "decline":
+        if "content" in resume_value:
+            msg = "Declined MCP elicitation must not include content."
+            raise ToolException(msg)
+        return _ElicitResult(action="decline")
+    if action == "cancel":
+        if "content" in resume_value:
+            msg = "Cancelled MCP elicitation must not include content."
+            raise ToolException(msg)
+        return _ElicitResult(action="cancel")
+
+    msg = "MCP elicitation responses require accept, decline, or cancel."
+    raise ToolException(msg)

--- a/libs/langchain_v1/langchain/mcp/resources.py
+++ b/libs/langchain_v1/langchain/mcp/resources.py
@@ -30,7 +30,7 @@ def convert_mcp_resource_to_langchain_blob(resource_uri: str, contents: Resource
         msg = f"Unsupported content type for URI {resource_uri}"
         raise TypeError(msg)
 
-    return Blob.from_data(data=data, mime_type=contents.mimeType, metadata={"uri": resource_uri})
+    return Blob.from_data(data=data, mime_type=contents.mime_type, metadata={"uri": resource_uri})
 
 
 async def get_mcp_resource(session: ClientSession, uri: str) -> list[Blob]:

--- a/libs/langchain_v1/langchain/mcp/sessions.py
+++ b/libs/langchain_v1/langchain/mcp/sessions.py
@@ -1,7 +1,7 @@
 """Session management for different MCP transport types.
 
 This module provides connection configurations and session management for various
-MCP transport types including stdio, SSE, WebSocket, and streamable HTTP.
+MCP transport types including stdio, SSE, and streamable HTTP.
 """
 
 from __future__ import annotations
@@ -10,17 +10,17 @@ from contextlib import asynccontextmanager
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 
+import httpx2
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
+from mcp.shared._httpx_utils import create_mcp_http_client
 from typing_extensions import NotRequired, TypedDict
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
     from pathlib import Path
-
-    import httpx
 
     from langchain.mcp.callbacks import _MCPCallbacks
 
@@ -37,15 +37,15 @@ DEFAULT_STREAMABLE_HTTP_SSE_READ_TIMEOUT = timedelta(seconds=60 * 5)
 
 
 class McpHttpClientFactory(Protocol):
-    """Protocol for creating httpx.AsyncClient instances for MCP connections."""
+    """Protocol for creating httpx2.AsyncClient instances for MCP connections."""
 
     def __call__(
         self,
         headers: dict[str, str] | None = None,
-        timeout: httpx.Timeout | None = None,
-        auth: httpx.Auth | None = None,
-    ) -> httpx.AsyncClient:
-        """Create an httpx.AsyncClient instance.
+        timeout: httpx2.Timeout | None = None,
+        auth: httpx2.Auth | None = None,
+    ) -> httpx2.AsyncClient:
+        """Create an httpx2.AsyncClient instance.
 
         Args:
             headers: HTTP headers to include in requests.
@@ -53,7 +53,7 @@ class McpHttpClientFactory(Protocol):
             auth: Authentication configuration.
 
         Returns:
-            Configured httpx.AsyncClient instance.
+            Configured httpx2.AsyncClient instance.
         """
         ...
 
@@ -134,9 +134,9 @@ class SSEConnection(TypedDict):
     """Additional keyword arguments to pass to the ClientSession."""
 
     httpx_client_factory: NotRequired[McpHttpClientFactory | None]
-    """Custom factory for httpx.AsyncClient (optional)."""
+    """Custom factory for httpx2.AsyncClient (optional)."""
 
-    auth: NotRequired[httpx.Auth]
+    auth: NotRequired[httpx2.Auth]
     """Optional authentication for the HTTP client."""
 
 
@@ -165,25 +165,13 @@ class StreamableHttpConnection(TypedDict):
     """Additional keyword arguments to pass to the ClientSession."""
 
     httpx_client_factory: NotRequired[McpHttpClientFactory | None]
-    """Custom factory for httpx.AsyncClient (optional)."""
+    """Custom factory for httpx2.AsyncClient (optional)."""
 
-    auth: NotRequired[httpx.Auth]
+    auth: NotRequired[httpx2.Auth]
     """Optional authentication for the HTTP client."""
 
 
-class WebsocketConnection(TypedDict):
-    """Configuration for WebSocket transport connections to MCP servers."""
-
-    transport: Literal["websocket"]
-
-    url: str
-    """The URL of the Websocket endpoint to connect to."""
-
-    session_kwargs: NotRequired[dict[str, Any] | None]
-    """Additional keyword arguments to pass to the ClientSession"""
-
-
-Connection = StdioConnection | SSEConnection | StreamableHttpConnection | WebsocketConnection
+Connection = StdioConnection | SSEConnection | StreamableHttpConnection
 
 
 @asynccontextmanager
@@ -239,7 +227,7 @@ async def _create_sse_session(
     sse_read_timeout: float = DEFAULT_SSE_READ_TIMEOUT,
     session_kwargs: dict[str, Any] | None = None,
     httpx_client_factory: McpHttpClientFactory | None = None,
-    auth: httpx.Auth | None = None,
+    auth: httpx2.Auth | None = None,
 ) -> AsyncIterator[ClientSession]:
     """Create a new session to an MCP server using SSE.
 
@@ -249,7 +237,7 @@ async def _create_sse_session(
         timeout: HTTP timeout.
         sse_read_timeout: SSE read timeout.
         session_kwargs: Additional keyword arguments to pass to the ClientSession.
-        httpx_client_factory: Custom factory for httpx.AsyncClient (optional).
+        httpx_client_factory: Custom factory for httpx2.AsyncClient (optional).
         auth: Authentication for the HTTP client.
 
     Yields:
@@ -280,7 +268,7 @@ async def _create_streamable_http_session(
     terminate_on_close: bool = True,
     session_kwargs: dict[str, Any] | None = None,
     httpx_client_factory: McpHttpClientFactory | None = None,
-    auth: httpx.Auth | None = None,
+    auth: httpx2.Auth | None = None,
 ) -> AsyncIterator[ClientSession]:
     """Create a new session to an MCP server using Streamable HTTP.
 
@@ -292,62 +280,28 @@ async def _create_streamable_http_session(
             disconnecting.
         terminate_on_close: Whether to terminate the session on close.
         session_kwargs: Additional keyword arguments to pass to the ClientSession.
-        httpx_client_factory: Custom factory for httpx.AsyncClient (optional).
+        httpx_client_factory: Custom factory for httpx2.AsyncClient (optional).
         auth: Authentication for the HTTP client.
 
     Yields:
         An initialized ClientSession.
     """
-    # Create and store the connection
-    kwargs = {}
-    if httpx_client_factory is not None:
-        kwargs["httpx_client_factory"] = httpx_client_factory
+    # `streamable_http_client` no longer takes the HTTP options directly; they belong to
+    # the client it is handed, which `httpx_client_factory` may supply instead.
+    factory = httpx_client_factory or create_mcp_http_client
+    http_client = factory(
+        headers=headers,
+        timeout=httpx2.Timeout(timeout.total_seconds(), read=sse_read_timeout.total_seconds()),
+        auth=auth,
+    )
 
     async with (
-        streamablehttp_client(
+        http_client,
+        streamable_http_client(
             url,
-            headers,
-            timeout,
-            sse_read_timeout,
-            terminate_on_close,
-            auth=auth,
-            **kwargs,
-        ) as (read, write, _),
-        ClientSession(read, write, **(session_kwargs or {})) as session,
-    ):
-        yield session
-
-
-@asynccontextmanager
-async def _create_websocket_session(
-    *,
-    url: str,
-    session_kwargs: dict[str, Any] | None = None,
-) -> AsyncIterator[ClientSession]:
-    """Create a new session to an MCP server using Websockets.
-
-    Args:
-        url: URL of the Websocket endpoint.
-        session_kwargs: Additional keyword arguments to pass to the ClientSession.
-
-    Yields:
-        An initialized ClientSession.
-
-    Raises:
-        ImportError: If websockets package is not installed.
-    """
-    try:
-        from mcp.client.websocket import websocket_client  # noqa: PLC0415
-    except ImportError:
-        msg = (
-            "Could not import websocket_client. "
-            "To use Websocket connections, please install the required dependency: "
-            "'pip install mcp[ws]' or 'pip install websockets'"
-        )
-        raise ImportError(msg) from None
-
-    async with (
-        websocket_client(url) as (read, write),
+            http_client=http_client,
+            terminate_on_close=terminate_on_close,
+        ) as (read, write),
         ClientSession(read, write, **(session_kwargs or {})) as session,
     ):
         yield session
@@ -374,7 +328,7 @@ async def create_session(
         msg = (
             "Configuration error: Missing 'transport' key in server configuration. "
             "Each server must include 'transport' with one of: "
-            "'stdio', 'sse', 'websocket', 'http'. "
+            "'stdio', 'sse', 'http'. "
             "Please refer to the langchain-mcp-adapters documentation for more details."
         )
         raise ValueError(msg)
@@ -410,15 +364,6 @@ async def create_session(
             raise ValueError(msg)
         async with _create_stdio_session(**params) as session:
             yield session
-    elif transport == "websocket":
-        if "url" not in params:
-            msg = "'url' parameter is required for Websocket connection"
-            raise ValueError(msg)
-        async with _create_websocket_session(**params) as session:
-            yield session
     else:
-        msg = (
-            f"Unsupported transport: {transport}. "
-            f"Must be one of: 'stdio', 'sse', 'websocket', 'http'"
-        )
+        msg = f"Unsupported transport: {transport}. Must be one of: 'stdio', 'sse', 'http'"
         raise ValueError(msg)

--- a/libs/langchain_v1/langchain/mcp/sessions.py
+++ b/libs/langchain_v1/langchain/mcp/sessions.py
@@ -1,310 +1,139 @@
-"""Session management for different MCP transport types.
+"""Connection configuration and session management for MCP servers.
 
-This module provides connection configurations and session management for various
-MCP transport types including stdio, SSE, and streamable HTTP.
+Connections are described with the MCP SDK's own types and opened with `create_session`,
+which builds an [`mcp.Client`][mcp.Client] and yields its session. Transports, protocol
+negotiation, and HTTP client construction all belong to that client.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping
 from contextlib import asynccontextmanager
-from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Literal, Protocol
+from typing import TYPE_CHECKING, Any, TypeAlias
 
-import httpx2
-from mcp import ClientSession, StdioServerParameters
+from mcp import Client, StdioServerParameters
+from mcp.client.session_group import (
+    ServerParameters,
+    SseServerParameters,
+    StreamableHttpParameters,
+)
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamable_http_client
 from mcp.shared._httpx_utils import create_mcp_http_client
-from typing_extensions import NotRequired, TypedDict
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
-    from pathlib import Path
+
+    from mcp import ClientSession
 
     from langchain.mcp.callbacks import _MCPCallbacks
 
-EncodingErrorHandler = Literal["strict", "ignore", "replace"]
+Connection: TypeAlias = ServerParameters | Mapping[str, Any] | Callable[[], Any]
+"""How to reach one MCP server.
 
-DEFAULT_ENCODING = "utf-8"
-DEFAULT_ENCODING_ERROR_HANDLER: EncodingErrorHandler = "strict"
+One of:
 
-DEFAULT_HTTP_TIMEOUT = 5
-DEFAULT_SSE_READ_TIMEOUT = 60 * 5
+- The MCP SDK's [`ServerParameters`][mcp.client.session_group.ServerParameters] —
+  `StdioServerParameters`, `SseServerParameters`, or `StreamableHttpParameters`.
+- A mapping of the same fields, selected by an optional `transport` key of `"stdio"`,
+  `"sse"`, or `"streamable_http"` and otherwise inferred from `command` or `url`. The
+  mapping additionally accepts `auth` and `http_client` for the HTTP transports, and any
+  [`Client`][mcp.Client] option such as `mode`, none of which the SDK's parameter models
+  describe.
+- A callable returning a transport or a `Client`, for anything the above cannot express.
+  It must be a callable rather than an instance, because a session is opened per
+  operation and both are single-use:
 
-DEFAULT_STREAMABLE_HTTP_TIMEOUT = timedelta(seconds=30)
-DEFAULT_STREAMABLE_HTTP_SSE_READ_TIMEOUT = timedelta(seconds=60 * 5)
+  ```python
+  lambda: streamable_http_client(url, http_client=authed_client)
+  lambda: Client(transport, mode="legacy", cache=cache_config)
+  ```
+"""
 
+_PARAMETERS_BY_TRANSPORT: dict[str, type[ServerParameters]] = {
+    "stdio": StdioServerParameters,
+    "sse": SseServerParameters,
+    "http": StreamableHttpParameters,
+    "streamable_http": StreamableHttpParameters,
+    "streamable-http": StreamableHttpParameters,
+}
 
-class McpHttpClientFactory(Protocol):
-    """Protocol for creating httpx2.AsyncClient instances for MCP connections."""
-
-    def __call__(
-        self,
-        headers: dict[str, str] | None = None,
-        timeout: httpx2.Timeout | None = None,
-        auth: httpx2.Auth | None = None,
-    ) -> httpx2.AsyncClient:
-        """Create an httpx2.AsyncClient instance.
-
-        Args:
-            headers: HTTP headers to include in requests.
-            timeout: Request timeout configuration.
-            auth: Authentication configuration.
-
-        Returns:
-            Configured httpx2.AsyncClient instance.
-        """
-        ...
-
-
-class StdioConnection(TypedDict):
-    """Configuration for stdio transport connections to MCP servers."""
-
-    transport: Literal["stdio"]
-
-    command: str
-    """The executable to run to start the server."""
-
-    args: list[str]
-    """Command line arguments to pass to the executable."""
-
-    env: NotRequired[dict[str, str] | None]
-    """The environment to use when spawning the process.
-
-    If not specified or set to None, a subset of the default environment
-    variables from the current process will be used.
-
-    Please refer to the MCP SDK documentation for details on which
-    environment variables are included by default. The behavior
-    varies by operating system.
-
-    https://github.com/modelcontextprotocol/python-sdk/blob/c47c767ff437ee88a19e6b9001e2472cb6f7d5ed/src/mcp/client/stdio/__init__.py#L51
-    """
-
-    cwd: NotRequired[str | Path | None]
-    """The working directory to use when spawning the process."""
-
-    encoding: NotRequired[str]
-    """The text encoding used when sending/receiving messages to the server.
-
-    Default is 'utf-8'.
-    """
-
-    encoding_error_handler: NotRequired[EncodingErrorHandler]
-    """
-    The text encoding error handler.
-
-    See https://docs.python.org/3/library/codecs.html#codec-base-classes for
-    explanations of possible values.
-
-    Default is 'strict', which raises an error on encoding/decoding errors.
-    """
-
-    session_kwargs: NotRequired[dict[str, Any] | None]
-    """Additional keyword arguments to pass to the ClientSession."""
+# Keys that configure the transport or the client rather than describing the server. The
+# SDK's parameter models ignore keys they do not declare, so these ride along in a mapping.
+_TRANSPORT_ONLY_KEYS = frozenset({"auth", "http_client"})
+_NOT_CLIENT_KEYS = frozenset({"transport", "session_kwargs"}) | _TRANSPORT_ONLY_KEYS
 
 
-class SSEConnection(TypedDict):
-    """Configuration for Server-Sent Events (SSE) transport connections to MCP."""
-
-    transport: Literal["sse"]
-
-    url: str
-    """The URL of the SSE endpoint to connect to."""
-
-    headers: NotRequired[dict[str, Any] | None]
-    """HTTP headers to send to the SSE endpoint."""
-
-    timeout: NotRequired[float]
-    """HTTP timeout.
-
-    Default is 5 seconds. If the server takes longer to respond,
-    you can increase this value.
-    """
-
-    sse_read_timeout: NotRequired[float]
-    """SSE read timeout.
-
-    Default is 300 seconds (5 minutes). This is how long the client will
-    wait for a new event before disconnecting.
-    """
-
-    session_kwargs: NotRequired[dict[str, Any] | None]
-    """Additional keyword arguments to pass to the ClientSession."""
-
-    httpx_client_factory: NotRequired[McpHttpClientFactory | None]
-    """Custom factory for httpx2.AsyncClient (optional)."""
-
-    auth: NotRequired[httpx2.Auth]
-    """Optional authentication for the HTTP client."""
-
-
-class StreamableHttpConnection(TypedDict):
-    """Connection configuration for Streamable HTTP transport."""
-
-    transport: Literal["streamable_http"]
-
-    url: str
-    """The URL of the endpoint to connect to."""
-
-    headers: NotRequired[dict[str, Any] | None]
-    """HTTP headers to send to the endpoint."""
-
-    timeout: NotRequired[timedelta]
-    """HTTP timeout."""
-
-    sse_read_timeout: NotRequired[timedelta]
-    """How long (in seconds) the client will wait for a new event before disconnecting.
-    All other HTTP operations are controlled by `timeout`."""
-
-    terminate_on_close: NotRequired[bool]
-    """Whether to terminate the session on close."""
-
-    session_kwargs: NotRequired[dict[str, Any] | None]
-    """Additional keyword arguments to pass to the ClientSession."""
-
-    httpx_client_factory: NotRequired[McpHttpClientFactory | None]
-    """Custom factory for httpx2.AsyncClient (optional)."""
-
-    auth: NotRequired[httpx2.Auth]
-    """Optional authentication for the HTTP client."""
-
-
-Connection = StdioConnection | SSEConnection | StreamableHttpConnection
-
-
-@asynccontextmanager
-async def _create_stdio_session(
+def _transport_from_parameters(
+    params: ServerParameters,
     *,
-    command: str,
-    args: list[str],
-    env: dict[str, str] | None = None,
-    cwd: str | Path | None = None,
-    encoding: str = DEFAULT_ENCODING,
-    encoding_error_handler: Literal["strict", "ignore", "replace"] = DEFAULT_ENCODING_ERROR_HANDLER,
-    session_kwargs: dict[str, Any] | None = None,
-) -> AsyncIterator[ClientSession]:
-    """Create a new session to an MCP server using stdio.
+    auth: Any = None,
+    http_client: Any = None,
+) -> Any:
+    """Build a transport from the SDK's connection parameters.
 
-    Args:
-        command: Command to execute.
-        args: Arguments for the command.
-        env: Environment variables for the command.
-            If not specified, inherits a subset of the current environment.
-            The details are implemented in the MCP sdk.
-        cwd: Working directory for the command.
-        encoding: Character encoding.
-        encoding_error_handler: How to handle encoding errors.
-        session_kwargs: Additional keyword arguments to pass to the ClientSession.
+    `auth` and `http_client` are taken separately because the SDK's HTTP parameter models
+    describe neither, and they are the usual reason to reach for a transport.
 
-    Yields:
-        An initialized ClientSession.
+    Raises:
+        ValueError: If the parameters are of an unrecognized type.
     """
-    server_params = StdioServerParameters(
-        command=command,
-        args=args,
-        env=env,
-        cwd=cwd,
-        encoding=encoding,
-        encoding_error_handler=encoding_error_handler,
-    )
+    if isinstance(params, StdioServerParameters):
+        return stdio_client(params)
+    if isinstance(params, SseServerParameters):
+        return sse_client(
+            params.url,
+            headers=params.headers,
+            timeout=params.timeout,
+            sse_read_timeout=params.sse_read_timeout,
+            auth=auth,
+        )
+    if isinstance(params, StreamableHttpParameters):
+        return streamable_http_client(
+            params.url,
+            http_client=http_client or create_mcp_http_client(headers=params.headers, auth=auth),
+            terminate_on_close=params.terminate_on_close,
+        )
+    msg = f"Unsupported server parameters: {type(params).__name__}"
+    raise ValueError(msg)
 
-    # Create and store the connection
-    async with (
-        stdio_client(server_params) as (read, write),
-        ClientSession(read, write, **(session_kwargs or {})) as session,
-    ):
-        yield session
 
+def _parse_mapping(config: Mapping[str, Any]) -> tuple[ServerParameters, dict[str, Any]]:
+    """Split a mapping into the SDK's server parameters and the client options around them.
 
-@asynccontextmanager
-async def _create_sse_session(
-    *,
-    url: str,
-    headers: dict[str, Any] | None = None,
-    timeout: float = DEFAULT_HTTP_TIMEOUT,
-    sse_read_timeout: float = DEFAULT_SSE_READ_TIMEOUT,
-    session_kwargs: dict[str, Any] | None = None,
-    httpx_client_factory: McpHttpClientFactory | None = None,
-    auth: httpx2.Auth | None = None,
-) -> AsyncIterator[ClientSession]:
-    """Create a new session to an MCP server using SSE.
-
-    Args:
-        url: URL of the SSE server.
-        headers: HTTP headers to send to the SSE endpoint.
-        timeout: HTTP timeout.
-        sse_read_timeout: SSE read timeout.
-        session_kwargs: Additional keyword arguments to pass to the ClientSession.
-        httpx_client_factory: Custom factory for httpx2.AsyncClient (optional).
-        auth: Authentication for the HTTP client.
-
-    Yields:
-        An initialized ClientSession.
+    Raises:
+        ValueError: If the transport is unknown.
     """
-    # Create and store the connection
-    kwargs = {}
-    if httpx_client_factory is not None:
-        kwargs["httpx_client_factory"] = httpx_client_factory
+    name = config.get("transport") or ("stdio" if "command" in config else "http")
+    model = _PARAMETERS_BY_TRANSPORT.get(name)
+    if model is None:
+        known = ", ".join(sorted(_PARAMETERS_BY_TRANSPORT))
+        msg = f"Unsupported transport: {name}. Must be one of: {known}"
+        raise ValueError(msg)
 
-    async with (
-        sse_client(url, headers, timeout, sse_read_timeout, auth=auth, **kwargs) as (
-            read,
-            write,
-        ),
-        ClientSession(read, write, **(session_kwargs or {})) as session,
-    ):
-        yield session
+    params = model.model_validate(config)
+    client_kwargs = {
+        key: value
+        for key, value in config.items()
+        if key not in _NOT_CLIENT_KEYS and key not in model.model_fields
+    }
+    client_kwargs.update(config.get("session_kwargs") or {})
+    return params, client_kwargs
 
 
-@asynccontextmanager
-async def _create_streamable_http_session(
-    *,
-    url: str,
-    headers: dict[str, Any] | None = None,
-    timeout: timedelta = DEFAULT_STREAMABLE_HTTP_TIMEOUT,
-    sse_read_timeout: timedelta = DEFAULT_STREAMABLE_HTTP_SSE_READ_TIMEOUT,
-    terminate_on_close: bool = True,
-    session_kwargs: dict[str, Any] | None = None,
-    httpx_client_factory: McpHttpClientFactory | None = None,
-    auth: httpx2.Auth | None = None,
-) -> AsyncIterator[ClientSession]:
-    """Create a new session to an MCP server using Streamable HTTP.
-
-    Args:
-        url: URL of the endpoint to connect to.
-        headers: HTTP headers to send to the endpoint.
-        timeout: HTTP timeout.
-        sse_read_timeout: How long the client will wait for a new event before
-            disconnecting.
-        terminate_on_close: Whether to terminate the session on close.
-        session_kwargs: Additional keyword arguments to pass to the ClientSession.
-        httpx_client_factory: Custom factory for httpx2.AsyncClient (optional).
-        auth: Authentication for the HTTP client.
-
-    Yields:
-        An initialized ClientSession.
-    """
-    # `streamable_http_client` no longer takes the HTTP options directly; they belong to
-    # the client it is handed, which `httpx_client_factory` may supply instead.
-    factory = httpx_client_factory or create_mcp_http_client
-    http_client = factory(
-        headers=headers,
-        timeout=httpx2.Timeout(timeout.total_seconds(), read=sse_read_timeout.total_seconds()),
-        auth=auth,
-    )
-
-    async with (
-        http_client,
-        streamable_http_client(
-            url,
-            http_client=http_client,
-            terminate_on_close=terminate_on_close,
-        ) as (read, write),
-        ClientSession(read, write, **(session_kwargs or {})) as session,
-    ):
-        yield session
+def _callback_kwargs(mcp_callbacks: _MCPCallbacks | None) -> dict[str, Any]:
+    """Client options for the callbacks the caller registered, if any."""
+    if mcp_callbacks is None:
+        return {}
+    return {
+        name: callback
+        for name, callback in (
+            ("logging_callback", mcp_callbacks.logging_callback),
+            ("elicitation_callback", mcp_callbacks.elicitation_callback),
+        )
+        if callback is not None
+    }
 
 
 @asynccontextmanager
@@ -314,56 +143,49 @@ async def create_session(
     """Create a new session to an MCP server.
 
     Args:
-        connection: Connection config to use to connect to the server
-        mcp_callbacks: mcp sdk compatible callbacks to use for the ClientSession
+        connection: How to reach the server. See `Connection`.
+        mcp_callbacks: mcp sdk compatible callbacks to use for the session
 
     Raises:
-        ValueError: If transport is not recognized
-        ValueError: If required parameters for the specified transport are missing
+        TypeError: If a transport or client instance is passed instead of a callable
+            returning one, or the connection is of an unusable type.
+        ValueError: If the transport is unknown.
 
     Yields:
         A ClientSession
     """
-    if "transport" not in connection:
-        msg = (
-            "Configuration error: Missing 'transport' key in server configuration. "
-            "Each server must include 'transport' with one of: "
-            "'stdio', 'sse', 'http'. "
-            "Please refer to the langchain-mcp-adapters documentation for more details."
+    callbacks = _callback_kwargs(mcp_callbacks)
+
+    if isinstance(connection, ServerParameters):
+        client = Client(_transport_from_parameters(connection), **callbacks)
+    elif isinstance(connection, Mapping):
+        params, options = _parse_mapping(connection)
+        transport = _transport_from_parameters(
+            params,
+            auth=connection.get("auth"),
+            http_client=connection.get("http_client"),
         )
-        raise ValueError(msg)
-
-    transport = connection["transport"]
-    params = {k: v for k, v in connection.items() if k != "transport"}
-
-    if mcp_callbacks is not None:
-        params["session_kwargs"] = params.get("session_kwargs", {})
-        if mcp_callbacks.logging_callback is not None:
-            params["session_kwargs"]["logging_callback"] = mcp_callbacks.logging_callback
-        if mcp_callbacks.elicitation_callback is not None:
-            params["session_kwargs"]["elicitation_callback"] = mcp_callbacks.elicitation_callback
-
-    if transport == "sse":
-        if "url" not in params:
-            msg = "'url' parameter is required for SSE connection"
-            raise ValueError(msg)
-        async with _create_sse_session(**params) as session:
-            yield session
-    elif transport in {"streamable_http", "streamable-http", "http"}:
-        if "url" not in params:
-            msg = "'url' parameter is required for Streamable HTTP connection"
-            raise ValueError(msg)
-        async with _create_streamable_http_session(**params) as session:
-            yield session
-    elif transport == "stdio":
-        if "command" not in params:
-            msg = "'command' parameter is required for stdio connection"
-            raise ValueError(msg)
-        if "args" not in params:
-            msg = "'args' parameter is required for stdio connection"
-            raise ValueError(msg)
-        async with _create_stdio_session(**params) as session:
-            yield session
+        client = Client(transport, **{**options, **callbacks})
+    elif hasattr(connection, "__aenter__"):
+        # Checked before the callable case, because transports and clients are context
+        # managers that also happen to be callable.
+        msg = (
+            "A transport or client cannot be used as a connection, because it can only "
+            "be entered once and a session is opened per operation. Pass a callable "
+            "returning a fresh one instead, such as "
+            "`lambda: streamable_http_client(url, http_client=...)`."
+        )
+        raise TypeError(msg)
+    elif callable(connection):
+        built = connection()
+        client = built if isinstance(built, Client) else Client(built, **callbacks)
     else:
-        msg = f"Unsupported transport: {transport}. Must be one of: 'stdio', 'sse', 'http'"
-        raise ValueError(msg)
+        msg = (
+            "Unsupported connection. Expected the MCP SDK's ServerParameters, a mapping "
+            "of the same fields, or a callable returning a transport or client; got "
+            f"{type(connection).__name__}."
+        )
+        raise TypeError(msg)
+
+    async with client:
+        yield client.session

--- a/libs/langchain_v1/langchain/mcp/tools.py
+++ b/libs/langchain_v1/langchain/mcp/tools.py
@@ -5,7 +5,7 @@ tools, handle tool execution, and manage tool conversion between the two formats
 """
 
 from collections.abc import Awaitable, Callable
-from typing import Annotated, Any, TypedDict, get_args
+from typing import Annotated, Any, TypedDict
 
 from langchain_core.messages import ToolMessage
 from langchain_core.messages.content import (
@@ -22,22 +22,19 @@ from langchain_core.tools import (
     StructuredTool,
     ToolException,
 )
-from langchain_core.tools.base import get_all_basemodel_annotations
 from mcp import ClientSession
-from mcp.server.fastmcp.tools import Tool as FastMCPTool
-from mcp.server.fastmcp.utilities.func_metadata import ArgModelBase, FuncMetadata
 from mcp.types import (
     AudioContent,
     BlobResourceContents,
     ContentBlock,
     EmbeddedResource,
     ImageContent,
+    PaginatedRequestParams,
     ResourceLink,
     TextContent,
     TextResourceContents,
 )
 from mcp.types import Tool as MCPTool
-from pydantic import BaseModel, create_model
 
 from langchain.mcp.callbacks import CallbackContext, Callbacks, _MCPCallbacks
 from langchain.mcp.interceptors import (
@@ -101,17 +98,17 @@ def _convert_mcp_content_to_lc_block(
         return create_text_block(text=content.text)
 
     if isinstance(content, ImageContent):
-        return create_image_block(base64=content.data, mime_type=content.mimeType)
+        return create_image_block(base64=content.data, mime_type=content.mime_type)
 
     if isinstance(content, AudioContent):
         msg = (
             "AudioContent conversion to LangChain content blocks is not yet "
-            f"supported. Received audio with mime type: {content.mimeType}"
+            f"supported. Received audio with mime type: {content.mime_type}"
         )
         raise NotImplementedError(msg)
 
     if isinstance(content, ResourceLink):
-        mime_type = content.mimeType or None
+        mime_type = content.mime_type or None
         if mime_type and mime_type.startswith("image/"):
             return create_image_block(url=str(content.uri), mime_type=mime_type)
         return create_file_block(url=str(content.uri), mime_type=mime_type)
@@ -121,7 +118,7 @@ def _convert_mcp_content_to_lc_block(
         if isinstance(resource, TextResourceContents):
             return create_text_block(text=resource.text)
         if isinstance(resource, BlobResourceContents):
-            mime_type = resource.mimeType or None
+            mime_type = resource.mime_type or None
             if mime_type and mime_type.startswith("image/"):
                 return create_image_block(base64=resource.blob, mime_type=mime_type)
             return create_file_block(base64=resource.blob, mime_type=mime_type)
@@ -176,7 +173,7 @@ def _convert_call_tool_result(
         _convert_mcp_content_to_lc_block(content) for content in call_tool_result.content
     ]
 
-    if call_tool_result.isError:
+    if call_tool_result.is_error:
         # Join text from all blocks
         error_parts = []
         for item in tool_content:
@@ -189,8 +186,8 @@ def _convert_call_tool_result(
 
     # Extract structured content and wrap in MCPToolArtifact
     artifact: MCPToolArtifact | None = None
-    if call_tool_result.structuredContent is not None:
-        artifact = MCPToolArtifact(structured_content=call_tool_result.structuredContent)
+    if call_tool_result.structured_content is not None:
+        artifact = MCPToolArtifact(structured_content=call_tool_result.structured_content)
 
     return tool_content, artifact
 
@@ -252,17 +249,18 @@ async def _list_all_tools(session: ClientSession) -> list[MCPTool]:
             msg = "Reached max of 1000 iterations while listing tools."
             raise RuntimeError(msg)
 
-        list_tools_page_result = await session.list_tools(cursor=current_cursor)
+        page_params = PaginatedRequestParams(cursor=current_cursor) if current_cursor else None
+        list_tools_page_result = await session.list_tools(params=page_params)
 
         if list_tools_page_result.tools:
             all_tools.extend(list_tools_page_result.tools)
 
         # Pagination spec: https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/pagination
         # compatible with None or ""
-        if not list_tools_page_result.nextCursor:
+        if not list_tools_page_result.next_cursor:
             break
 
-        current_cursor = list_tools_page_result.nextCursor
+        current_cursor = list_tools_page_result.next_cursor
     return all_tools
 
 
@@ -411,7 +409,9 @@ def convert_mcp_tool_to_langchain_tool(
         return _convert_call_tool_result(call_tool_result)
 
     meta = getattr(tool, "meta", None)
-    base = tool.annotations.model_dump() if tool.annotations is not None else {}
+    # Dump by alias so these stay the specification's names (`readOnlyHint`), which
+    # mcp 2.x renamed to snake_case on the model itself.
+    base = tool.annotations.model_dump(by_alias=True) if tool.annotations is not None else {}
     meta = {"_meta": meta} if meta is not None else {}
     metadata = {**base, **meta} or None
 
@@ -423,7 +423,7 @@ def convert_mcp_tool_to_langchain_tool(
     return StructuredTool(
         name=lc_tool_name,
         description=tool.description or "",
-        args_schema=tool.inputSchema,
+        args_schema=tool.input_schema,
         coroutine=call_tool,
         response_format="content_and_artifact",
         metadata=metadata,
@@ -490,76 +490,3 @@ async def load_mcp_tools(
         )
         for tool in tools
     ]
-
-
-def _get_injected_args(tool: BaseTool) -> list[str]:
-    """Extract field names with InjectedToolArg annotation from tool schema.
-
-    Args:
-        tool: LangChain tool to inspect.
-
-    Returns:
-        List of field names marked as injected arguments.
-    """
-
-    def _is_injected_arg_type(type_: type) -> bool:
-        """Check if type annotation contains InjectedToolArg."""
-        return any(
-            isinstance(arg, InjectedToolArg)
-            or (isinstance(arg, type) and issubclass(arg, InjectedToolArg))
-            for arg in get_args(type_)[1:]
-        )
-
-    return [
-        field
-        for field, field_info in get_all_basemodel_annotations(tool.args_schema).items()
-        if _is_injected_arg_type(field_info)
-    ]
-
-
-def to_fastmcp(tool: BaseTool) -> FastMCPTool:
-    """Convert LangChain tool to FastMCP tool.
-
-    Args:
-        tool: LangChain tool to convert.
-
-    Returns:
-        FastMCP tool equivalent.
-
-    Raises:
-        TypeError: If args_schema is not BaseModel subclass.
-        NotImplementedError: If tool has injected arguments.
-    """
-    if not issubclass(tool.args_schema, BaseModel):
-        msg = (
-            "Tool args_schema must be a subclass of pydantic.BaseModel. "
-            "Tools with dict args schema are not supported."
-        )
-        raise TypeError(msg)
-
-    parameters = tool.tool_call_schema.model_json_schema()
-    field_definitions = {
-        field: (field_info.annotation, field_info)
-        for field, field_info in tool.tool_call_schema.model_fields.items()
-    }
-    arg_model = create_model(f"{tool.name}Arguments", **field_definitions, __base__=ArgModelBase)
-    fn_metadata = FuncMetadata(arg_model=arg_model)
-
-    # We'll use an Any type for the function return type.
-    # We're providing the parameters separately
-    async def fn(**arguments: dict[str, Any]) -> Any:
-        return await tool.ainvoke(arguments)
-
-    injected_args = _get_injected_args(tool)
-    if len(injected_args) > 0:
-        msg = "LangChain tools with injected arguments are not supported"
-        raise NotImplementedError(msg)
-
-    return FastMCPTool(
-        fn=fn,
-        name=tool.name,
-        description=tool.description,
-        parameters=parameters,
-        fn_metadata=fn_metadata,
-        is_async=True,
-    )

--- a/libs/langchain_v1/langchain/mcp/tools.py
+++ b/libs/langchain_v1/langchain/mcp/tools.py
@@ -36,7 +36,8 @@ from mcp.types import (
 )
 from mcp.types import Tool as MCPTool
 
-from langchain.mcp.callbacks import CallbackContext, Callbacks, _MCPCallbacks
+from langchain.mcp.callbacks import CallbackContext, Callbacks
+from langchain.mcp.elicitation import ElicitationMode
 from langchain.mcp.interceptors import (
     MCPToolCallRequest,
     MCPToolCallResult,
@@ -271,6 +272,7 @@ def convert_mcp_tool_to_langchain_tool(
     connection: Connection | None = None,
     callbacks: Callbacks | None = None,
     tool_interceptors: list[ToolCallInterceptor] | None = None,
+    elicitation: ElicitationMode | None = None,
     server_name: str | None = None,
     tool_name_prefix: bool = False,
 ) -> BaseTool:
@@ -285,6 +287,8 @@ def convert_mcp_tool_to_langchain_tool(
                     if a `session` is not provided
         callbacks: Optional callbacks for handling notifications and events
         tool_interceptors: Optional list of interceptors for tool call processing
+        elicitation: If `"interrupt"`, surface server elicitation through LangGraph
+            interrupts when invoking this tool.
         server_name: Name of the server this tool belongs to
         tool_name_prefix: If `True` and `server_name` is provided, the tool name will be
             prefixed w/ server name (e.g., `"weather_search"` instead of `"search"`)
@@ -295,6 +299,13 @@ def convert_mcp_tool_to_langchain_tool(
     """
     if session is None and connection is None:
         msg = "Either a session or a connection config must be provided"
+        raise ValueError(msg)
+    if session is not None and elicitation is not None:
+        msg = (
+            "`elicitation` requires a connection-backed tool so LangChain can configure "
+            'the MCP session. Configure `MultiServerMCPClient(elicitation="interrupt")` '
+            "before opening an explicit session instead."
+        )
         raise ValueError(msg)
 
     async def call_tool(
@@ -312,12 +323,9 @@ def convert_mcp_tool_to_langchain_tool(
             - content: string, list of strings/content blocks, ToolMessage, or Command
             - artifact: MCPToolArtifact with structured_content if present, else None
         """
-        mcp_callbacks = (
-            callbacks.to_mcp_format(
-                context=CallbackContext(server_name=server_name, tool_name=tool.name)
-            )
-            if callbacks is not None
-            else _MCPCallbacks()
+        mcp_callbacks = (callbacks or Callbacks()).to_mcp_format(
+            context=CallbackContext(server_name=server_name, tool_name=tool.name),
+            elicitation=elicitation,
         )
 
         # Create the innermost handler that actually executes the tool call
@@ -439,6 +447,7 @@ async def load_mcp_tools(
     connection: Connection | None = None,
     callbacks: Callbacks | None = None,
     tool_interceptors: list[ToolCallInterceptor] | None = None,
+    elicitation: ElicitationMode | None = None,
     server_name: str | None = None,
     tool_name_prefix: bool = False,
 ) -> list[BaseTool]:
@@ -449,6 +458,8 @@ async def load_mcp_tools(
         connection: Connection config to create a new session if session is `None`.
         callbacks: Optional `Callbacks` for handling notifications and events.
         tool_interceptors: Optional list of interceptors for tool call processing.
+        elicitation: If `"interrupt"`, surface server elicitation through LangGraph
+            interrupts when invoking the loaded tools.
         server_name: Name of the server these tools belong to.
         tool_name_prefix: If `True` and `server_name` is provided, tool names will be
             prefixed w/ server name (e.g., `"weather_search"` instead of `"search"`).
@@ -463,11 +474,17 @@ async def load_mcp_tools(
     if session is None and connection is None:
         msg = "Either a session or a connection config must be provided"
         raise ValueError(msg)
+    if session is not None and elicitation is not None:
+        msg = (
+            "`elicitation` requires a connection-backed tool so LangChain can configure "
+            'the MCP session. Configure `MultiServerMCPClient(elicitation="interrupt")` '
+            "before opening an explicit session instead."
+        )
+        raise ValueError(msg)
 
-    mcp_callbacks = (
-        callbacks.to_mcp_format(context=CallbackContext(server_name=server_name))
-        if callbacks is not None
-        else _MCPCallbacks()
+    mcp_callbacks = (callbacks or Callbacks()).to_mcp_format(
+        context=CallbackContext(server_name=server_name),
+        elicitation=elicitation,
     )
 
     if session is None:
@@ -487,6 +504,7 @@ async def load_mcp_tools(
             connection=connection,
             callbacks=callbacks,
             tool_interceptors=tool_interceptors,
+            elicitation=elicitation,
             server_name=server_name,
             tool_name_prefix=tool_name_prefix,
         )

--- a/libs/langchain_v1/langchain/mcp/tools.py
+++ b/libs/langchain_v1/langchain/mcp/tools.py
@@ -4,7 +4,7 @@ This module provides functionality to convert MCP tools into LangChain-compatibl
 tools, handle tool execution, and manage tool conversion between the two formats.
 """
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Annotated, Any, TypedDict
 
 from langchain_core.messages import ToolMessage
@@ -340,7 +340,11 @@ def convert_mcp_tool_to_langchain_tool(
 
             # If headers were modified, create a new connection with updated headers
             modified_headers = request.headers
-            if modified_headers is not None and connection is not None:
+            if (
+                modified_headers is not None
+                and connection is not None
+                and isinstance(connection, Mapping)
+            ):
                 # Create a new connection config with updated headers
                 updated_connection = dict(connection)
                 if connection["transport"] in (
@@ -367,7 +371,6 @@ def convert_mcp_tool_to_langchain_tool(
                 async with create_session(
                     effective_connection, mcp_callbacks=mcp_callbacks
                 ) as tool_session:
-                    await tool_session.initialize()
                     try:
                         call_tool_result = await tool_session.call_tool(
                             tool_name,
@@ -473,7 +476,6 @@ async def load_mcp_tools(
             msg = "Either session or connection must be provided"
             raise ValueError(msg)
         async with create_session(connection, mcp_callbacks=mcp_callbacks) as tool_session:
-            await tool_session.initialize()
             tools = await _list_all_tools(tool_session)
     else:
         tools = await _list_all_tools(session)

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -49,7 +49,7 @@ deepseek = ["langchain-deepseek"]
 xai = ["langchain-xai"]
 perplexity = ["langchain-perplexity"]
 meta = ["langchain-meta"]
-mcp = ["mcp>=1.9.2,<2.0.0", "typing-extensions>=4.14.0"]
+mcp = ["mcp>=2.0.0,<3.0.0", "typing-extensions>=4.14.0"]
 
 [project.urls]
 Homepage = "https://docs.langchain.com/"
@@ -76,11 +76,9 @@ test = [
     "blockbuster>=1.5.26,<1.6.0",
     "langchain-tests>=1.1.9,<2.0.0",
     "langchain-openai",
-    "mcp>=1.9.2,<2.0.0",
+    "mcp>=2.0.0,<3.0.0",
     "dirty-equals>=0.9.0",
-    "starlette>=0.27.0",
     "uvicorn>=0.30.0",
-    "websockets>=13.0",
 ]
 lint = [
     "ruff>=0.15.0,<0.17.0",

--- a/libs/langchain_v1/tests/integration_tests/mcp/conftest.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/conftest.py
@@ -1,58 +1,10 @@
-import multiprocessing
-import socket
-import time
-from collections.abc import Generator
-
 import pytest
 import pytest_socket
-
-from tests.integration_tests.mcp.utils import run_server
-
-
-@pytest.fixture
-def websocket_server_port() -> int:
-    with socket.socket() as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-    raise ValueError("Free port not found!")
-
-
-@pytest.fixture
-def websocket_server(websocket_server_port: int) -> Generator[None, None, None]:
-    proc = multiprocessing.Process(
-        target=run_server,
-        kwargs={"server_port": websocket_server_port},
-        daemon=True,
-    )
-    proc.start()
-
-    # Wait for server to be running
-    max_attempts = 20
-    attempt = 0
-
-    while attempt < max_attempts:
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.connect(("127.0.0.1", websocket_server_port))
-                break
-        except ConnectionRefusedError:
-            time.sleep(0.1)
-            attempt += 1
-    else:
-        raise RuntimeError(f"Server failed to start after {max_attempts} attempts")
-
-    yield
-
-    # Signal the server to stop
-    proc.kill()
-    proc.join(timeout=2)
-    if proc.is_alive():
-        raise RuntimeError("Server process is still alive after attempting to terminate it")
 
 
 @pytest.fixture
 def socket_enabled():
-    """Temporarily enable socket connections for websocket tests."""
+    """Temporarily enable socket connections to the local test servers."""
     try:
         pytest_socket.enable_socket()
         previous_state = pytest_socket.socket_allow_hosts()

--- a/libs/langchain_v1/tests/integration_tests/mcp/servers/math_server.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/servers/math_server.py
@@ -1,6 +1,6 @@
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
-mcp = FastMCP("Math")
+mcp = MCPServer("Math")
 
 
 @mcp.tool()

--- a/libs/langchain_v1/tests/integration_tests/mcp/servers/time_server.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/servers/time_server.py
@@ -1,6 +1,6 @@
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
-mcp = FastMCP("time")
+mcp = MCPServer("time")
 
 
 @mcp.tool()

--- a/libs/langchain_v1/tests/integration_tests/mcp/servers/weather_server.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/servers/weather_server.py
@@ -1,6 +1,6 @@
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
-mcp = FastMCP("Weather")
+mcp = MCPServer("Weather")
 
 
 @mcp.tool()

--- a/libs/langchain_v1/tests/integration_tests/mcp/test_callbacks.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/test_callbacks.py
@@ -2,8 +2,7 @@
 
 import asyncio
 
-from mcp.server import FastMCP
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context, MCPServer
 from mcp.server.session import ServerSession
 from mcp.types import LoggingMessageNotificationParams
 
@@ -57,7 +56,7 @@ async def test_to_mcp_format_with_callbacks() -> None:
 
 def _create_callback_server():
     """Create a server with a tool for testing callbacks."""
-    server = FastMCP(port=8186)
+    server = MCPServer()
 
     @server.tool()
     async def execute_task(task: str, ctx: Context[ServerSession, None]) -> str:

--- a/libs/langchain_v1/tests/integration_tests/mcp/test_callbacks.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/test_callbacks.py
@@ -100,6 +100,7 @@ async def test_callbacks_with_mcp_tool_execution(socket_enabled) -> None:
                 "callback_test": {
                     "url": "http://localhost:8186/mcp",
                     "transport": "streamable_http",
+                    "mode": "legacy",
                 }
             },
             callbacks=callbacks,

--- a/libs/langchain_v1/tests/integration_tests/mcp/test_client.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/test_client.py
@@ -12,14 +12,13 @@ from tests.integration_tests.mcp.utils import IsLangChainID
 
 async def test_multi_server_mcp_client(
     socket_enabled,
-    websocket_server,
-    websocket_server_port: int,
 ):
     """Test that MultiServerMCPClient can connect to multiple servers and load tools."""
     # Get the absolute path to the server scripts
     current_dir = Path(__file__).parent
     math_server_path = os.path.join(current_dir, "servers/math_server.py")
     weather_server_path = os.path.join(current_dir, "servers/weather_server.py")
+    time_server_path = os.path.join(current_dir, "servers/time_server.py")
 
     client = MultiServerMCPClient(
         {
@@ -34,8 +33,9 @@ async def test_multi_server_mcp_client(
                 "transport": "stdio",
             },
             "time": {
-                "url": f"ws://127.0.0.1:{websocket_server_port}/ws",
-                "transport": "websocket",
+                "command": "python3",
+                "args": [time_server_path],
+                "transport": "stdio",
             },
         },
     )
@@ -92,13 +92,12 @@ async def test_multi_server_mcp_client(
 
 async def test_multi_server_connect_methods(
     socket_enabled,
-    websocket_server,
-    websocket_server_port: int,
 ):
     """Test the different connect methods for MultiServerMCPClient."""
     # Get the absolute path to the server scripts
     current_dir = Path(__file__).parent
     math_server_path = os.path.join(current_dir, "servers/math_server.py")
+    time_server_path = os.path.join(current_dir, "servers/time_server.py")
 
     # Initialize client without initial connections
     client = MultiServerMCPClient(
@@ -109,8 +108,9 @@ async def test_multi_server_connect_methods(
                 "transport": "stdio",
             },
             "time": {
-                "url": f"ws://127.0.0.1:{websocket_server_port}/ws",
-                "transport": "websocket",
+                "command": "python3",
+                "args": [time_server_path],
+                "transport": "stdio",
             },
         },
     )

--- a/libs/langchain_v1/tests/integration_tests/mcp/test_client.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/test_client.py
@@ -1,13 +1,18 @@
 import os
 from pathlib import Path
 
+import pytest
 from langchain_core.documents.base import Blob
 from langchain_core.messages import AIMessage
 from langchain_core.tools import BaseTool
+from mcp import StdioServerParameters
+from mcp.client.streamable_http import streamable_http_client
+from mcp.server.mcpserver import MCPServer
+from mcp.shared._httpx_utils import create_mcp_http_client
 
 from langchain.mcp.client import MultiServerMCPClient
 from langchain.mcp.tools import load_mcp_tools
-from tests.integration_tests.mcp.utils import IsLangChainID
+from tests.integration_tests.mcp.utils import IsLangChainID, run_streamable_http
 
 
 async def test_multi_server_mcp_client(
@@ -238,3 +243,66 @@ async def test_get_resources_from_specific_server():
     assert len(weather_resources) == 1
     assert str(weather_resources[0].metadata["uri"]) == "weather://forecast"
     assert weather_resources[0].data == "Sunny with a chance of clouds"
+
+
+async def test_connections_accept_sdk_server_parameters():
+    """The MCP SDK's own parameter models work anywhere a connection mapping does."""
+    current_dir = Path(__file__).parent
+    math_server_path = os.path.join(current_dir, "servers/math_server.py")
+
+    client = MultiServerMCPClient(
+        {
+            "math": StdioServerParameters(
+                command="python3",
+                args=[math_server_path],
+            ),
+        },
+    )
+
+    tools = await client.get_tools()
+    assert {"add", "multiply"} <= {tool.name for tool in tools}
+
+
+async def test_connections_accept_a_transport_factory(socket_enabled):
+    """A factory composes a server endpoint with a fully configured HTTP client.
+
+    The SDK's own HTTP parameter models describe neither `auth` nor an `http_client`, so
+    this is how the two layers are brought together. It must be a factory rather than a
+    transport, because a session is opened per operation and transports are single-use.
+    """
+
+    def transport():
+        return streamable_http_client(
+            "http://localhost:8187/mcp",
+            http_client=create_mcp_http_client(headers={"X-Test": "1"}),
+        )
+
+    with run_streamable_http(_create_time_server, 8187):
+        client = MultiServerMCPClient({"time": transport})
+
+        tools = {tool.name: tool for tool in await client.get_tools()}
+        assert list(tools) == ["get_time"]
+
+        # A second operation opens another session, which is why a factory is required.
+        result = await tools["get_time"].ainvoke({"args": {}, "id": "1", "type": "tool_call"})
+        assert "5:20" in str(result.content)
+
+
+async def test_a_bare_transport_is_rejected(socket_enabled):
+    """Passing a transport directly would work once and then fail, so it is refused."""
+    client = MultiServerMCPClient(
+        {"time": streamable_http_client("http://localhost:8187/mcp")},
+    )
+    with pytest.raises(TypeError, match="can only be entered once"):
+        await client.get_tools()
+
+
+def _create_time_server():
+    server = MCPServer()
+
+    @server.tool()
+    def get_time() -> str:
+        """Get current time"""
+        return "5:20:00 PM EST"
+
+    return server

--- a/libs/langchain_v1/tests/integration_tests/mcp/test_elicitation.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/test_elicitation.py
@@ -67,6 +67,7 @@ async def test_elicitation_callback_accept(socket_enabled) -> None:
                 "test": {
                     "url": "http://localhost:8184/mcp",
                     "transport": "http",
+                    "mode": "legacy",
                 }
             },
             callbacks=Callbacks(on_elicitation=on_elicitation),
@@ -113,6 +114,7 @@ async def test_elicitation_callback_decline(socket_enabled) -> None:
                 "test": {
                     "url": "http://localhost:8184/mcp",
                     "transport": "http",
+                    "mode": "legacy",
                 }
             },
             callbacks=Callbacks(on_elicitation=on_elicitation),
@@ -144,6 +146,7 @@ async def test_elicitation_callback_cancel(socket_enabled) -> None:
                 "test": {
                     "url": "http://localhost:8184/mcp",
                     "transport": "http",
+                    "mode": "legacy",
                 }
             },
             callbacks=Callbacks(on_elicitation=on_elicitation),

--- a/libs/langchain_v1/tests/integration_tests/mcp/test_elicitation.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/test_elicitation.py
@@ -1,7 +1,7 @@
 """Tests for MCP elicitation callback support."""
 
-from mcp.server.fastmcp import Context, FastMCP
-from mcp.shared.context import RequestContext
+from mcp.client.session import ClientRequestContext as RequestContext
+from mcp.server.mcpserver import Context, MCPServer
 from mcp.types import ElicitRequestParams, ElicitResult
 from pydantic import BaseModel
 
@@ -15,7 +15,7 @@ def _create_elicitation_server():
         email: str
         age: int
 
-    server = FastMCP(port=8184)
+    server = MCPServer()
 
     # Track how many times code before elicit runs (should be exactly once)
     server._pre_elicit_call_count = 0

--- a/libs/langchain_v1/tests/integration_tests/mcp/test_interceptors.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/test_interceptors.py
@@ -2,7 +2,7 @@
 
 import pytest
 from langchain_core.messages import ToolMessage
-from mcp.server import FastMCP
+from mcp.server.mcpserver import MCPServer
 from mcp.types import (
     CallToolResult,
     TextContent,
@@ -17,7 +17,7 @@ from tests.integration_tests.mcp.utils import IsLangChainID, run_streamable_http
 
 def _create_math_server(port: int = 8200):
     """Create a math server with add and multiply tools."""
-    server = FastMCP(port=port)
+    server = MCPServer()
 
     @server.tool()
     def add(a: int, b: int) -> int:
@@ -116,7 +116,7 @@ class TestInterceptorModifiesResponse:
 
             return CallToolResult(
                 content=modified_content,
-                isError=result.isError,
+                isError=result.is_error,
             )
 
         with run_streamable_http(_create_math_server, 8203):

--- a/libs/langchain_v1/tests/integration_tests/mcp/test_tools.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/test_tools.py
@@ -1,17 +1,16 @@
 import typing
 from collections.abc import Callable, Sequence
-from typing import Annotated, Any
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
-import httpx
+import httpx2
 import pytest
-from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.runnables import Runnable
-from langchain_core.tools import BaseTool, InjectedToolArg, ToolException, tool
-from mcp.server import FastMCP
+from langchain_core.tools import BaseTool, ToolException
+from mcp.server.mcpserver import MCPServer
 from mcp.types import (
     AudioContent,
     BlobResourceContents,
@@ -24,7 +23,6 @@ from mcp.types import (
     ToolAnnotations,
 )
 from mcp.types import Tool as MCPTool
-from pydantic import BaseModel
 
 from langchain.mcp.client import MultiServerMCPClient
 from langchain.mcp.interceptors import MCPToolCallRequest, MCPToolCallResult
@@ -33,7 +31,6 @@ from langchain.mcp.tools import (
     _convert_call_tool_result,
     convert_mcp_tool_to_langchain_tool,
     load_mcp_tools,
-    to_fastmcp,
 )
 from tests.integration_tests.mcp.utils import IsLangChainID, run_streamable_http
 
@@ -464,7 +461,7 @@ async def test_load_mcp_tools():
             inputSchema=tool_input_schema,
         ),
     ]
-    session.list_tools.return_value = MagicMock(tools=mcp_tools, nextCursor=None)
+    session.list_tools.return_value = MagicMock(tools=mcp_tools, next_cursor=None)
 
     # Mock call_tool to return different results for different tools
     async def mock_call_tool(tool_name, arguments, progress_callback=None):
@@ -519,7 +516,7 @@ async def test_load_mcp_tools():
 
 
 def _create_annotations_server():
-    server = FastMCP(port=8181)
+    server = MCPServer()
 
     @server.tool(
         annotations=ToolAnnotations(title="Get Time", readOnlyHint=True, idempotentHint=False),
@@ -577,92 +574,8 @@ async def test_load_mcp_tools_with_annotations(socket_enabled) -> None:
         }
 
 
-# Tests for to_fastmcp functionality
-
-
-@tool
-def add(a: int, b: int) -> int:
-    """Add two numbers"""
-    return a + b
-
-
-class AddInput(BaseModel):
-    """Add two numbers"""
-
-    a: int
-    b: int
-
-
-@tool("add", args_schema=AddInput)
-def add_with_schema(a: int, b: int) -> int:
-    return a + b
-
-
-@tool("add")
-def add_with_injection(a: int, b: int, injected_arg: Annotated[str, InjectedToolArg()]) -> int:
-    """Add two numbers"""
-    return a + b
-
-
-class AddTool(BaseTool):
-    name: str = "add"
-    description: str = "Add two numbers"
-    args_schema: type[BaseModel] | None = AddInput
-
-    def _run(self, a: int, b: int, run_manager: CallbackManagerForToolRun | None = None) -> int:
-        """Use the tool."""
-        return a + b
-
-    async def _arun(
-        self,
-        a: int,
-        b: int,
-        run_manager: CallbackManagerForToolRun | None = None,
-    ) -> int:
-        """Use the tool."""
-        return self._run(a, b, run_manager=run_manager)
-
-
-@pytest.mark.parametrize(
-    "tool_instance",
-    [add, add_with_schema, AddTool()],
-    ids=["tool", "tool_with_schema", "tool_class"],
-)
-async def test_convert_langchain_tool_to_fastmcp_tool(tool_instance):
-    fastmcp_tool = to_fastmcp(tool_instance)
-    assert fastmcp_tool.name == "add"
-    assert fastmcp_tool.description == "Add two numbers"
-    assert fastmcp_tool.parameters == {
-        "description": "Add two numbers",
-        "properties": {
-            "a": {"title": "A", "type": "integer"},
-            "b": {"title": "B", "type": "integer"},
-        },
-        "required": ["a", "b"],
-        "title": "add",
-        "type": "object",
-    }
-    assert fastmcp_tool.fn_metadata.arg_model.model_json_schema() == {
-        "properties": {
-            "a": {"title": "A", "type": "integer"},
-            "b": {"title": "B", "type": "integer"},
-        },
-        "required": ["a", "b"],
-        "title": "addArguments",
-        "type": "object",
-    }
-
-    arguments = {"a": 1, "b": 2}
-    assert await fastmcp_tool.run(arguments=arguments) == 3
-
-
-def test_convert_langchain_tool_to_fastmcp_tool_with_injection():
-    with pytest.raises(NotImplementedError):
-        to_fastmcp(add_with_injection)
-
-
 def _create_status_server():
-    server = FastMCP(port=8182)
+    server = MCPServer()
 
     @server.tool()
     def get_status() -> str:
@@ -681,16 +594,16 @@ async def test_load_mcp_tools_with_custom_httpx_client_factory(socket_enabled) -
     # Custom httpx client factory
     def custom_httpx_client_factory(
         headers: dict[str, str] | None = None,
-        timeout: httpx.Timeout | None = None,
-        auth: httpx.Auth | None = None,
-    ) -> httpx.AsyncClient:
-        """Custom factory for creating httpx.AsyncClient with specific configuration."""
-        return httpx.AsyncClient(
+        timeout: httpx2.Timeout | None = None,
+        auth: httpx2.Auth | None = None,
+    ) -> httpx2.AsyncClient:
+        """Custom factory for creating httpx2.AsyncClient with specific configuration."""
+        return httpx2.AsyncClient(
             headers=headers,
-            timeout=timeout or httpx.Timeout(30.0),
+            timeout=timeout or httpx2.Timeout(30.0),
             auth=auth,
             # Custom configuration
-            limits=httpx.Limits(max_keepalive_connections=5, max_connections=10),
+            limits=httpx2.Limits(max_keepalive_connections=5, max_connections=10),
         )
 
     with run_streamable_http(_create_status_server, 8182):
@@ -718,7 +631,7 @@ async def test_load_mcp_tools_with_custom_httpx_client_factory(socket_enabled) -
 
 
 def _create_info_server():
-    server = FastMCP(port=8183)
+    server = MCPServer()
 
     @server.tool()
     def get_info() -> str:
@@ -736,16 +649,16 @@ async def test_load_mcp_tools_with_custom_httpx_client_factory_sse(
     # Custom httpx client factory
     def custom_httpx_client_factory(
         headers: dict[str, str] | None = None,
-        timeout: httpx.Timeout | None = None,
-        auth: httpx.Auth | None = None,
-    ) -> httpx.AsyncClient:
-        """Custom factory for creating httpx.AsyncClient with specific configuration."""
-        return httpx.AsyncClient(
+        timeout: httpx2.Timeout | None = None,
+        auth: httpx2.Auth | None = None,
+    ) -> httpx2.AsyncClient:
+        """Custom factory for creating httpx2.AsyncClient with specific configuration."""
+        return httpx2.AsyncClient(
             headers=headers,
-            timeout=timeout or httpx.Timeout(30.0),
+            timeout=timeout or httpx2.Timeout(30.0),
             auth=auth,
             # Custom configuration for SSE
-            limits=httpx.Limits(max_keepalive_connections=3, max_connections=5),
+            limits=httpx2.Limits(max_keepalive_connections=3, max_connections=5),
         )
 
     with run_streamable_http(_create_info_server, 8183):
@@ -839,7 +752,7 @@ async def test_convert_mcp_tool_metadata_variants():
 
 
 def _create_increment_server():
-    server = FastMCP(port=8183)
+    server = MCPServer()
 
     @server.tool()
     def increment(value: int) -> str:
@@ -978,7 +891,7 @@ async def test_mcp_tools_with_agent_and_command_interceptor(socket_enabled) -> N
 
 def _create_weather_search_server():
     """Create a weather server with a search tool."""
-    server = FastMCP(port=8185)
+    server = MCPServer()
 
     @server.tool()
     def search(query: str) -> str:
@@ -990,7 +903,7 @@ def _create_weather_search_server():
 
 def _create_flights_search_server():
     """Create a flights server with a search tool."""
-    server = FastMCP(port=8186)
+    server = MCPServer()
 
     @server.tool()
     def search(destination: str) -> str:

--- a/libs/langchain_v1/tests/integration_tests/mcp/test_tools.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/test_tools.py
@@ -585,105 +585,35 @@ def _create_status_server():
     return server
 
 
-# Tests for httpx_client_factory functionality
+# Tests for supplying an HTTP client
 
 
-async def test_load_mcp_tools_with_custom_httpx_client_factory(socket_enabled) -> None:
-    """Test load mcp tools with custom httpx client factory."""
-
-    # Custom httpx client factory
-    def custom_httpx_client_factory(
-        headers: dict[str, str] | None = None,
-        timeout: httpx2.Timeout | None = None,
-        auth: httpx2.Auth | None = None,
-    ) -> httpx2.AsyncClient:
-        """Custom factory for creating httpx2.AsyncClient with specific configuration."""
-        return httpx2.AsyncClient(
-            headers=headers,
-            timeout=timeout or httpx2.Timeout(30.0),
-            auth=auth,
-            # Custom configuration
-            limits=httpx2.Limits(max_keepalive_connections=5, max_connections=10),
-        )
+async def test_load_mcp_tools_with_supplied_http_client(socket_enabled) -> None:
+    """A caller-supplied HTTP client is used instead of one built from the config."""
+    http_client = httpx2.AsyncClient(
+        timeout=httpx2.Timeout(30.0),
+        limits=httpx2.Limits(max_keepalive_connections=5, max_connections=10),
+    )
 
     with run_streamable_http(_create_status_server, 8182):
-        # Initialize client with custom httpx_client_factory
         client = MultiServerMCPClient(
             {
                 "status": {
                     "url": "http://localhost:8182/mcp",
                     "transport": "streamable_http",
-                    "httpx_client_factory": custom_httpx_client_factory,
+                    "http_client": http_client,
                 },
             },
         )
 
         tools = await client.get_tools(server_name="status")
         assert len(tools) == 1
-        tool = tools[0]
-        assert tool.name == "get_status"
+        assert tools[0].name == "get_status"
 
-        # Test that the tool works correctly
-        result = await tool.ainvoke({"args": {}, "id": "1", "type": "tool_call"})
+        result = await tools[0].ainvoke({"args": {}, "id": "1", "type": "tool_call"})
         assert result.content == [
             {"type": "text", "text": "Server is running", "id": IsLangChainID}
         ]
-
-
-def _create_info_server():
-    server = MCPServer()
-
-    @server.tool()
-    def get_info() -> str:
-        """Get server info"""
-        return "SSE Server Info"
-
-    return server
-
-
-async def test_load_mcp_tools_with_custom_httpx_client_factory_sse(
-    socket_enabled,
-) -> None:
-    """Test load mcp tools with custom httpx client factory using SSE transport."""
-
-    # Custom httpx client factory
-    def custom_httpx_client_factory(
-        headers: dict[str, str] | None = None,
-        timeout: httpx2.Timeout | None = None,
-        auth: httpx2.Auth | None = None,
-    ) -> httpx2.AsyncClient:
-        """Custom factory for creating httpx2.AsyncClient with specific configuration."""
-        return httpx2.AsyncClient(
-            headers=headers,
-            timeout=timeout or httpx2.Timeout(30.0),
-            auth=auth,
-            # Custom configuration for SSE
-            limits=httpx2.Limits(max_keepalive_connections=3, max_connections=5),
-        )
-
-    with run_streamable_http(_create_info_server, 8183):
-        # Initialize client with custom httpx_client_factory for SSE
-        client = MultiServerMCPClient(
-            {
-                "info": {
-                    "url": "http://localhost:8183/sse",
-                    "transport": "sse",
-                    "httpx_client_factory": custom_httpx_client_factory,
-                },
-            },
-        )
-
-        # Note: This test may not work in practice since the server doesn't expose SSE
-        # endpoint,
-        # but it tests the configuration propagation
-        try:
-            tools = await client.get_tools(server_name="info")
-            # If we get here, the httpx_client_factory was properly passed
-            assert isinstance(tools, list)
-        except Exception:
-            # Expected to fail since server doesn't have SSE endpoint,
-            # but the important thing is that httpx_client_factory was passed correctly
-            pass
 
 
 async def test_convert_mcp_tool_metadata_variants():

--- a/libs/langchain_v1/tests/integration_tests/mcp/utils.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/utils.py
@@ -6,42 +6,13 @@ from collections.abc import Generator
 
 import uvicorn
 from dirty_equals import IsStr
-from mcp.server.websocket import websocket_server
-from starlette.applications import Starlette
-from starlette.routing import WebSocketRoute
-
-from tests.integration_tests.mcp.servers.time_server import mcp as time_mcp
 
 # Helper for matching auto-generated LangChain content block IDs
 IsLangChainID = IsStr(regex=r"lc_.*")
 
 
-def make_server_app() -> Starlette:
-    server = time_mcp._mcp_server
-
-    async def handle_ws(websocket):
-        async with websocket_server(websocket.scope, websocket.receive, websocket.send) as streams:
-            await server.run(streams[0], streams[1], server.create_initialization_options())
-
-    app = Starlette(routes=[WebSocketRoute("/ws", endpoint=handle_ws)])
-
-    return app
-
-
-def run_server(server_port: int) -> None:
-    app = make_server_app()
-    server = uvicorn.Server(
-        config=uvicorn.Config(app=app, host="127.0.0.1", port=server_port, log_level="error"),
-    )
-    server.run()
-
-    # Give server time to start
-    while not server.started:
-        time.sleep(0.5)
-
-
 def run_streamable_http_server(server_factory, server_port: int) -> None:
-    """Run a FastMCP server in a separate process exposing a streamable HTTP."""
+    """Run a server in a separate process exposing a streamable HTTP."""
     server = server_factory()
     app = server.streamable_http_app()
     uvicorn_server = uvicorn.Server(

--- a/libs/langchain_v1/tests/unit_tests/mcp/test_elicitation.py
+++ b/libs/langchain_v1/tests/unit_tests/mcp/test_elicitation.py
@@ -1,0 +1,276 @@
+"""Unit tests for MCP elicitation interrupts."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from langchain_core.messages import HumanMessage, ToolCall, ToolMessage
+from langchain_core.tools import ToolException
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import Command
+from mcp.types import TextContent
+from typing_extensions import TypedDict
+
+from langchain.agents import create_agent
+from langchain.mcp import elicitation
+from langchain.mcp import tools as mcp_tools
+from langchain.mcp.callbacks import CallbackContext, Callbacks
+from langchain.mcp.tools import convert_mcp_tool_to_langchain_tool, load_mcp_tools
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+
+class _ElicitationState(TypedDict):
+    response: dict[str, object]
+
+
+async def test_interrupt_elicitation_resumes_a_graph() -> None:
+    """The bridge pauses and resumes an async LangGraph node with form content."""
+
+    async def elicit(_state: _ElicitationState) -> _ElicitationState:
+        result = elicitation.interrupt_for_elicitation(
+            SimpleNamespace(
+                mode="form",
+                message="What date should the meeting occur?",
+                requested_schema={"type": "object", "properties": {"date": {"type": "string"}}},
+            ),
+            CallbackContext(server_name="calendar"),
+        )
+        assert result.content is not None
+        return {"response": result.content}
+
+    graph = (
+        StateGraph(_ElicitationState)
+        .add_node("elicit", elicit)
+        .add_edge(START, "elicit")
+        .add_edge("elicit", END)
+        .compile(checkpointer=InMemorySaver())
+    )
+    config = {"configurable": {"thread_id": "elicitation"}}
+
+    paused = await graph.ainvoke({"response": {}}, config)
+    interrupt_value = paused["__interrupt__"][0].value
+    assert interrupt_value["type"] == "mcp_elicitation"
+    assert interrupt_value["mode"] == "form"
+
+    resumed = await graph.ainvoke(
+        Command(resume={"action": "accept", "content": {"date": "2026-12-24"}}),
+        config,
+    )
+    assert resumed["response"] == {"date": "2026-12-24"}
+
+
+async def test_create_agent_resumes_an_elicitation_enabled_mcp_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An agent pauses and resumes while executing a converted MCP tool."""
+
+    @asynccontextmanager
+    async def fake_create_session(_connection: object, *, mcp_callbacks: Any):
+        class FakeSession:
+            async def call_tool(
+                self,
+                _tool_name: str,
+                _arguments: dict[str, Any],
+                *,
+                progress_callback: Any,
+            ) -> Any:
+                del progress_callback
+                assert mcp_callbacks.elicitation_callback is not None
+                response = await mcp_callbacks.elicitation_callback(
+                    SimpleNamespace(),
+                    SimpleNamespace(
+                        mode="form",
+                        message="Who should receive the invitation?",
+                        requested_schema={
+                            "type": "object",
+                            "properties": {"email": {"type": "string"}},
+                            "required": ["email"],
+                        },
+                    ),
+                )
+                assert response.action == "accept"
+                return SimpleNamespace(
+                    content=[
+                        TextContent(type="text", text=f"Invited {response.content['email']}.")
+                    ],
+                    is_error=False,
+                    structured_content=None,
+                )
+
+        yield FakeSession()
+
+    monkeypatch.setattr(mcp_tools, "create_session", fake_create_session)
+    mcp_tool = SimpleNamespace(
+        name="create_invitation",
+        description="Create a calendar invitation.",
+        input_schema={
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        },
+        annotations=None,
+        meta=None,
+    )
+    tool = convert_mcp_tool_to_langchain_tool(
+        None,
+        mcp_tool,
+        connection={},
+        elicitation="interrupt",
+        server_name="calendar",
+    )
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="create_invitation", args={"name": "Ada"}, id="call-1")],
+            [],
+        ]
+    )
+    agent = create_agent(model, tools=[tool], checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": "agent-elicitation"}}
+
+    paused = await agent.ainvoke({"messages": [HumanMessage("Create an invitation")]}, config)
+    interrupt_value = paused["__interrupt__"][0].value
+    assert interrupt_value == {
+        "type": "mcp_elicitation",
+        "mode": "form",
+        "server": "calendar",
+        "message": "Who should receive the invitation?",
+        "response_schema": {
+            "type": "object",
+            "properties": {"email": {"type": "string"}},
+            "required": ["email"],
+        },
+    }
+
+    completed = await agent.ainvoke(
+        Command(resume={"action": "accept", "content": {"email": "ada@example.com"}}),
+        config,
+    )
+    tool_messages = [
+        message for message in completed["messages"] if isinstance(message, ToolMessage)
+    ]
+    assert tool_messages[-1].content[0]["text"] == "Invited ada@example.com."
+
+
+async def test_interrupt_elicitation_callback_returns_accepted_form_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The callback turns a form request into an interrupt and MCP result."""
+    seen: list[dict[str, Any]] = []
+
+    def fake_interrupt(payload: dict[str, Any]) -> dict[str, Any]:
+        seen.append(payload)
+        return {"action": "accept", "content": {"email": "ada@example.com"}}
+
+    monkeypatch.setattr(elicitation, "interrupt", fake_interrupt)
+    mcp_callbacks = Callbacks().to_mcp_format(
+        context=CallbackContext(server_name="calendar", tool_name="create_event"),
+        elicitation="interrupt",
+    )
+    assert mcp_callbacks.elicitation_callback is not None
+
+    result = await mcp_callbacks.elicitation_callback(
+        SimpleNamespace(),
+        SimpleNamespace(
+            mode="form",
+            message="Who should receive the invitation?",
+            requested_schema={"type": "object", "properties": {"email": {"type": "string"}}},
+        ),
+    )
+
+    assert result.action == "accept"
+    assert result.content == {"email": "ada@example.com"}
+    assert seen == [
+        {
+            "type": "mcp_elicitation",
+            "mode": "form",
+            "server": "calendar",
+            "message": "Who should receive the invitation?",
+            "response_schema": {"type": "object", "properties": {"email": {"type": "string"}}},
+        }
+    ]
+
+
+async def test_interrupt_elicitation_callback_handles_url_consent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """URL-mode acceptance never returns user-supplied content to the server."""
+    monkeypatch.setattr(elicitation, "interrupt", lambda _payload: {"action": "accept"})
+    mcp_callbacks = Callbacks().to_mcp_format(
+        context=CallbackContext(server_name="calendar"),
+        elicitation="interrupt",
+    )
+    assert mcp_callbacks.elicitation_callback is not None
+
+    result = await mcp_callbacks.elicitation_callback(
+        SimpleNamespace(),
+        SimpleNamespace(
+            mode="url",
+            message="Connect your calendar account.",
+            url="https://calendar.example.com/connect",
+        ),
+    )
+
+    assert result.action == "accept"
+    assert result.content is None
+
+
+def test_interrupt_elicitation_rejects_invalid_responses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed resume value cannot be returned as an MCP elicitation result."""
+    monkeypatch.setattr(elicitation, "interrupt", lambda _payload: {"action": "accept"})
+
+    with pytest.raises(ToolException, match="requires object content"):
+        elicitation.interrupt_for_elicitation(
+            SimpleNamespace(
+                mode="form",
+                message="Who should receive the invitation?",
+                requested_schema={"type": "object"},
+            ),
+            CallbackContext(server_name="calendar"),
+        )
+
+
+async def test_interrupt_elicitation_rejects_nested_form_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Form content uses MCP's flat primitive value subset."""
+    monkeypatch.setattr(
+        elicitation,
+        "interrupt",
+        lambda _payload: {"action": "accept", "content": {"details": {"nested": "value"}}},
+    )
+
+    with pytest.raises(ToolException, match="unsupported value"):
+        elicitation.interrupt_for_elicitation(
+            SimpleNamespace(
+                mode="form",
+                message="Provide details.",
+                requested_schema={"type": "object"},
+            ),
+            CallbackContext(server_name="profile"),
+        )
+
+
+async def test_existing_session_rejects_interrupt_elicitation() -> None:
+    """An existing SDK session cannot be retrofitted with an interrupt callback."""
+    with pytest.raises(ValueError, match="connection-backed tool"):
+        await load_mcp_tools(object(), elicitation="interrupt")  # type: ignore[arg-type]
+
+
+def test_custom_and_interrupt_elicitation_handlers_conflict() -> None:
+    """A caller must choose one elicitation handling strategy."""
+
+    async def custom_elicitation(*args: object) -> Any:
+        return None
+
+    callbacks = Callbacks(on_elicitation=custom_elicitation)
+    with pytest.raises(ValueError, match="either `on_elicitation`"):
+        callbacks.to_mcp_format(
+            context=CallbackContext(server_name="calendar"),
+            elicitation="interrupt",
+        )

--- a/libs/langchain_v1/tests/unit_tests/mcp/test_import.py
+++ b/libs/langchain_v1/tests/unit_tests/mcp/test_import.py
@@ -1,3 +1,10 @@
+import pytest
+from mcp import StdioServerParameters
+from mcp.client.session_group import SseServerParameters, StreamableHttpParameters
+
+from langchain.mcp.sessions import _parse_mapping
+
+
 def test_import() -> None:
     """Test that the code can be imported"""
     from langchain.mcp import (  # noqa: F401, PLC0415
@@ -7,3 +14,27 @@ def test_import() -> None:
         resources,
         tools,
     )
+
+
+def test_connection_mapping_parses_into_sdk_parameters() -> None:
+    """Mapping configs are validated by the SDK's models, not types declared here."""
+    params, options = _parse_mapping(
+        {"transport": "stdio", "command": "python3", "args": ["s.py"], "env": {"A": "b"}}
+    )
+    assert isinstance(params, StdioServerParameters)
+    assert (params.command, params.args, params.env) == ("python3", ["s.py"], {"A": "b"})
+    assert options == {}
+
+    # Transport is inferred when omitted, and client options ride alongside.
+    params, options = _parse_mapping({"url": "https://x/mcp", "mode": "legacy"})
+    assert isinstance(params, StreamableHttpParameters)
+    assert params.url == "https://x/mcp"
+    assert options == {"mode": "legacy"}
+
+    params, _ = _parse_mapping({"transport": "sse", "url": "https://x/sse"})
+    assert isinstance(params, SseServerParameters)
+
+
+def test_unknown_transport_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Unsupported transport"):
+        _parse_mapping({"transport": "carrier-pigeon", "url": "https://x"})

--- a/libs/langchain_v1/tests/unit_tests/mcp/test_import.py
+++ b/libs/langchain_v1/tests/unit_tests/mcp/test_import.py
@@ -10,6 +10,7 @@ def test_import() -> None:
     from langchain.mcp import (  # noqa: F401, PLC0415
         callbacks,
         client,
+        elicitation,
         prompts,
         resources,
         tools,

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1722,6 +1722,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1761,6 +1774,32 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
+]
+
+[[package]]
 name = "huggingface-hub"
 version = "0.36.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1790,11 +1829,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -2091,11 +2130,9 @@ test = [
     { name = "pytest-socket" },
     { name = "pytest-watcher" },
     { name = "pytest-xdist" },
-    { name = "starlette" },
     { name = "syrupy" },
     { name = "toml" },
     { name = "uvicorn" },
-    { name = "websockets" },
 ]
 test-integration = [
     { name = "langchain-text-splitters" },
@@ -2131,7 +2168,7 @@ requires-dist = [
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
     { name = "langgraph", specifier = ">=1.2.11,<1.3.0" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.9.2,<2.0.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=2.0.0,<3.0.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
     { name = "typing-extensions", marker = "extra == 'mcp'", specifier = ">=4.14.0" },
 ]
@@ -2144,7 +2181,7 @@ test = [
     { name = "dirty-equals", specifier = ">=0.9.0" },
     { name = "langchain-openai", editable = "../partners/openai" },
     { name = "langchain-tests", editable = "../standard-tests" },
-    { name = "mcp", specifier = ">=1.9.2,<2.0.0" },
+    { name = "mcp", specifier = ">=2.0.0,<3.0.0" },
     { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0.0" },
     { name = "pytest-benchmark", specifier = ">=5.1.0,<6.0.0" },
@@ -2153,11 +2190,9 @@ test = [
     { name = "pytest-socket", specifier = ">=0.6.0,<1.0.0" },
     { name = "pytest-watcher", specifier = ">=0.2.6,<1.0.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
-    { name = "starlette", specifier = ">=0.27.0" },
     { name = "syrupy", specifier = ">=5.0.0,<6.0.0" },
     { name = "toml", specifier = ">=0.10.2,<1.0.0" },
     { name = "uvicorn", specifier = ">=0.30.0" },
-    { name = "websockets", specifier = ">=13.0" },
 ]
 test-integration = [
     { name = "langchain-text-splitters", editable = "../text-splitters" },
@@ -3013,15 +3048,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.29.1"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -3031,9 +3066,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/48/0bb26fdfe7ac16875f534a101ce2405eae192bdef37e7451f2f4507c13ec/mcp-1.29.1.tar.gz", hash = "sha256:1967ba4c315f7a375146209949f45950d18b0efd2f913d7cf3400bc723ee5f04", size = 646823, upload-time = "2026-08-24T18:30:41.161Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/3b/3acf4897b934ceeb8d22df7309a435a76c34f94be936b36eee8bb57b29a3/mcp-2.1.0.tar.gz", hash = "sha256:b4407b2890238248795d03e8c17d02d311c600ca9272d023ab12dbfa6ad21c70", size = 3983282, upload-time = "2026-08-24T19:04:32.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/04/d6b4fb82eefe9e81807aabca1ac98f460ae0883974b83a997aaa20c52545/mcp-1.29.1-py3-none-any.whl", hash = "sha256:b6310eeb59153300c4ab8b9aec4c52f4819a2d6a8e429eb43d908bed7c783648", size = 224653, upload-time = "2026-08-24T18:30:39.573Z" },
+    { url = "https://files.pythonhosted.org/packages/88/67/b2160b6cf138872860d2552cca2894dbe4d29da7f1c6fae0c21d22782838/mcp-2.1.0-py3-none-any.whl", hash = "sha256:b8acaed6ca4b9376801377463e44246395749363b1c34467ec6243a50be5ed28", size = 357320, upload-time = "2026-08-24T19:04:29.909Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/97/5b1c2e40d6121172c97638a0f1d6240526f5aeebdc9ebea11ddcf2139249/mcp_types-2.1.0.tar.gz", hash = "sha256:16f91064ce33d7ee7a75a7e198a437172215180c16d4bbcfa0e61488ede92c54", size = 66679, upload-time = "2026-08-24T19:04:34.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/99/f9041368b5af773de32af6192ff0627a71368c240123e57262439ae5b594/mcp_types-2.1.0-py3-none-any.whl", hash = "sha256:6a65bfb7d057ceaf2418781ee61b3041e1f4b5418199297f8939a4b4ed334c3a", size = 69654, upload-time = "2026-08-24T19:04:31.327Z" },
 ]
 
 [[package]]
@@ -5403,6 +5451,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
* adds elicitation support to tools as described in the [latest spec](https://modelcontextprotocol.io/specification/2026-07-28/client/elicitation). Does this by reacting to elictation events as typed interrupts instaed of the opaque callback mechanism we have
* WIP: i'm not that happy with how elicitaiton is surfaced to MultiServerMCPClient (e.g. the `elicitation` kwarg). Interrupt shape looks good though, and we're probably going to amend it anyways
