### PR TITLE
fix(perplexity): map Responses API cache tokens into input_token_details

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -38,6 +38,7 @@ from langchain_core.messages import (
     ToolMessageChunk,
 )
 from langchain_core.messages.ai import (
+    InputTokenDetails,
     OutputTokenDetails,
     UsageMetadata,
     subtract_usage,
@@ -344,6 +345,10 @@ def _convert_responses_usage(usage: Any) -> UsageMetadata | None:
     Returns `None` if `usage` itself is missing or if either token field is
     absent — emitting zeroed `UsageMetadata` would silently undercount usage
     in downstream cost dashboards.
+
+    Cache hits and cache writes reported under `input_tokens_details` are mapped
+    onto the standard `InputTokenDetails` slots so downstream consumers can tell
+    cached input from fresh input.
     """
     if usage is None:
         return None
@@ -354,10 +359,22 @@ def _convert_responses_usage(usage: Any) -> UsageMetadata | None:
     total_tokens = _get_attr(usage, "total_tokens", None)
     if total_tokens is None:
         total_tokens = input_tokens + output_tokens
+
+    input_token_details: InputTokenDetails = {}
+    details = _get_attr(usage, "input_tokens_details", None)
+    if details is not None:
+        cache_read = _get_attr(details, "cache_read_input_tokens", None)
+        if cache_read is not None:
+            input_token_details["cache_read"] = cache_read
+        cache_creation = _get_attr(details, "cache_creation_input_tokens", None)
+        if cache_creation is not None:
+            input_token_details["cache_creation"] = cache_creation
+
     return UsageMetadata(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=total_tokens,
+        input_token_details=input_token_details,
     )
 
 

--- a/libs/partners/perplexity/tests/unit_tests/test_chat_models_responses.py
+++ b/libs/partners/perplexity/tests/unit_tests/test_chat_models_responses.py
@@ -850,6 +850,123 @@ def test_convert_responses_usage_derives_total_when_absent() -> None:
     assert result["total_tokens"] == 12
 
 
+def test_convert_responses_usage_maps_cache_token_details() -> None:
+    details = _make_response_obj(
+        cache_read_input_tokens=800, cache_creation_input_tokens=150
+    )
+    usage = _make_response_obj(
+        input_tokens=1000,
+        output_tokens=50,
+        total_tokens=1050,
+        input_tokens_details=details,
+    )
+    result = _convert_responses_usage(usage)
+    assert result is not None
+    assert result["input_token_details"] == {"cache_read": 800, "cache_creation": 150}
+
+
+def test_convert_responses_usage_maps_cache_token_details_from_mapping() -> None:
+    """`_get_attr` accepts dict payloads, so a mapping must map identically."""
+    usage = {
+        "input_tokens": 1000,
+        "output_tokens": 50,
+        "total_tokens": 1050,
+        "input_tokens_details": {
+            "cache_read_input_tokens": 800,
+            "cache_creation_input_tokens": 150,
+        },
+    }
+    result = _convert_responses_usage(usage)
+    assert result is not None
+    assert result["input_token_details"] == {"cache_read": 800, "cache_creation": 150}
+
+
+def test_convert_responses_usage_maps_only_reported_cache_fields() -> None:
+    details = _make_response_obj(
+        cache_read_input_tokens=800, cache_creation_input_tokens=None
+    )
+    usage = _make_response_obj(
+        input_tokens=1000,
+        output_tokens=50,
+        total_tokens=1050,
+        input_tokens_details=details,
+    )
+    result = _convert_responses_usage(usage)
+    assert result is not None
+    assert result["input_token_details"] == {"cache_read": 800}
+
+
+def test_convert_responses_usage_omits_cache_details_when_not_reported() -> None:
+    usage = _make_response_obj(input_tokens=10, output_tokens=2, total_tokens=12)
+    result = _convert_responses_usage(usage)
+    assert result is not None
+    assert result["input_token_details"] == {}
+
+
+def test_convert_responses_to_chat_result_includes_cache_token_details() -> None:
+    details = _make_response_obj(
+        cache_read_input_tokens=800, cache_creation_input_tokens=150
+    )
+    usage = _make_response_obj(
+        input_tokens=1000,
+        output_tokens=50,
+        total_tokens=1050,
+        input_tokens_details=details,
+    )
+    response = _make_response_obj(
+        id="resp_cache",
+        model="sonar-pro",
+        status="completed",
+        object="response",
+        output_text="hi",
+        output=[],
+        usage=usage,
+        citations=None,
+        images=None,
+        related_questions=None,
+        search_results=None,
+    )
+
+    result = _convert_responses_to_chat_result(response)
+    message = result.generations[0].message
+
+    assert isinstance(message, AIMessage)
+    assert message.usage_metadata is not None
+    assert message.usage_metadata["input_token_details"] == {
+        "cache_read": 800,
+        "cache_creation": 150,
+    }
+
+
+def test_stream_event_conversion_for_completed_includes_cache_token_details() -> None:
+    details = _make_response_obj(
+        cache_read_input_tokens=800, cache_creation_input_tokens=150
+    )
+    usage = _make_response_obj(
+        input_tokens=1000,
+        output_tokens=50,
+        total_tokens=1050,
+        input_tokens_details=details,
+    )
+    response = _make_response_obj(
+        id="resp_cache_stream",
+        model="sonar-pro",
+        status="completed",
+        object="response",
+        usage=usage,
+    )
+    chunk = _convert_responses_stream_event_to_chunk(
+        _make_event("response.completed", response=response)
+    )
+    assert chunk is not None
+    assert isinstance(chunk.message, AIMessageChunk)
+    assert chunk.message.usage_metadata is not None
+    assert chunk.message.usage_metadata["input_token_details"] == {
+        "cache_read": 800,
+        "cache_creation": 150,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Error and edge cases in conversion / streaming
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #39897

`ChatPerplexity` on the Responses (Agent) API path dropped the cache token counts Perplexity reports, so callers tracking cached vs fresh input saw nothing — in the issue's example 950 of 1000 input tokens were cache-related and none of it reached `usage_metadata`. `_convert_responses_usage` now maps `input_tokens_details.cache_read_input_tokens` and `cache_creation_input_tokens` onto the standard `InputTokenDetails.cache_read` / `cache_creation` slots, matching what `langchain-anthropic`, `langchain-groq` and `langchain-openai` already do.

The mapping reads through the existing `_get_attr` helper, so both object and mapping payloads work, and only keys the provider actually reported are set. When a response carries no cache details, `input_token_details` is emitted empty — the same shape `_create_usage_metadata` in this module already produces for `output_token_details`. Token arithmetic is untouched: `input_tokens` and `total_tokens` are unchanged, and `InputTokenDetails` is documented as not needing to sum to the full input count, so there is no double counting.

Scope is deliberately limited to the Responses path. The SDK declares `input_tokens_details` only on `ResponsesUsage`; `UsageInfo` (Chat Completions) does not declare it. Its base model is `extra="allow"`, so an undeclared key would survive `model_dump()` and a Chat Completions mapping would be harmless — but I have no payload showing those fields on that endpoint, so I left it out rather than ship an unverified mapping. Happy to extend in a follow-up if someone can confirm the raw response carries them.

## Release note

`ChatPerplexity` now reports Perplexity's cache token counts on the Responses API path: `usage_metadata["input_token_details"]` carries `cache_read` and `cache_creation` when the provider returns them.

## How did you verify your code works?

Six regression tests added in `tests/unit_tests/test_chat_models_responses.py`, covering the helper directly (object payload, mapping payload, only one field reported, nothing reported) and both call sites that consume it — the non-streaming `_convert_responses_to_chat_result` and the `response.completed` streaming event.

Run from `libs/partners/perplexity`:

- `make test` — 159 passed, 1 skipped (153 passed on master, plus the 6 new)
- `make lint_package` and `make lint_tests` — ruff check, ruff format and mypy clean on both `langchain_perplexity` and `tests`
- `make check_imports` — clean
- Also ran the new tests on Python 3.10 and 3.14, and the full unit suite on Python 3.12 with `pydantic~=2.7.0`, matching this package's CI matrix
- `uv.lock` untouched

I also checked aggregation end to end: streaming a response whose deltas carry no usage and whose `response.completed` carries the cache details yields exactly one set of details on the merged message (`cache_read` 800, `cache_creation` 150) with `input_tokens` not doubled. `response.completed` is the only Responses stream event that emits `usage_metadata`, so repeated events cannot accumulate the details.
