### PR TITLE
fix(core): await aformat for DictPromptTemplate in async message path

### DIFF
--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -636,7 +636,7 @@ class _StringImageMessagePromptTemplate(BaseMessagePromptTemplate):
                 formatted_image: ImageURL = await prompt.aformat(**inputs)
                 content.append({"type": "image_url", "image_url": formatted_image})
             elif isinstance(prompt, DictPromptTemplate):
-                formatted_dict: dict[str, Any] = prompt.format(**inputs)
+                formatted_dict: dict[str, Any] = await prompt.aformat(**inputs)
                 content.append(formatted_dict)
         return self._msg_class(
             content=content, additional_kwargs=self.additional_kwargs

--- a/libs/core/tests/unit_tests/prompts/test_chat.py
+++ b/libs/core/tests/unit_tests/prompts/test_chat.py
@@ -28,6 +28,7 @@ from langchain_core.prompts.chat import (
     SystemMessagePromptTemplate,
     _convert_to_message_template,
 )
+from langchain_core.prompts.dict import DictPromptTemplate
 from langchain_core.prompts.message import BaseMessagePromptTemplate
 from langchain_core.prompts.string import PromptTemplateFormat
 from langchain_core.utils.pydantic import PYDANTIC_VERSION
@@ -1983,3 +1984,37 @@ def test_mustache_template_attribute_access_vulnerability() -> None:
     )
     result_dict = prompt_dict.invoke({"person": {"name": "Alice"}})
     assert result_dict.messages[0].content == "Alice"  # type: ignore[attr-defined]
+
+
+async def test_chat_tmpl_dict_prompt_awaits_aformat() -> None:
+    """`aformat_messages` must await `DictPromptTemplate.aformat`.
+
+    The sibling `StringPromptTemplate` and `ImagePromptTemplate` branches await their
+    async formatters, so a `DictPromptTemplate` subclass that overrides `aformat` with
+    real async work was silently bypassed on the async path.
+    """
+
+    class AsyncDictPromptTemplate(DictPromptTemplate):
+        """Records which formatter ran so the async path can be asserted on."""
+
+        def format(self, **kwargs: Any) -> dict[str, Any]:
+            return {**super().format(**kwargs), "via": "sync"}
+
+        async def aformat(self, **kwargs: Any) -> dict[str, Any]:
+            return {**super().format(**kwargs), "via": "async"}
+
+    template = HumanMessagePromptTemplate(
+        prompt=[
+            AsyncDictPromptTemplate(
+                template={"type": "text", "text": "{greeting}"},
+                template_format="f-string",
+            )
+        ]
+    )
+
+    async_message = await template.aformat(greeting="hello")
+    assert async_message.content == [{"type": "text", "text": "hello", "via": "async"}]
+
+    # The synchronous path must keep using `format`.
+    sync_message = template.format(greeting="hello")
+    assert sync_message.content == [{"type": "text", "text": "hello", "via": "sync"}]


### PR DESCRIPTION
Fixes #39835

### Why

In `_StringImageMessagePromptTemplate.aformat_messages`, the `StringPromptTemplate` and `ImagePromptTemplate` branches await their async formatters, but the `DictPromptTemplate` branch calls the synchronous `format`:

```python
elif isinstance(prompt, ImagePromptTemplate):
    formatted_image: ImageURL = await prompt.aformat(**inputs)
elif isinstance(prompt, DictPromptTemplate):
    formatted_dict: dict[str, Any] = prompt.format(**inputs)  # never awaits aformat
```

`DictPromptTemplate.aformat` therefore has no reachable caller on this path, and a subclass that overrides `aformat` with real async work is silently bypassed.

This is the only site in `langchain_core/prompts/` where sibling branches *within one loop* disagree about sync vs. async. The other seven sync-`format`-inside-`async` calls are deliberate whole-body delegation (`return self.format(**kwargs)`) — the standard async-fallback pattern, one of which documents the choice inline — and are left untouched.

### Scope

The base `DictPromptTemplate.aformat` delegates to `format`, so this is behavior-preserving for the base class and for every template built through the public constructors. Only subclasses that override `aformat` change behavior — which is the bug being fixed. No public signature changes.

### Worth careful review

- The regression test asserts on a `DictPromptTemplate` **subclass**, because the base class delegates `aformat` to `format` and so cannot distinguish the two paths. If that delegation is ever considered load-bearing, the test is the place to look.
- The test also pins the synchronous path to keep using `format`, to catch the symmetric mistake in the other direction.

### Testing

- New test fails on `master` (`via: sync`) and passes with the fix (`via: async`)
- `156 passed, 1 xfailed` in `libs/core/tests/unit_tests/prompts/`
- `ruff check`, `ruff format --check`, and `mypy` clean

---

*Disclaimer: this contribution was prepared with AI assistance. An AI agent performed the root-cause investigation, wrote the fix and the regression test, and verified the test fails without the change. All output was reviewed before submission.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)