### PR TITLE
fix(core): support mustache in check_valid_template and accept Sequence[str] in validate_input_variables

### DIFF
--- a/libs/core/langchain_core/prompts/string.py
+++ b/libs/core/langchain_core/prompts/string.py
@@ -207,6 +207,31 @@ def _create_model_recursive(name: str, defs: Defs) -> type[BaseModel]:
     )
 
 
+def validate_mustache(template: str, input_variables: list[str]) -> None:
+    """Validate that the input variables are valid for the mustache template.
+
+    Issues a warning if missing or extra variables are found.
+
+    Args:
+        template: The template string.
+        input_variables: The input variables.
+    """
+    input_variables_set = set(input_variables)
+    valid_variables = mustache_template_vars(template)
+    missing_variables = valid_variables - input_variables_set
+    extra_variables = input_variables_set - valid_variables
+
+    warning_message = ""
+    if missing_variables:
+        warning_message += f"Missing variables: {missing_variables} "
+
+    if extra_variables:
+        warning_message += f"Extra variables: {extra_variables}"
+
+    if warning_message:
+        warnings.warn(warning_message.strip(), stacklevel=7)
+
+
 DEFAULT_FORMATTER_MAPPING: dict[str, Callable[..., str]] = {
     "f-string": formatter.format,
     "mustache": mustache_formatter,
@@ -215,6 +240,7 @@ DEFAULT_FORMATTER_MAPPING: dict[str, Callable[..., str]] = {
 
 DEFAULT_VALIDATOR_MAPPING: dict[str, Callable[[str, list[str]], None]] = {
     "f-string": formatter.validate_input_variables,
+    "mustache": validate_mustache,
     "jinja2": validate_jinja2,
 }
 
@@ -268,7 +294,7 @@ def check_valid_template(
         template: The template string.
         template_format: The template format.
 
-            Should be one of `'f-string'` or `'jinja2'`.
+            Should be one of `'f-string'`, `'mustache'`, or `'jinja2'`.
         input_variables: The input variables.
 
     Raises:

--- a/libs/core/langchain_core/utils/formatting.py
+++ b/libs/core/langchain_core/utils/formatting.py
@@ -48,7 +48,7 @@ class StrictFormatter(Formatter):
         return super().vformat(format_string, args, kwargs)
 
     def validate_input_variables(
-        self, format_string: str, input_variables: list[str]
+        self, format_string: str, input_variables: Sequence[str]
     ) -> None:
         """Validate that input variables match the placeholders in a format string.
 
@@ -59,7 +59,7 @@ class StrictFormatter(Formatter):
         Args:
             format_string: A string containing replacement fields to validate
                 against (e.g., `'Hello, {name}!'`).
-            input_variables: List of variable names expected to fill the
+            input_variables: Sequence of variable names expected to fill the
                 replacement fields.
 
         Raises:

--- a/libs/core/tests/unit_tests/prompts/test_string.py
+++ b/libs/core/tests/unit_tests/prompts/test_string.py
@@ -88,3 +88,8 @@ def test_f_string_templates_allow_safe_format_specs(
 ) -> None:
     assert get_template_variables(template, "f-string") == expected_variables
     assert formatter.format(template, **kwargs) == expected_output
+
+
+def test_check_valid_template_mustache() -> None:
+    check_valid_template("Hello {{name}}", "mustache", ["name"])
+    check_valid_template("Hello {{user.name}}", "mustache", ["user"])


### PR DESCRIPTION
# Description
Fixes #39988

Fixes mustache template validation in `check_valid_template` and updates variable sequence type hints in `StrictFormatter.validate_input_variables`.


### Details:
1. `DEFAULT_FORMATTER_MAPPING` supports `"mustache"`, and `PromptTemplate` allows `template_format="mustache"`. However, `DEFAULT_VALIDATOR_MAPPING` was missing `"mustache"`, causing `check_valid_template("Hello {{name}}", "mustache", ["name"])` to raise:
   `ValueError: Invalid template format 'mustache', should be one of ['f-string', 'mustache', 'jinja2'].`
2. Implemented `validate_mustache` using `mustache_template_vars` and registered it in `DEFAULT_VALIDATOR_MAPPING`.
3. Updated `StrictFormatter.validate_input_variables` to accept `Sequence[str]` (supporting lists, tuples, sets) and updated `check_valid_template` docstring.
4. Added unit test `test_check_valid_template_mustache` in `tests/unit_tests/prompts/test_string.py`.

# Twitter / LinkedIn handle
N/A
