### PR TITLE
fix(langchain-groq): token usage aggregation in _combine_llm_outputs

### DIFF
--- a/libs/partners/groq/langchain_groq/chat_models.py
+++ b/libs/partners/groq/langchain_groq/chat_models.py
@@ -872,21 +872,20 @@ class ChatGroq(BaseChatModel):
             token_usage = output["token_usage"]
             if token_usage is not None:
                 for k, v in token_usage.items():
-                    if k in overall_token_usage and v is not None:
-                        # Handle nested dictionaries
-                        if isinstance(v, dict):
-                            if k not in overall_token_usage:
-                                overall_token_usage[k] = {}
-                            for nested_k, nested_v in v.items():
-                                if (
-                                    nested_k in overall_token_usage[k]
-                                    and nested_v is not None
-                                ):
-                                    overall_token_usage[k][nested_k] += nested_v
-                                else:
-                                    overall_token_usage[k][nested_k] = nested_v
-                        else:
-                            overall_token_usage[k] += v
+                    if v is None:
+                        continue
+                    # Handle nested dictionaries
+                    if isinstance(v, dict):
+                        existing = overall_token_usage.setdefault(k, {})
+                        for nested_k, nested_v in v.items():
+                            if nested_v is None:
+                                continue
+                            if nested_k in existing:
+                                existing[nested_k] += nested_v
+                            else:
+                                existing[nested_k] = nested_v
+                    elif k in overall_token_usage:
+                        overall_token_usage[k] += v
                     else:
                         overall_token_usage[k] = v
             if system_fingerprint is None:


### PR DESCRIPTION
Fixes #39940

`ChatGroq._combine_llm_outputs` could overwrite previously accumulated token usage with `None` when combining multiple LLM outputs. This change skips `None` values while merging usage and removes the unreachable conditional, preserving the accumulated token usage correctly.

## Release note

Fix token usage aggregation in `ChatGroq` when combining multiple LLM outputs.

## How did you verify your code works?

Verified the behavior by directly calling `_combine_llm_outputs` with multiple outputs, including a subsequent `None` token value:

```python
outputs = [
    {"token_usage": {"completion_tokens": 10}},
    {"token_usage": {"completion_tokens": None}},
]

result = model._combine_llm_outputs(outputs)
print(result["token_usage"])
```

The combined result now preserves the previously accumulated `completion_tokens` value instead of overwriting it with `None`.


## Social handles (optional)

Twitter: @
LinkedIn: https://www.linkedin.com/in/syedali237/
