### PR TITLE
fix(core): await DictPromptTemplate.aformat in multimodal async prompt path (#39835)

### DIFF
--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -641,7 +641,7 @@ class _StringImageMessagePromptTemplate(BaseMessagePromptTemplate):
                 formatted_image = await prompt.aformat(**inputs)
                 content.append({"type": "image_url", "image_url": formatted_image})
             elif isinstance(prompt, DictPromptTemplate):
-                formatted_dict = prompt.format(**inputs)
+                formatted_dict = await prompt.aformat(**inputs)
                 content.append(formatted_dict)
         return self._msg_class(
             content=content, additional_kwargs=self.additional_kwargs

--- a/libs/core/tests/unit_tests/prompts/test_chat.py
+++ b/libs/core/tests/unit_tests/prompts/test_chat.py
@@ -28,6 +28,7 @@ from langchain_core.prompts.chat import (
     SystemMessagePromptTemplate,
     _convert_to_message_template,
 )
+from langchain_core.prompts.dict import DictPromptTemplate
 from langchain_core.prompts.message import BaseMessagePromptTemplate
 from langchain_core.prompts.string import PromptTemplateFormat
 from langchain_core.utils.pydantic import PYDANTIC_VERSION
@@ -2004,3 +2005,15 @@ def test_mustache_template_attribute_access_vulnerability() -> None:
     )
     result_dict = prompt_dict.invoke({"person": {"name": "Alice"}})
     assert result_dict.messages[0].content == "Alice"  # type: ignore[attr-defined]
+
+
+async def test_multimodal_dict_prompt_template_aformat(mocker: Any) -> None:
+    """Test that DictPromptTemplate.aformat is called on async format paths."""
+    spy = mocker.spy(DictPromptTemplate, "aformat")
+    tmpl = ChatPromptTemplate.from_messages(
+        [("human", [{"type": "text", "text": "{q}"}, {"my_field": "{q}"}])]
+    )
+    messages = await tmpl.aformat_messages(q="hi")
+    assert messages[0].content == [{"type": "text", "text": "hi"}, {"my_field": "hi"}]
+    spy.assert_called_once()
+


### PR DESCRIPTION
## Description
Fixes #39835

In _MultiModalMessagePromptTemplate.aformat (in langchain-core/prompts/chat.py), the DictPromptTemplate branch previously called the synchronous prompt.format(**inputs) method instead of wait prompt.aformat(**inputs), unlike its sibling StringPromptTemplate and ImagePromptTemplate branches.

This caused the async prompt formatting path (format_messages) to bypass DictPromptTemplate.aformat overrides and break consistency with the async API contract.

## Changes Made
- Updated _MultiModalMessagePromptTemplate.aformat in [libs/core/langchain_core/prompts/chat.py](file:///C:/Users/Vijay/langchain/libs/core/langchain_core/prompts/chat.py) to await prompt.aformat(**inputs).
- Added unit test 	est_multimodal_dict_prompt_template_aformat in [libs/core/tests/unit_tests/prompts/test_chat.py](file:///C:/Users/Vijay/langchain/libs/core/tests/unit_tests/prompts/test_chat.py) spying on DictPromptTemplate.aformat to verify it is called during ChatPromptTemplate.aformat_messages().

## Testing
- Ran pytest on 	est_chat.py: all 68 tests passed (1 known upstream xfail).
- Ran uff check: all checks passed.