### PR TITLE
fix(core): count only readable text in reasoning/thinking blocks for count_tokens_approximately

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -2352,6 +2352,14 @@ def count_tokens_approximately(
                     elif block_type == "text":
                         text = block.get("text", "")
                         message_chars += len(text)
+                    # Count only readable text for reasoning/thinking blocks,
+                    # ignoring provider metadata like encrypted_content/signature
+                    elif block_type in {"reasoning", "thinking"}:
+                        reasoning_text = block.get(
+                            "reasoning", block.get("thinking", "")
+                        )
+                        if reasoning_text:
+                            message_chars += len(reasoning_text)
                     # Conservative estimate for unknown block types
                     else:
                         message_chars += len(repr(block))

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -2879,6 +2879,56 @@ def test_count_tokens_approximately_with_unknown_block_type() -> None:
     assert mixed > text_only
 
 
+def test_count_tokens_approximately_with_reasoning_block() -> None:
+    """Test that reasoning blocks only count readable text, not extras metadata."""
+    reasoning_text = "I should inspect the staging model."
+    ciphertext = "g" * 4000
+
+    block_with_extras = {
+        "type": "reasoning",
+        "id": "rs_abc",
+        "reasoning": reasoning_text,
+        "extras": {"content": [], "encrypted_content": ciphertext},
+    }
+    block_without_extras = {
+        "type": "reasoning",
+        "id": "rs_abc",
+        "reasoning": reasoning_text,
+    }
+
+    with_extras = count_tokens_approximately(
+        [AIMessage(content=[block_with_extras], id="ai-1")]
+    )
+    without_extras = count_tokens_approximately(
+        [AIMessage(content=[block_without_extras], id="ai-1")]
+    )
+
+    # Both should produce the same token count since extras are ignored
+    assert with_extras == without_extras
+
+    # Token count should be based on reasoning text length, not the full repr
+    # reasoning_text is 35 chars + 9 role chars = 44 chars / 4 = 11 + 3 = 14 tokens
+    assert with_extras < 20
+
+
+def test_count_tokens_approximately_with_thinking_block() -> None:
+    """Test that thinking blocks (Anthropic raw format) count only the text."""
+    thinking_text = "Let me analyze this step by step."
+    signature = "s" * 2000
+
+    block = {
+        "type": "thinking",
+        "thinking": thinking_text,
+        "signature": signature,
+    }
+
+    result = count_tokens_approximately([AIMessage(content=[block], id="ai-1")])
+
+    # Should count only the thinking text, not the signature
+    # thinking_text is 33 chars + 9 role chars = 42 chars / 4 = 11 + 3 = 14 tokens
+    assert result < 20
+
+
 def test_count_tokens_approximately_ai_tool_calls_skipped_for_list_content() -> None:
     """Test that tool_calls aren't double-counted for list (Anthropic-style) content."""
     tool_calls = [


### PR DESCRIPTION
## Description

Fixes #39697

`count_tokens_approximately` has no dedicated case for `reasoning` or `thinking` content blocks. They fall through to the catch-all `len(repr(block))` branch, which stringifies the entire block dict including provider metadata like `encrypted_content` and `signature`. This inflates token estimates 5-10x for messages containing reasoning blocks.

## Fix

Added a dedicated handler for `reasoning` and `thinking` block types in the multimodal content loop that only counts the readable text (`block["reasoning"]` or `block["thinking"]`), ignoring provider-specific metadata stored in `extras`.

This means:
- `{"type": "reasoning", "reasoning": "short text", "extras": {"encrypted_content": "...4000 chars..."}}` now counts ~9 tokens instead of ~1070
- Blocks with empty or missing reasoning text contribute 0 characters
- Boolean categoricals (existing `thinking` blocks from Anthropic/Google) are handled identically

## Tests

Added two test cases:
- `test_count_tokens_approximately_with_reasoning_block`: verifies reasoning blocks with/without extras produce the same count
- `test_count_tokens_approximately_with_thinking_block`: verifies thinking blocks ignore `signature` metadata