### PR TITLE
fix: add IPv6 detection to PIIMiddleware `ip`

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/_redaction.py
+++ b/libs/langchain_v1/langchain/agents/middleware/_redaction.py
@@ -105,14 +105,24 @@ def detect_ip(content: str) -> list[PIIMatch]:
         A list of detected IP address matches.
     """
     matches: list[PIIMatch] = []
-    ipv4_pattern = r"\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b"
 
-    for match in re.finditer(ipv4_pattern, content):
+    ipv4_pattern = r"\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b"
+    ipv4_mapped_ipv6_pattern = (
+        r"(?<![\w:])::ffff:"
+        r"(?:[0-9]{1,3}\.){3}[0-9]{1,3}"
+        r"(?![\w:])"
+    )
+    ipv6_pattern = r"(?<![\w:])(?:[0-9A-Fa-f]{0,4}:){1,7}[0-9A-Fa-f]{0,4}(?![\w:])"
+
+    # Detect IPv4-mapped IPv6 addresses first.
+    for match in re.finditer(ipv4_mapped_ipv6_pattern, content):
         ip_candidate = match.group()
+
         try:
             ipaddress.ip_address(ip_candidate)
         except ValueError:
             continue
+
         matches.append(
             PIIMatch(
                 type="ip",
@@ -122,7 +132,59 @@ def detect_ip(content: str) -> list[PIIMatch]:
             )
         )
 
-    return matches
+    # Detect regular IPv6 addresses.
+    for match in re.finditer(ipv6_pattern, content):
+        ip_candidate = match.group()
+
+        # Skip candidates that overlap an already detected IPv4-mapped IPv6 address.
+        if any(
+            existing["start"] <= match.start()
+            and match.end() <= existing["end"]
+            for existing in matches
+        ):
+            continue
+
+        try:
+            ipaddress.ip_address(ip_candidate)
+        except ValueError:
+            continue
+
+        matches.append(
+            PIIMatch(
+                type="ip",
+                value=ip_candidate,
+                start=match.start(),
+                end=match.end(),
+            )
+        )
+
+    # Detect IPv4 addresses.
+    for match in re.finditer(ipv4_pattern, content):
+        # Skip IPv4 addresses that are part of an already detected IPv6 address.
+        if any(
+            existing["start"] <= match.start()
+            and match.end() <= existing["end"]
+            for existing in matches
+        ):
+            continue
+
+        ip_candidate = match.group()
+
+        try:
+            ipaddress.ip_address(ip_candidate)
+        except ValueError:
+            continue
+
+        matches.append(
+            PIIMatch(
+                type="ip",
+                value=ip_candidate,
+                start=match.start(),
+                end=match.end(),
+            )
+        )
+
+    return sorted(matches, key=lambda match: match["start"])
 
 
 def detect_mac_address(content: str) -> list[PIIMatch]:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
@@ -148,6 +148,48 @@ class TestIPDetection:
         assert matches[0]["type"] == "ip"
         assert matches[0]["value"] == "192.168.1.1"
 
+    def test_detect_valid_ipv6(self) -> None:
+        content = "Server IP: 2001:db8::1"
+        matches = detect_ip(content)
+
+        assert len(matches) == 1
+        assert matches[0]["type"] == "ip"
+        assert matches[0]["value"] == "2001:db8::1"
+
+    def test_detect_ipv6_loopback(self) -> None:
+        content = "Localhost: ::1"
+        matches = detect_ip(content)
+
+        assert len(matches) == 1
+        assert matches[0]["value"] == "::1"
+
+    def test_detect_ipv6_link_local(self) -> None:
+        content = "Interface: fe80::1"
+        matches = detect_ip(content)
+
+        assert len(matches) == 1
+        assert matches[0]["value"] == "fe80::1"
+
+    def test_detect_full_ipv6(self) -> None:
+        content = "Address: 2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+        matches = detect_ip(content)
+
+        assert len(matches) == 1
+        assert matches[0]["value"] == "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+
+    def test_detect_ipv4_mapped_ipv6(self) -> None:
+        content = "Address: ::ffff:192.168.1.1"
+        matches = detect_ip(content)
+
+        assert len(matches) == 1
+        assert matches[0]["value"] == "::ffff:192.168.1.1"
+
+    def test_ipv6_like_text_not_detected(self) -> None:
+        content = "Use std::collections or foo::bar"
+        matches = detect_ip(content)
+
+        assert len(matches) == 0
+
     def test_detect_multiple_ips(self) -> None:
         content = "Connect to 10.0.0.1 or 8.8.8.8"
         matches = detect_ip(content)


### PR DESCRIPTION
Fixes #39842

Added an IPv6 detection to PIIMiddleware `ip`. IPv4 and IPv6 candidates are validated using Python `ipaddress` module, with overlap handling to detect IPv4-mapped IPv6 addresses correctly.

---

## Release note

Fix the issue of IPv6 addresses not being detected by PIIMiddleware `ip`.

## How did you verify your code works?

Added the following regression tests:

- Standard compressed IPv6 addresses, for example `2001:db8::1`
- IPv6 loopback: `::1`
- IPv6 link-local addresses: `fe80::1`
- IPv4-mapped IPv6 addresses: `::ffff:192.168.1.1`
- IPv6-like text: `foo::bar`

The IPv6 candidates are validated with `ipaddress.ip_address()` so that only valid IP addresses are returned. I verified locally using:

`uv run pytest tests/unit_tests/agents/middleware/implementations/test_pii.py -v`

115 tests have passed. Also ran `make format`, `make lint` and `make test`. All three successful.