### PR TITLE
fix(core): support '+' bullet marker in MarkdownListOutputParser (#39900)

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -221,7 +221,7 @@ class NumberedListOutputParser(ListOutputParser):
 class MarkdownListOutputParser(ListOutputParser):
     """Parse a Markdown list."""
 
-    pattern: str = r"^\s*[-*]\s([^\n]+)$"
+    pattern: str = r"^\s*[-*+]\s([^\n]+)$"
     """The pattern to match a Markdown list item."""
 
     @override

--- a/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
@@ -136,10 +136,16 @@ def test_markdown_list() -> None:
 
     text3 = "No items in the list."
 
+    text4 = "Items with plus bullets:\n+ first\n+ second\n+ third"
+
+    text5 = "Items with asterisk bullets:\n* alpha\n* beta\n* gamma"
+
     for text, expected in [
         (text1, ["foo", "bar", "baz"]),
         (text2, ["apple", "banana", "cherry"]),
         (text3, []),
+        (text4, ["first", "second", "third"]),
+        (text5, ["alpha", "beta", "gamma"]),
     ]:
         expectedlist = [[a] for a in expected]
         assert parser.parse(text) == expected
@@ -282,10 +288,16 @@ async def test_markdown_list_async() -> None:
 
     text3 = "No items in the list."
 
+    text4 = "Items with plus bullets:\n+ first\n+ second\n+ third"
+
+    text5 = "Items with asterisk bullets:\n* alpha\n* beta\n* gamma"
+
     for text, expected in [
         (text1, ["foo", "bar", "baz"]),
         (text2, ["apple", "banana", "cherry"]),
         (text3, []),
+        (text4, ["first", "second", "third"]),
+        (text5, ["alpha", "beta", "gamma"]),
     ]:
         expectedlist = [[a] for a in expected]
         assert await parser.aparse(text) == expected


### PR DESCRIPTION
## Description
Fixes #39900

CommonMark defines '-', '*', and '+' as valid Markdown bullet list markers. However, MarkdownListOutputParser in langchain-core previously only matched '-' and '*' bullets while silently dropping valid '+' bullet list items.

## Changes Made
- Updated MarkdownListOutputParser.pattern in libs/core/langchain_core/output_parsers/list.py to match '-', '*', and '+' bullet markers.
- Added test cases for '+' and '*' bullet markers in both sync (test_markdown_list) and async (test_markdown_list_async) test suites in libs/core/tests/unit_tests/output_parsers/test_list_parser.py.

## Testing
- Verified with pytest: all 10 unit test cases in test_list_parser.py passed.
- Verified with ruff check: all checks passed.