### PR TITLE
fix(core): support '+' bullet in MarkdownListOutputParser (#39900)

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -221,7 +221,7 @@ class NumberedListOutputParser(ListOutputParser):
 class MarkdownListOutputParser(ListOutputParser):
     """Parse a Markdown list."""
 
-    pattern: str = r"^\s*[-*]\s([^\n]+)$"
+    pattern: str = r"^\s*[-*+]\s([^\n]+)$"
     """The pattern to match a Markdown list item."""
 
     @override

--- a/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
@@ -312,3 +312,29 @@ async def test_markdown_list_async() -> None:
         assert [
             a async for a in parser.atransform(aiter_from_iter([text]))
         ] == expectedlist
+
+
+def test_markdown_list_plus_bullet() -> None:
+    """Regression test for #39900: MarkdownListOutputParser silently drops '+' bullets.
+
+    CommonMark defines ``-``, ``*``, and ``+`` as bullet list markers.
+    Previously only ``-`` and ``*`` were matched.
+    """
+    parser = MarkdownListOutputParser()
+    text = "+ foo\n+ bar\n+ baz"
+    expected = ["foo", "bar", "baz"]
+
+    assert parser.parse(text) == expected
+    assert list(parser.transform(t for t in text)) == [[a] for a in expected]
+
+
+async def test_markdown_list_plus_bullet_async() -> None:
+    """Async regression test for #39900."""
+    parser = MarkdownListOutputParser()
+    text = "+ foo\n+ bar\n+ baz"
+    expected = ["foo", "bar", "baz"]
+
+    assert await parser.aparse(text) == expected
+    assert [
+        a async for a in parser.atransform(aiter_from_iter(t for t in text))
+    ] == [[a] for a in expected]


### PR DESCRIPTION
## Description

Fixes #39900

`MarkdownListOutputParser` parses `-` and `*` bullets but silently drops `+` bullets, returning an empty list. CommonMark defines all three (`-`, `*`, `+`) as valid bullet list markers, so a model legitimately producing `+ item` is incorrectly parsed.

## Changes

- **list.py**: Extend character class `[-*]` → `[-*+]` in `MarkdownListOutputParser.pattern`.
- **test_list_parser.py**: Add `test_markdown_list_plus_bullet` and `test_markdown_list_plus_bullet_async` regression tests.

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Added/updated unit tests for the change
- [x] Verified existing `-` and `*` bullet tests still pass

---

cc @baskaryan @efriis