### PR TITLE
docs(resources): add Hybrid RAG Action for automated repo triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ LangChain helps developers build applications powered by LLMs through a standard
 - [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview) — how to contribute and find good first issues
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards
+- [Hybrid RAG Action](https://github.com/Cagrik34/hybrid-rag-action) — Zero-dependency GitHub Action & Retriever combining Okapi BM25 and dense embeddings with RRF for automated repo triage


### PR DESCRIPTION
### Summary
Adds [Hybrid RAG Action](https://github.com/Cagrik34/hybrid-rag-action) to community resources.

### Description
`Hybrid RAG Action` is a standalone, zero-dependency GitHub Action and LangChain-compatible retriever. It combines Okapi BM25 sparse lexical search with dense vector similarity fused via Reciprocal Rank Fusion (RRF, $k=60$) to provide context-grounded repository triage and AST line citations.

Fixes #39968
