### PR TITLE
release(langchain): 1.3.18

### DIFF
--- a/libs/langchain_v1/langchain/__init__.py
+++ b/libs/langchain_v1/langchain/__init__.py
@@ -1,3 +1,3 @@
 """Main entrypoint into LangChain."""
 
-__version__ = "1.3.17"
+__version__ = "1.3.18"

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-version = "1.3.17"
+version = "1.3.18"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.6.0,<2.0.0",

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1816,7 +1816,7 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.17"
+version = "1.3.18"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
Patch bump of `langchain` from 1.3.17 to 1.3.18 to prepare a release.

Picks up the `PIIMiddleware` redaction fix (#39894): message content that is a list of content blocks was being flattened into the string `repr` of the list during redaction, and redacted messages were losing fields such as `additional_kwargs`.

Standard three-file bump — `__version__`, `pyproject.toml`, and the `langchain` entry in `uv.lock`. Running `uv lock` locally also pulled in unrelated dependency drift (upstream specifier changes and environment-dependent marker lines), so that churn was reverted and only the version line kept, matching prior release PRs.

---

*Written with the help of an AI agent (Claude Code).*