### PR TITLE
fix(langchain): filter unsupported model inputs

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -19,7 +19,13 @@ from typing import (
 )
 
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage, AnyMessage, SystemMessage, ToolMessage
+from langchain_core.messages import (
+    AIMessage,
+    AnyMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
 from langchain_core.tools import BaseTool
 from langgraph._internal._runnable import RunnableCallable
 from langgraph.constants import END, START
@@ -83,6 +89,8 @@ class _ComposedExtendedModelResponse(Generic[ResponseT]):
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterable, Sequence
 
+    from langchain_core.language_models.model_profile import ModelProfile
+    from langchain_core.messages.content import ContentBlock
     from langchain_core.runnables import Runnable, RunnableConfig
     from langgraph.cache.base import BaseCache
     from langgraph.graph.state import CompiledStateGraph
@@ -115,6 +123,70 @@ if TYPE_CHECKING:
 
 
 STRUCTURED_OUTPUT_ERROR_TEMPLATE = "Error: {error}\n Please fix your mistakes."
+
+_INPUT_PROFILE_FIELDS = {
+    "image": "image_inputs",
+    "audio": "audio_inputs",
+    "video": "video_inputs",
+}
+_TOOL_MESSAGE_PROFILE_FIELDS = {
+    "image": "image_tool_message",
+    "file": "pdf_tool_message",
+}
+
+
+def _content_block_supported(
+    block: ContentBlock,
+    profile: ModelProfile,
+    *,
+    in_tool_message: bool,
+) -> bool:
+    """Return whether a model profile supports an input content block."""
+    block_type = block["type"]
+    field = _INPUT_PROFILE_FIELDS.get(block_type)
+    if block_type == "image" and "url" in block:
+        field = "image_url_inputs"
+    elif block_type == "file" and block.get("mime_type") == "application/pdf":
+        field = "pdf_inputs"
+    if field is not None and profile.get(field) == False:  # noqa: E712
+        return False
+    tool_field = _TOOL_MESSAGE_PROFILE_FIELDS.get(block_type)
+    return not (
+        in_tool_message and tool_field is not None and profile.get(tool_field) == False  # noqa: E712
+    )
+
+
+def _filter_unsupported_content_blocks(
+    messages: list[AnyMessage], model: BaseChatModel
+) -> list[AnyMessage]:
+    """Replace input blocks explicitly unsupported by the active model profile."""
+    profile = model.profile
+    if profile is None:
+        return messages
+    filtered: list[AnyMessage] = []
+    changed = False
+    for message in messages:
+        if not isinstance(message, (HumanMessage, ToolMessage)):
+            filtered.append(message)
+            continue
+        blocks = message.content_blocks
+        content = [
+            block
+            if _content_block_supported(
+                block, profile, in_tool_message=isinstance(message, ToolMessage)
+            )
+            else {
+                "type": "text",
+                "text": f"[{block['type']} content omitted: unsupported by this model]",
+            }
+            for block in blocks
+        ]
+        changed = changed or content != blocks
+        filtered.append(
+            message.model_copy(update={"content": content}) if content != blocks else message
+        )
+    return filtered if changed else messages
+
 
 DYNAMIC_TOOL_ERROR_TEMPLATE = """
 Middleware added tools that the agent doesn't know how to execute.
@@ -1447,7 +1519,7 @@ def create_agent(
         """
         # Get the bound model (with auto-detection if needed)
         model_, effective_response_format = _get_bound_model(request)
-        messages = request.messages
+        messages = _filter_unsupported_content_blocks(request.messages, request.model)
         if request.system_message:
             messages = [request.system_message, *messages]
 
@@ -1498,7 +1570,7 @@ def create_agent(
         """
         # Get the bound model (with auto-detection if needed)
         model_, effective_response_format = _get_bound_model(request)
-        messages = request.messages
+        messages = _filter_unsupported_content_blocks(request.messages, request.model)
         if request.system_message:
             messages = [request.system_message, *messages]
 

--- a/libs/langchain_v1/tests/unit_tests/agents/test_model_profile_inputs.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_model_profile_inputs.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from pydantic import Field
+from typing_extensions import override
+
+from langchain.agents import create_agent
+from langchain.agents.middleware import AgentMiddleware
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langchain_core.callbacks import CallbackManagerForLLMRun
+
+    from langchain.agents.middleware.types import ModelRequest, ModelResponse
+
+
+class RecordingModel(GenericFakeChatModel):
+    captured_messages: list[list[BaseMessage]] = Field(default_factory=list)
+
+    @override
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        self.captured_messages.append(messages)
+        return ChatResult(generations=[ChatGeneration(message=AIMessage("done"))])
+
+
+@pytest.mark.parametrize(
+    ("startup_profile", "runtime_profile", "expected_type"),
+    [
+        ({"image_inputs": False}, {"image_inputs": True}, "image"),
+        ({"image_inputs": True}, {"image_inputs": False}, "text"),
+    ],
+)
+def test_filters_inputs_against_runtime_model_profile(
+    startup_profile: dict[str, bool],
+    runtime_profile: dict[str, bool],
+    expected_type: str,
+) -> None:
+    startup = RecordingModel(messages=iter([]), profile=startup_profile)
+    runtime = RecordingModel(messages=iter([]), profile=runtime_profile)
+
+    class SwapModel(AgentMiddleware):
+        def wrap_model_call(
+            self,
+            request: ModelRequest,
+            handler: Callable[[ModelRequest], ModelResponse],
+        ) -> ModelResponse:
+            return handler(request.override(model=runtime))
+
+    agent = create_agent(startup, middleware=[SwapModel()])
+    image = {"type": "image", "base64": "aW1hZ2U=", "mime_type": "image/png"}
+
+    agent.invoke({"messages": [HumanMessage(content=[image])]})
+
+    assert not startup.captured_messages
+    message = runtime.captured_messages[0][0]
+    assert isinstance(message, HumanMessage)
+    assert message.content_blocks[0]["type"] == expected_type
+
+
+async def test_async_filters_inputs_against_runtime_model_profile() -> None:
+    startup = RecordingModel(messages=iter([]), profile={"image_inputs": True})
+    runtime = RecordingModel(messages=iter([]), profile={"image_inputs": False})
+
+    class SwapModel(AgentMiddleware):
+        async def awrap_model_call(
+            self,
+            request: ModelRequest,
+            handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+        ) -> ModelResponse:
+            return await handler(request.override(model=runtime))
+
+    agent = create_agent(startup, middleware=[SwapModel()])
+    image = {"type": "image", "base64": "aW1hZ2U=", "mime_type": "image/png"}
+
+    await agent.ainvoke({"messages": [HumanMessage(content=[image])]})
+
+    message = runtime.captured_messages[0][0]
+    assert isinstance(message, HumanMessage)
+    assert message.content_blocks[0]["type"] == "text"
+
+
+def test_tool_message_profile_gate() -> None:
+    model = RecordingModel(
+        messages=iter([]),
+        profile={"image_inputs": True, "image_tool_message": False},
+    )
+    agent = create_agent(model)
+    image = {"type": "image", "base64": "aW1hZ2U=", "mime_type": "image/png"}
+    tool_message = ToolMessage(content=[image], tool_call_id="call")
+
+    agent.invoke({"messages": [tool_message]})
+
+    message = model.captured_messages[0][0]
+    assert isinstance(message, ToolMessage)
+    assert message.content_blocks[0]["type"] == "text"


### PR DESCRIPTION
## Description
`create_agent` now filters multimodal input blocks against the final runtime model profile at the model-execution boundary. This handles middleware model switches correctly without requiring middleware ordering conventions.

## Release Note
Agents omit multimodal inputs explicitly unsupported by the active runtime model.

## Test Plan
- [x] Verify sync model switches preserve or omit images based on the runtime profile.
- [x] Verify async switching and tool-message gates.

Made by [Open SWE](https://openswe.vercel.app/agents/d68402b2-febc-5f3a-ac93-0d9e4c346ffc)