### PR TITLE
fix(core): keep a v0 block `id` out of `extras` during conversion

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/langchain_v0.py
+++ b/libs/core/langchain_core/messages/block_translators/langchain_v0.py
@@ -77,7 +77,7 @@ def _convert_legacy_v0_content_block_to_v1(
         source_type = block.get("source_type")
         if source_type == "url":
             # image-url
-            known_keys = {"mime_type", "type", "source_type", "url"}
+            known_keys = {"mime_type", "type", "source_type", "url", "id"}
             extras = _extract_v0_extras(block, known_keys)
             if "id" in block:
                 return types.create_image_block(
@@ -102,7 +102,7 @@ def _convert_legacy_v0_content_block_to_v1(
             return v1_image_url
         if source_type == "base64":
             # image-base64
-            known_keys = {"mime_type", "type", "source_type", "data"}
+            known_keys = {"mime_type", "type", "source_type", "data", "id"}
             extras = _extract_v0_extras(block, known_keys)
             if "id" in block:
                 return types.create_image_block(
@@ -145,7 +145,7 @@ def _convert_legacy_v0_content_block_to_v1(
         source_type = block.get("source_type")
         if source_type == "url":
             # audio-url
-            known_keys = {"mime_type", "type", "source_type", "url"}
+            known_keys = {"mime_type", "type", "source_type", "url", "id"}
             extras = _extract_v0_extras(block, known_keys)
             if "id" in block:
                 return types.create_audio_block(
@@ -172,7 +172,7 @@ def _convert_legacy_v0_content_block_to_v1(
             return v1_audio_url
         if source_type == "base64":
             # audio-base64
-            known_keys = {"mime_type", "type", "source_type", "data"}
+            known_keys = {"mime_type", "type", "source_type", "data", "id"}
             extras = _extract_v0_extras(block, known_keys)
             if "id" in block:
                 return types.create_audio_block(
@@ -216,7 +216,7 @@ def _convert_legacy_v0_content_block_to_v1(
         source_type = block.get("source_type")
         if source_type == "url":
             # file-url
-            known_keys = {"mime_type", "type", "source_type", "url"}
+            known_keys = {"mime_type", "type", "source_type", "url", "id"}
             extras = _extract_v0_extras(block, known_keys)
             if "id" in block:
                 return types.create_file_block(
@@ -242,7 +242,7 @@ def _convert_legacy_v0_content_block_to_v1(
             return v1_file_url
         if source_type == "base64":
             # file-base64
-            known_keys = {"mime_type", "type", "source_type", "data"}
+            known_keys = {"mime_type", "type", "source_type", "data", "id"}
             extras = _extract_v0_extras(block, known_keys)
             if "id" in block:
                 return types.create_file_block(
@@ -273,7 +273,7 @@ def _convert_legacy_v0_content_block_to_v1(
             return types.create_file_block(file_id=block["id"], **extras)
         if source_type == "text":
             # file-text
-            known_keys = {"mime_type", "type", "source_type", "url"}
+            known_keys = {"mime_type", "type", "source_type", "url", "id"}
             extras = _extract_v0_extras(block, known_keys)
             if "id" in block:
                 return types.create_plaintext_block(

--- a/libs/core/tests/unit_tests/messages/block_translators/test_langchain_v0.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_langchain_v0.py
@@ -1,3 +1,7 @@
+from typing import Any
+
+import pytest
+
 from langchain_core.messages import HumanMessage
 from langchain_core.messages import content as types
 from langchain_core.messages.block_translators.langchain_v0 import (
@@ -111,3 +115,61 @@ def test_convert_with_extras_on_v0_block() -> None:
     }
 
     assert _convert_legacy_v0_content_block_to_v1(block) == expected_output
+
+
+@pytest.mark.parametrize(
+    ("block", "expected"),
+    [
+        (
+            {
+                "type": "image",
+                "source_type": "url",
+                "url": "https://example.com/image.png",
+                "id": "block-1",
+            },
+            {"type": "image", "url": "https://example.com/image.png", "id": "block-1"},
+        ),
+        (
+            {
+                "type": "audio",
+                "source_type": "base64",
+                "data": "<base64 data>",
+                "mime_type": "audio/mpeg",
+                "id": "block-2",
+            },
+            {
+                "type": "audio",
+                "base64": "<base64 data>",
+                "mime_type": "audio/mpeg",
+                "id": "block-2",
+            },
+        ),
+        (
+            {
+                "type": "file",
+                "source_type": "text",
+                "url": "some text",
+                "id": "block-3",
+            },
+            {
+                "type": "text-plain",
+                "text": "some text",
+                "mime_type": "text/plain",
+                "id": "block-3",
+            },
+        ),
+    ],
+)
+def test_convert_v0_block_carrying_a_block_id(
+    block: dict[str, Any], expected: dict[str, Any]
+) -> None:
+    """A block id must not also be swept into extras and passed twice."""
+    assert _convert_legacy_v0_content_block_to_v1(block) == expected
+
+
+def test_convert_v0_id_source_still_maps_to_file_id() -> None:
+    """For `source_type` of `id` the id is the file reference, not a block id."""
+    converted = _convert_legacy_v0_content_block_to_v1(
+        {"type": "image", "source_type": "id", "id": "file-123"}
+    )
+    assert converted == {"type": "image", "file_id": "file-123"}


### PR DESCRIPTION
Closes #39797

---

Reading `content_blocks` on a message that holds a v0-style block with a block id raises instead of converting:

```python
HumanMessage(
    content=[{
        "type": "image", "source_type": "url",
        "url": "https://example.com/x.png", "id": "block-1",
    }]
).content_blocks
```

```
TypeError: create_image_block() got multiple values for keyword argument 'id'
```

`_extract_v0_extras` returns every key that is not in `known_keys`, and `known_keys` did not list `id`. So the id ended up in `extras`, while the branch above it was already passing the same id to the factory by name. The factory then received it twice.

This adds `id` to `known_keys` in the seven url, base64 and text branches, so the id is passed once and nothing else changes.

The three `source_type` of `id` branches are deliberately untouched. There `id` is the file reference rather than a block id, it is already listed in `known_keys`, and it maps to `file_id`. A test covers that so the distinction does not get flattened later.

## Tests

Four cases in `test_langchain_v0.py`: an image url, an audio base64, a file text, each carrying a block id, plus the `source_type` of `id` case as a control. The three block-id cases fail on `master`; the control passes either way, which is the point of including it.

Full `langchain-core` unit suite: 2245 passed, 20 skipped, 9 xfailed, 1 xpassed. `ruff check` and `ruff format --check` clean.

---

Disclaimer: this contribution was prepared with the assistance of an AI agent. I reproduced the `TypeError` against `master` first, reviewed the change, and ran the core unit suite and linters locally before opening it.
