### PR TITLE
fix(langchain): avoid duplicate tool call limit responses

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/tool_call_limit.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_call_limit.py
@@ -350,12 +350,15 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
         if not messages:
             return None
 
-        # Find the last AIMessage
+        # Find the last AIMessage and any tool calls already answered after it.
         last_ai_message = None
+        answered_tool_call_ids: set[str] = set()
         for message in reversed(messages):
             if isinstance(message, AIMessage):
                 last_ai_message = message
                 break
+            if isinstance(message, ToolMessage):
+                answered_tool_call_ids.add(message.tool_call_id)
 
         if not last_ai_message or not last_ai_message.tool_calls:
             return None
@@ -417,6 +420,7 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
                 status="error",
             )
             for tool_call in blocked_calls
+            if tool_call["id"] not in answered_tool_call_ids
         ]
 
         if self.exit_behavior == "end":
@@ -424,7 +428,9 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
             # pending calls so none are executed and the message history stays valid.
             blocked_ids = {tool_call["id"] for tool_call in blocked_calls}
             pending_tool_calls = [
-                tc for tc in last_ai_message.tool_calls if tc["id"] not in blocked_ids
+                tc
+                for tc in last_ai_message.tool_calls
+                if tc["id"] not in blocked_ids and tc["id"] not in answered_tool_call_ids
             ]
             artificial_messages.extend(
                 ToolMessage(

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py
@@ -787,6 +787,61 @@ def test_middleware_end_behavior_with_allowed_and_blocked_parallel_calls() -> No
     )
 
 
+def test_continue_behavior_does_not_duplicate_answered_blocked_call() -> None:
+    """Do not emit a second response for a blocked call answered by middleware."""
+    middleware = ToolCallLimitMiddleware(run_limit=1, exit_behavior="continue")
+    runtime = None
+    state = ToolCallLimitState(
+        messages=[
+            AIMessage(
+                "Response",
+                tool_calls=[
+                    {"name": "search", "args": {}, "id": "call_1"},
+                    {"name": "search", "args": {}, "id": "call_2"},
+                ],
+            ),
+            ToolMessage(content="Already handled", tool_call_id="call_2"),
+        ],
+        thread_tool_call_count={"__all__": 1},
+        run_tool_call_count={"__all__": 1},
+    )
+
+    result = middleware.after_model(state, runtime)  # type: ignore[arg-type]
+
+    assert result is not None
+    tool_messages = [msg for msg in result["messages"] if isinstance(msg, ToolMessage)]
+    assert [msg.tool_call_id for msg in tool_messages] == ["call_1"]
+    assert result["run_tool_call_count"] == {"__all__": 3}
+
+
+def test_end_behavior_does_not_duplicate_answered_pending_call() -> None:
+    """Do not emit a second response for a pending call answered by middleware."""
+    middleware = ToolCallLimitMiddleware(thread_limit=1, exit_behavior="end")
+    runtime = None
+    state = ToolCallLimitState(
+        messages=[
+            AIMessage(
+                "Response",
+                tool_calls=[
+                    {"name": "search", "args": {}, "id": "call_1"},
+                    {"name": "search", "args": {}, "id": "call_2"},
+                ],
+            ),
+            ToolMessage(content="Already handled", tool_call_id="call_1"),
+        ],
+        thread_tool_call_count={},
+        run_tool_call_count={},
+    )
+
+    result = middleware.after_model(state, runtime)  # type: ignore[arg-type]
+
+    assert result is not None
+    assert result["jump_to"] == "end"
+    tool_messages = [msg for msg in result["messages"] if isinstance(msg, ToolMessage)]
+    assert [msg.tool_call_id for msg in tool_messages] == ["call_2"]
+    assert result["thread_tool_call_count"] == {"__all__": 0}
+
+
 def test_parallel_mixed_tool_calls_with_specific_tool_limit() -> None:
     """Test parallel calls to different tools when limiting a specific tool.
 


### PR DESCRIPTION
Fixes #39815

---

ToolCallLimitMiddleware can run after another middleware has already answered a tool call. It currently emits another synthetic ToolMessage for the same tool call ID, leaving an invalid message history with duplicate responses.

This change records ToolMessage IDs answered after the latest AIMessage and excludes them from synthetic responses in both the blocked-call path and the end-of-run pending-call path. Tool-call counting behavior remains unchanged.

Regression coverage verifies both exit_behavior="continue" and exit_behavior="end". The focused test file passes with 20 tests; Ruff and mypy pass.

## Release note

ToolCallLimitMiddleware no longer emits duplicate ToolMessage responses for tool calls already answered by another middleware.