### PR TITLE
fix: rerun shell startup commands after timeout

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
@@ -836,7 +836,16 @@ class ShellToolMiddleware(AgentMiddleware[ShellToolState[ResponseT], ContextT, R
 
         if result.timed_out:
             timeout_seconds = self._execution_policy.command_timeout
-            message = f"Error: Command timed out after {timeout_seconds:.1f} seconds."
+            try:
+                self._run_startup_commands(session)
+            except BaseException as err:
+                LOGGER.exception("Re-running startup commands after timeout failed.")
+                msg = "Failed to restore shell session after command timeout."
+                raise ToolException(msg) from err
+            message = (
+                f"Error: Command timed out after {timeout_seconds:.1f} seconds. "
+                "The shell session was restarted."
+            )
             return self._format_tool_message(
                 message,
                 tool_call_id,

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
@@ -18,6 +18,7 @@ from langgraph.runtime import Runtime
 
 from langchain.agents.factory import create_agent
 from langchain.agents.middleware.shell_tool import (
+    CommandExecutionResult,
     HostExecutionPolicy,
     RedactionRule,
     ShellSession,
@@ -113,6 +114,28 @@ def test_timeout_returns_error(tmp_path: Path) -> None:
         assert "timed out" in result.lower()
     finally:
         middleware.after_agent(state, runtime)
+
+
+def test_timeout_reruns_startup_commands() -> None:
+    policy = HostExecutionPolicy(command_timeout=0.5)
+    middleware = ShellToolMiddleware(execution_policy=policy)
+    session = Mock()
+    session.execute.return_value = CommandExecutionResult(
+        output="",
+        exit_code=None,
+        timed_out=True,
+        truncated_by_lines=False,
+        truncated_by_bytes=False,
+        total_lines=0,
+        total_bytes=0,
+    )
+    resources = _SessionResources(session=session, tempdir=None, policy=policy)  # type: ignore[arg-type]
+    middleware._run_startup_commands = Mock()
+    result = middleware._run_shell_tool(resources, {"command": "timeout"}, tool_call_id=None)
+    assert "timed out" in result.lower()
+    assert "restarted" in result.lower()
+    middleware._run_startup_commands.assert_called_once_with(session)
+    resources.finalizer()
 
 
 def test_redaction_policy_applies(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

When a shell command timed out, `ShellSession.execute` restarted the session but `_run_shell_tool` did not rerun configured `startup_commands`. This left the model using a fresh shell without its configured working directory, environment, or safeguards.

This change reruns `startup_commands` after a timeout and tells the model that the session was restarted. Startup failures are surfaced as a `ToolException`.

## Testing

- `uv run --frozen --directory libs/langchain_v1 pytest tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_timeout_reruns_startup_commands -q`
- `uv run --frozen --directory libs/langchain_v1 ruff check langchain/agents/middleware/shell_tool.py tests/unit_tests/agents/middleware/implementations/test_shell_tool.py`
- `uv run --frozen --directory libs/langchain_v1 ruff format --check langchain/agents/middleware/shell_tool.py tests/unit_tests/agents/middleware/implementations/test_shell_tool.py`
- `git diff --check`

The complete shell middleware test module is not runnable on Windows because the existing suite launches `/bin/bash` and uses POSIX signal semantics; the focused regression test is platform-neutral.

Fixes #39953
