### PR TITLE
docs(groq): remove duplicate `method` block from `with_structured_output` docstring

### DIFF
--- a/libs/partners/groq/langchain_groq/chat_models.py
+++ b/libs/partners/groq/langchain_groq/chat_models.py
@@ -998,17 +998,6 @@ class ChatGroq(BaseChatModel):
                 Learn more about the differences between the methods and which models
                 support which methods [here](https://console.groq.com/docs/structured-outputs).
 
-            method:
-                The method for steering model generation, either `'function_calling'`
-                or `'json_mode'`. If `'function_calling'` then the schema will be converted
-                to an OpenAI function and the returned model will make use of the
-                function-calling API. If `'json_mode'` then JSON mode will be used.
-
-                !!! note
-                    If using `'json_mode'` then you must include instructions for formatting
-                    the output into the desired schema into the model call. (either via the
-                    prompt itself or in the system message/prompt/instructions).
-
                 !!! warning
                     `'json_mode'` does not support streaming responses stop sequences.
 

--- a/libs/partners/groq/langchain_groq/chat_models.py
+++ b/libs/partners/groq/langchain_groq/chat_models.py
@@ -999,7 +999,7 @@ class ChatGroq(BaseChatModel):
                 support which methods [here](https://console.groq.com/docs/structured-outputs).
 
                 !!! warning
-                    `'json_mode'` does not support streaming responses stop sequences.
+                    `'json_mode'` does not support streaming responses or stop sequences.
 
             include_raw:
                 If `False` then only the parsed structured output is returned.

--- a/libs/partners/groq/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/groq/tests/unit_tests/test_chat_models.py
@@ -1322,3 +1322,11 @@ def test_handle_invalid_request_ignores_max_tokens_error() -> None:
         _handle_groq_invalid_request(err)
 
     assert not isinstance(exc_info.value, ContextOverflowError)
+
+
+def test_with_structured_output_documents_method_once() -> None:
+    """`method` was documented twice, and the stale block omitted `json_schema`."""
+    doc = ChatGroq.with_structured_output.__doc__
+    assert doc is not None
+    assert doc.count("method:") == 1
+    assert "json_schema" in doc


### PR DESCRIPTION
Closes #39977

---

Anyone reading the `ChatGroq.with_structured_output` reference sees the `method` argument documented twice, and the two blocks disagree with each other.

The first block is the current one. It lists three options and matches how the sibling `langchain-openai` package documents the same argument. The second block is older. It says the argument is `'function_calling'` or `'json_mode'`, which stopped being true when `'json_schema'` support was added. A reader who stops at the second block will not know `'json_schema'` exists, and the duplicate key also breaks API reference rendering.

This removes the stale block. The one thing it said that the surviving block did not was the warning that `'json_mode'` does not support streaming responses or stop sequences, so that warning moves up rather than being dropped. Everything else in it was already covered above.

No behaviour changes, docstring only.

The added unit test asserts `method` appears once and that `json_schema` is still described. It fails on the current `master` and passes with this change.

---

Disclaimer: this contribution was prepared with the assistance of an AI agent. I reviewed the change, verified the reproduction from the issue against `master`, and ran the package unit tests and `ruff` locally before opening it.
