### PR TITLE
fix(openai): correct reasoning_effort_levels for gpt-5 family and gpt-5.1 (#39935)

### DIFF
--- a/libs/partners/openai/langchain_openai/data/_profiles.py
+++ b/libs/partners/openai/langchain_openai/data/_profiles.py
@@ -371,11 +371,10 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "tool_choice": True,
         "tool_call_streaming": True,
         "reasoning_effort_levels": [
-            "none",
+            "minimal",
             "low",
             "medium",
             "high",
-            "xhigh",
         ],
     },
     "gpt-5-chat-latest": {
@@ -437,11 +436,10 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "tool_choice": True,
         "tool_call_streaming": True,
         "reasoning_effort_levels": [
-            "none",
+            "minimal",
             "low",
             "medium",
             "high",
-            "xhigh",
         ],
     },
     "gpt-5-nano": {
@@ -471,11 +469,10 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "tool_choice": True,
         "tool_call_streaming": True,
         "reasoning_effort_levels": [
-            "none",
+            "minimal",
             "low",
             "medium",
             "high",
-            "xhigh",
         ],
     },
     "gpt-5-pro": {
@@ -514,8 +511,8 @@ _PROFILES: dict[str, dict[str, Any]] = {
     },
     "gpt-5.1": {
         "name": "GPT-5.1",
-        "release_date": "2025-11-13",
-        "last_updated": "2025-11-13",
+        "release_date": "2025-11-12",
+        "last_updated": "2025-11-12",
         "open_weights": False,
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
@@ -543,7 +540,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
             "low",
             "medium",
             "high",
-            "xhigh",
         ],
     },
     "gpt-5.1-chat-latest": {

--- a/libs/partners/openai/langchain_openai/data/profile_augmentations.toml
+++ b/libs/partners/openai/langchain_openai/data/profile_augmentations.toml
@@ -32,11 +32,11 @@ reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh"]
 
 [overrides."gpt-5.1"]
 max_input_tokens = 272000
-reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh"]
+reasoning_effort_levels = ["none", "low", "medium", "high"]
 
 [overrides."gpt-5-nano"]
 max_input_tokens = 272000
-reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh"]
+reasoning_effort_levels = ["minimal", "low", "medium", "high"]
 
 [overrides."gpt-5-codex"]
 max_input_tokens = 272000
@@ -44,7 +44,7 @@ reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh"]
 
 [overrides."gpt-5-mini"]
 max_input_tokens = 272000
-reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh"]
+reasoning_effort_levels = ["minimal", "low", "medium", "high"]
 
 [overrides."gpt-5.1-codex-max"]
 max_input_tokens = 272000
@@ -56,7 +56,7 @@ reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh"]
 
 [overrides."gpt-5"]
 max_input_tokens = 272000
-reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh"]
+reasoning_effort_levels = ["minimal", "low", "medium", "high"]
 
 [overrides."gpt-5-pro"]
 max_input_tokens = 272000


### PR DESCRIPTION
## Summary

Fixes #39935.

Corrects `reasoning_effort_levels` in `profile_augmentations.toml` and regenerated `_profiles.py` for `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, and `gpt-5.1` to match official OpenAI documentation:
- `gpt-5`, `gpt-5-mini`, `gpt-5-nano`: `["minimal", "low", "medium", "high"]` (supports `minimal`, excludes unsupported `none` / `xhigh`)
- `gpt-5.1`: `["none", "low", "medium", "high"]` (excludes unsupported `xhigh`)