### PR TITLE
fix(core): support '+' bullets in MarkdownListOutputParser (#39900)

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -221,7 +221,7 @@ class NumberedListOutputParser(ListOutputParser):
 class MarkdownListOutputParser(ListOutputParser):
     """Parse a Markdown list."""
 
-    pattern: str = r"^\s*[-*]\s([^\n]+)$"
+    pattern: str = r"^\s*[-*+]\s([^\n]+)$"
     """The pattern to match a Markdown list item."""
 
     @override

--- a/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
@@ -280,12 +280,15 @@ async def test_markdown_list_async() -> None:
 
     text2 = "Items:\n- apple\n- banana\n- cherry"
 
-    text3 = "No items in the list."
+    text3 = "Items with plus:\n+ one\n+ two\n+ three"
+
+    text4 = "No items in the list."
 
     for text, expected in [
         (text1, ["foo", "bar", "baz"]),
         (text2, ["apple", "banana", "cherry"]),
-        (text3, []),
+        (text3, ["one", "two", "three"]),
+        (text4, []),
     ]:
         expectedlist = [[a] for a in expected]
         assert await parser.aparse(text) == expected


### PR DESCRIPTION
## Summary

Fixes #39900.

CommonMark defines `-`, `+`, and `*` as valid bullet list markers. `MarkdownListOutputParser` currently accepts `-` and `*` bullets, but returns an empty list for `+` bullets.

### Changes
- Updated the regex pattern in `MarkdownListOutputParser` from `r"^\s*[-*]\s([^\n]+)$"` to `r"^\s*[-*+]\s([^\n]+)$"` in `libs/core/langchain_core/output_parsers/list.py`.
- Added unit test cases for `+` bullets in `libs/core/tests/unit_tests/output_parsers/test_list_parser.py`.