### PR TITLE
fix(openai): correct `reasoning_effort_levels` for gpt-5 and gpt-5.1 profiles

### DIFF
--- a/libs/partners/openai/langchain_openai/data/_profiles.py
+++ b/libs/partners/openai/langchain_openai/data/_profiles.py
@@ -371,11 +371,10 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "tool_choice": True,
         "tool_call_streaming": True,
         "reasoning_effort_levels": [
-            "none",
+            "minimal",
             "low",
             "medium",
             "high",
-            "xhigh",
         ],
     },
     "gpt-5-chat-latest": {
@@ -437,11 +436,10 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "tool_choice": True,
         "tool_call_streaming": True,
         "reasoning_effort_levels": [
-            "none",
+            "minimal",
             "low",
             "medium",
             "high",
-            "xhigh",
         ],
     },
     "gpt-5-nano": {
@@ -471,11 +469,10 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "tool_choice": True,
         "tool_call_streaming": True,
         "reasoning_effort_levels": [
-            "none",
+            "minimal",
             "low",
             "medium",
             "high",
-            "xhigh",
         ],
     },
     "gpt-5-pro": {
@@ -543,7 +540,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
             "low",
             "medium",
             "high",
-            "xhigh",
         ],
     },
     "gpt-5.1-chat-latest": {

--- a/libs/partners/openai/langchain_openai/data/profile_augmentations.toml
+++ b/libs/partners/openai/langchain_openai/data/profile_augmentations.toml
@@ -32,11 +32,11 @@ reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh"]
 
 [overrides."gpt-5.1"]
 max_input_tokens = 272000
-reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh"]
+reasoning_effort_levels = ["none", "low", "medium", "high"]
 
 [overrides."gpt-5-nano"]
 max_input_tokens = 272000
-reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh"]
+reasoning_effort_levels = ["minimal", "low", "medium", "high"]
 
 [overrides."gpt-5-codex"]
 max_input_tokens = 272000
@@ -44,7 +44,7 @@ reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh"]
 
 [overrides."gpt-5-mini"]
 max_input_tokens = 272000
-reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh"]
+reasoning_effort_levels = ["minimal", "low", "medium", "high"]
 
 [overrides."gpt-5.1-codex-max"]
 max_input_tokens = 272000
@@ -56,7 +56,7 @@ reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh"]
 
 [overrides."gpt-5"]
 max_input_tokens = 272000
-reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh"]
+reasoning_effort_levels = ["minimal", "low", "medium", "high"]
 
 [overrides."gpt-5-pro"]
 max_input_tokens = 272000

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -181,6 +181,23 @@ def test_profile() -> None:
     assert model.profile["max_input_tokens"] == 272_000
 
 
+def test_gpt_5_reasoning_effort_levels() -> None:
+    """GPT-5 and GPT-5.1 predate `xhigh`, and GPT-5 supports `minimal`."""
+    for model_name in ("gpt-5", "gpt-5-mini", "gpt-5-nano"):
+        model = ChatOpenAI(model=model_name)
+        assert model.profile
+        assert model.profile["reasoning_effort_levels"] == [
+            "minimal",
+            "low",
+            "medium",
+            "high",
+        ]
+
+    model = ChatOpenAI(model="gpt-5.1")
+    assert model.profile
+    assert model.profile["reasoning_effort_levels"] == ["none", "low", "medium", "high"]
+
+
 def test_gpt_5_3_chat_latest_profile_has_no_reasoning_effort() -> None:
     model = ChatOpenAI(model="gpt-5.3-chat-latest")
 


### PR DESCRIPTION
Fixes #39934

---

`gpt-5`, `gpt-5-mini`, `gpt-5-nano` and `gpt-5.1` no longer advertise a reasoning effort level they reject, and the GPT-5 models advertise `minimal` again.

---

The profile augmentations currently give all four models `["none", "low", "medium", "high", "xhigh"]`. OpenAI's [GPT-5 model page](https://developers.openai.com/api/docs/models/gpt-5) states that effort supports "minimal, low, medium, and high", and the [GPT-5.1 page](https://developers.openai.com/api/docs/models/gpt-5.1) lists "none (default), low, medium, and high". `xhigh` arrived later, with GPT-5.1-Codex-Max.

A client that reads `profile["reasoning_effort_levels"]` to build its settings therefore offers `xhigh` on models that reject it, and hides `minimal`, which GPT-5 accepts. The corrected values match the models.dev entries for the same models.

The `gpt-5.2` / `gpt-5.4` / `gpt-5.6` profiles are already correct and are untouched. A few other entries (`gpt-5-pro`, `gpt-5.2-pro`, `gpt-5.4-pro`, `gpt-5.2-chat-latest`) also differ from models.dev, but I could not confirm those from OpenAI's own docs, so I left them alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
