### PR TITLE
fix(core): include + bullet marker in MarkdownListOutputParser

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -221,7 +221,7 @@ class NumberedListOutputParser(ListOutputParser):
 class MarkdownListOutputParser(ListOutputParser):
     """Parse a Markdown list."""
 
-    pattern: str = r"^\s*[-*]\s([^\n]+)$"
+    pattern: str = r"^\s*[-*+]\s([^\n]+)$"
     """The pattern to match a Markdown list item."""
 
     @override

--- a/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
@@ -160,6 +160,18 @@ def test_markdown_list() -> None:
         assert list(parser.transform(iter([text]))) == expectedlist
 
 
+def test_markdown_list_plus_bullet() -> None:
+    """Test that + bullet markers are parsed correctly (CommonMark spec)."""
+    parser = MarkdownListOutputParser()
+
+    # + bullets
+    assert parser.parse("+ a\n+ b") == ["a", "b"]
+    # mixed markers
+    assert parser.parse("- a\n* b\n+ c") == ["a", "b", "c"]
+    # + with indentation
+    assert parser.parse("Items:\n+ apple\n+ banana") == ["apple", "banana"]
+
+
 T = TypeVar("T")
 
 


### PR DESCRIPTION
## Summary

CommonMark defines three bullet list markers: `-`, `*`, and `+`. The existing regex in `MarkdownListOutputParser` only matched `-` and `*`, so LLM-generated output using `+` bullets was silently dropped, returning an empty list.

## Changes

- Add `+` to the character class in the pattern (`[-*]` to `[-*+]`)
- Add a test covering `+`-only, mixed-marker, and indented `+` cases

## Reproduction

```python
from langchain_core.output_parsers import MarkdownListOutputParser

parser = MarkdownListOutputParser()
print(parser.parse("+ a\n+ b"))  # [] (expected ["a", "b"])
```

Fixes #39900