### PR TITLE
release(fireworks): 1.6.1

### DIFF
--- a/libs/partners/fireworks/langchain_fireworks/_version.py
+++ b/libs/partners/fireworks/langchain_fireworks/_version.py
@@ -1,3 +1,3 @@
 """Version information for `langchain-fireworks`."""
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"

--- a/libs/partners/fireworks/pyproject.toml
+++ b/libs/partners/fireworks/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 
-version = "1.6.0"
+version = "1.6.1"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.6.0,<2.0.0",

--- a/libs/partners/fireworks/uv.lock
+++ b/libs/partners/fireworks/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "../../core" }
 dependencies = [
     { name = "httpx" },
@@ -882,7 +882,7 @@ typing = [
 
 [[package]]
 name = "langchain-fireworks"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Bumps `langchain-fireworks` to 1.6.1, a patch release carrying one fix since 1.6.0:

- `fix(fireworks): drop reasoning history blocks` (#39973)