### PR TITLE
fix(perplexity): emit search_context_size once per stream in _astream

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -1318,6 +1318,7 @@ class ChatPerplexity(BaseChatModel):
 
         added_model_name: bool = False
         added_search_queries: bool = False
+        added_search_context_size: bool = False
         async for chunk in stream_resp:
             if not isinstance(chunk, dict):
                 chunk = chunk.model_dump()
@@ -1341,8 +1342,10 @@ class ChatPerplexity(BaseChatModel):
                     if not added_search_queries:
                         generation_info["num_search_queries"] = num_search_queries
                         added_search_queries = True
-                if search_context_size := total_usage.get("search_context_size"):
-                    generation_info["search_context_size"] = search_context_size
+                if not added_search_context_size:
+                    if search_context_size := total_usage.get("search_context_size"):
+                        generation_info["search_context_size"] = search_context_size
+                        added_search_context_size = True
 
             choices = chunk.get("choices") or []
             if len(choices) == 0:

--- a/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import AsyncIterator
 from typing import Any, cast
 from unittest.mock import MagicMock
 
@@ -8,6 +9,7 @@ from langchain_core.messages import (
     AIMessage,
     AIMessageChunk,
     BaseMessage,
+    BaseMessageChunk,
     ToolMessage,
 )
 from langchain_core.runnables import RunnableBinding
@@ -157,6 +159,90 @@ def test_perplexity_stream_includes_videos_and_reasoning(mocker: MockerFixture) 
         first_chunk.additional_kwargs["reasoning_steps"][0]["thought"]
         == "I should search"
     )
+
+
+def _usage_bearing_chunks() -> list[dict[str, Any]]:
+    """Three chunks, each carrying cumulative usage.
+
+    Perplexity reports aggregate usage on every chunk -- that is what the
+    `prev_total_usage` / `subtract_usage` bookkeeping in `_stream` and `_astream`
+    exists for -- so single-valued metadata must only be emitted once.
+    """
+    return [
+        {
+            "model": "sonar",
+            "choices": [{"delta": {"content": "Hello "}, "finish_reason": None}],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 1,
+                "total_tokens": 11,
+                "num_search_queries": 2,
+                "search_context_size": "low",
+            },
+        },
+        {
+            "model": "sonar",
+            "choices": [{"delta": {"content": "world"}, "finish_reason": None}],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 2,
+                "total_tokens": 12,
+                "num_search_queries": 2,
+                "search_context_size": "low",
+            },
+        },
+        {
+            "model": "sonar",
+            "choices": [{"delta": {}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 3,
+                "total_tokens": 13,
+                "num_search_queries": 2,
+                "search_context_size": "low",
+            },
+        },
+    ]
+
+
+def test_perplexity_stream_emits_single_valued_usage_metadata_once() -> None:
+    llm = ChatPerplexity(model="sonar", api_key="test", timeout=30)
+    mock_stream = MagicMock()
+    mock_stream.__iter__.return_value = _usage_bearing_chunks()
+    llm.client.chat.completions.create = MagicMock(return_value=mock_stream)
+
+    full: BaseMessageChunk | None = None
+    for chunk in llm.stream("Hello"):
+        full = chunk if full is None else full + chunk
+
+    assert full is not None
+    assert full.response_metadata["search_context_size"] == "low"
+    assert full.response_metadata["num_search_queries"] == 2
+    assert full.response_metadata["model_name"] == "sonar"
+
+
+@pytest.mark.asyncio
+async def test_perplexity_astream_emits_single_valued_usage_metadata_once() -> None:
+    """`search_context_size` is a string, so repeating it concatenates on merge."""
+    llm = ChatPerplexity(model="sonar", api_key="test", timeout=30)
+
+    async def _chunk_iter() -> AsyncIterator[dict[str, Any]]:
+        for chunk in _usage_bearing_chunks():
+            yield chunk
+
+    async def _create(**kwargs: Any) -> AsyncIterator[dict[str, Any]]:
+        return _chunk_iter()
+
+    llm.async_client.chat.completions.create = _create
+
+    full: BaseMessageChunk | None = None
+    async for chunk in llm.astream("Hello"):
+        full = chunk if full is None else full + chunk
+
+    assert full is not None
+    assert full.response_metadata["search_context_size"] == "low"
+    assert full.response_metadata["num_search_queries"] == 2
+    assert full.response_metadata["model_name"] == "sonar"
 
 
 def test_create_usage_metadata_basic() -> None:


### PR DESCRIPTION
Fixes #39896

`ChatPerplexity._stream` guards `search_context_size` so it is written into `generation_info` once per stream; `_astream` had no such guard and wrote it on every usage-bearing chunk. Perplexity reports cumulative usage on each chunk — that is what the `prev_total_usage` / `subtract_usage` bookkeeping in both loops exists for — and `search_context_size` is a string, which `merge_dicts` concatenates for keys outside its exempt list. Merging the chunks therefore turned `"low"` into `"lowlow"`, growing with the chunk count, so anyone reading `response_metadata["search_context_size"]` off an async stream got a corrupted value.

The fix mirrors the sync guard in `_astream`. The two sibling fields in the same block, `model_name` and `num_search_queries`, are already guarded in both paths — only this one was missed when `_astream` was introduced in #34412, the same change that added the guard to `_stream`. `num_search_queries` would not corrupt anyway, since it is an `int` and `merge_dicts` skips equal non-string values.

Worth noting either way: if a deployment only ever sent usage on the final chunk, this change would be a no-op. There is no behaviour to lose.

This was diagnosed first by @akshatDE in #38796, which proposed the same fix; that PR was closed automatically because its description carried the template's `Fixes #` with no issue number, so it was never reviewed.

## Release note

`ChatPerplexity.astream()` no longer repeats `search_context_size` across chunks, so `response_metadata["search_context_size"]` is the value the API reported (`"low"`) instead of a concatenation of it (`"lowlow"`).

## How did you verify your code works?

Two regression tests added in `tests/unit_tests/test_chat_models.py`, one per path, sharing a helper that builds three chunks each carrying cumulative usage. They assert that `search_context_size`, `num_search_queries` and `model_name` each survive the merge exactly once, so the guards on all three fields are covered.

The async test fails on current `master` with `AssertionError: assert 'lowlowlow' == 'low'` and passes with the guard in place; the sync test passes either way and pins the existing behaviour against future drift.

Run from `libs/partners/perplexity`:

- `make test` — 155 passed, 1 skipped (153 passed on master, plus the 2 new)
- `make lint_package` and `make lint_tests` — ruff check, ruff format and mypy clean on both `langchain_perplexity` and `tests`
- `pytest -m compile tests/integration_tests` — passes
- Also ran the new tests on Python 3.10 and 3.14, and the full unit suite on Python 3.12 with `pydantic~=2.7.0`, matching this package's CI matrix
- `uv.lock` untouched
