### PR TITLE
fix(core): enforce `mime_type` for base64 in `create_image_block`

### DIFF
--- a/libs/core/langchain_core/messages/content.py
+++ b/libs/core/langchain_core/messages/content.py
@@ -1034,6 +1034,10 @@ def create_image_block(
         msg = "Must provide one of: url, base64, or file_id"
         raise ValueError(msg)
 
+    if base64 and not mime_type:
+        msg = "mime_type is required when using base64 data"
+        raise ValueError(msg)
+
     block = ImageContentBlock(type="image", id=ensure_id(id))
 
     if url is not None:

--- a/libs/core/tests/unit_tests/messages/test_content.py
+++ b/libs/core/tests/unit_tests/messages/test_content.py
@@ -1,0 +1,34 @@
+import pytest
+
+from langchain_core.messages.content import (
+    create_audio_block,
+    create_file_block,
+    create_image_block,
+    create_video_block,
+)
+
+BASE64_FACTORIES = [
+    create_image_block,
+    create_video_block,
+    create_audio_block,
+    create_file_block,
+]
+
+
+@pytest.mark.parametrize("factory", BASE64_FACTORIES)
+def test_base64_without_mime_type_is_rejected(factory: object) -> None:
+    with pytest.raises(ValueError, match="mime_type is required"):
+        factory(base64="aGk=")  # type: ignore[operator]
+
+
+@pytest.mark.parametrize("factory", BASE64_FACTORIES)
+def test_base64_with_mime_type_is_accepted(factory: object) -> None:
+    block = factory(base64="aGk=", mime_type="application/octet-stream")  # type: ignore[operator]
+    assert block["base64"] == "aGk="
+    assert block["mime_type"] == "application/octet-stream"
+
+
+@pytest.mark.parametrize("factory", BASE64_FACTORIES)
+def test_url_without_mime_type_is_accepted(factory: object) -> None:
+    block = factory(url="https://example.com/x")  # type: ignore[operator]
+    assert block["url"] == "https://example.com/x"


### PR DESCRIPTION
Closes #39799

---

`create_image_block` is the only one of the four media block factories that does not reject base64 data without a `mime_type`. Its own docstring already promises it does:

> Raises:
>     ValueError: If no image source is provided or if `base64` is used without `mime_type`.

`create_video_block`, `create_audio_block` and `create_file_block` all raise. `create_image_block` returns a block instead. So somebody following the documented contract gets back an image block that every sibling factory would have refused, and the missing `mime_type` only surfaces later wherever the block is consumed.

This adds the same guard the other three already use, worded identically.

## Release note

`create_image_block` now raises `ValueError` when `base64` is passed without `mime_type`, matching its documented behaviour and the other media block factories. Code that relied on the missing validation and constructed an image block from base64 data with no MIME type will now raise. Passing `mime_type` alongside `base64`, or using `url` or `file_id`, is unaffected.

## Tests

There was no unit test file covering these factories, so this adds `tests/unit_tests/messages/test_content.py` mirroring the source layout. It parametrises all four factories over three cases: base64 without a MIME type is rejected, base64 with one is accepted, and a URL without one is accepted. Only the `create_image_block` rejection case fails on `master`; the other eleven pass either way, which is what pins this as a parity fix rather than a new rule.

Full `langchain-core` unit suite: 2253 passed, 20 skipped, 9 xfailed, 1 xpassed. `ruff check` and `ruff format --check` clean on both files.

---

Disclaimer: this contribution was prepared with the assistance of an AI agent. I reproduced the issue against `master` first, reviewed the change, and ran the core unit suite and linters locally before opening it.
