### PR TITLE
fix(core): forward feedback_config in EvaluatorCallbackHandler

### DIFF
--- a/libs/core/langchain_core/tracers/evaluation.py
+++ b/libs/core/langchain_core/tracers/evaluation.py
@@ -199,6 +199,7 @@ class EvaluatorCallbackHandler(BaseTracer):
                 source_info=source_info_,
                 source_run_id=res.source_run_id or source_run_id,
                 feedback_source_type=langsmith.schemas.FeedbackSourceType.MODEL,
+                feedback_config=res.feedback_config,
             )
         return results
 

--- a/libs/core/tests/unit_tests/tracers/test_evaluation.py
+++ b/libs/core/tests/unit_tests/tracers/test_evaluation.py
@@ -1,0 +1,134 @@
+"""Regression tests for EvaluationResult.feedback_config forwarding.
+
+Ensures that EvaluatorCallbackHandler._log_evaluation_feedback forwards
+feedback_config to client.create_feedback (see issue #31802).
+"""
+
+import unittest.mock
+from uuid import UUID
+
+import langsmith
+from langsmith.evaluation.evaluator import EvaluationResult
+
+from langchain_core.tracers.evaluation import EvaluatorCallbackHandler
+from langchain_core.tracers.schemas import Run
+
+
+def _make_run() -> Run:
+    """Create a minimal Run for testing."""
+    return Run(
+        id=UUID("00000000-0000-0000-0000-000000000001"),
+        name="test_run",
+        run_type="chain",
+        inputs={},
+        trace_id=UUID("00000000-0000-0000-0000-000000000002"),
+        dotted_order="1.2",
+    )
+
+
+def test_feedback_config_forwarded() -> None:
+    """Test that feedback_config is forwarded to create_feedback."""
+    client = unittest.mock.MagicMock(spec=langsmith.Client)
+    handler = EvaluatorCallbackHandler(evaluators=[], client=client)
+
+    run = _make_run()
+    result = EvaluationResult(
+        key="quality",
+        score=0.9,
+        feedback_config={"type": "continuous", "min": 0.0, "max": 1.0},
+    )
+
+    handler._log_evaluation_feedback(result, run)
+
+    client.create_feedback.assert_called_once()
+    call_kwargs = client.create_feedback.call_args
+    assert call_kwargs[1]["feedback_config"] == {
+        "type": "continuous",
+        "min": 0.0,
+        "max": 1.0,
+    }
+
+
+def test_feedback_config_none_forwarded() -> None:
+    """Test that feedback_config=None is forwarded when not set."""
+    client = unittest.mock.MagicMock(spec=langsmith.Client)
+    handler = EvaluatorCallbackHandler(evaluators=[], client=client)
+
+    run = _make_run()
+    result = EvaluationResult(key="quality", score=0.9)
+
+    handler._log_evaluation_feedback(result, run)
+
+    client.create_feedback.assert_called_once()
+    call_kwargs = client.create_feedback.call_args
+    assert call_kwargs[1]["feedback_config"] is None
+
+
+def test_other_fields_still_forwarded() -> None:
+    """Test that all other fields are still forwarded correctly."""
+    client = unittest.mock.MagicMock(spec=langsmith.Client)
+    handler = EvaluatorCallbackHandler(evaluators=[], client=client)
+
+    run = _make_run()
+    result = EvaluationResult(
+        key="quality",
+        score=0.9,
+        value="good",
+        comment="Looks great",
+        correction={"suggestion": "improve"},
+        evaluator_info={"model": "gpt-4"},
+        source_run_id=UUID("00000000-0000-0000-0000-000000000003"),
+        feedback_config={"type": "categorical", "categories": ["good", "bad"]},
+    )
+
+    handler._log_evaluation_feedback(result, run)
+
+    client.create_feedback.assert_called_once()
+    call_kwargs = client.create_feedback.call_args
+    assert call_kwargs[1]["score"] == 0.9
+    assert call_kwargs[1]["value"] == "good"
+    assert call_kwargs[1]["comment"] == "Looks great"
+    assert call_kwargs[1]["correction"] == {"suggestion": "improve"}
+    assert call_kwargs[1]["source_info"] == {"model": "gpt-4"}
+    assert call_kwargs[1]["feedback_config"] == {
+        "type": "categorical",
+        "categories": ["good", "bad"],
+    }
+
+
+def test_multiple_results_forward_feedback_config() -> None:
+    """Test that feedback_config is forwarded for multiple results."""
+    client = unittest.mock.MagicMock(spec=langsmith.Client)
+    handler = EvaluatorCallbackHandler(evaluators=[], client=client)
+
+    run = _make_run()
+    results = {
+        "results": [
+            EvaluationResult(
+                key="quality",
+                score=0.9,
+                feedback_config={"type": "continuous", "min": 0.0, "max": 1.0},
+            ),
+            EvaluationResult(
+                key="relevance",
+                score=0.8,
+                feedback_config={"type": "continuous", "min": 0.0, "max": 1.0},
+            ),
+        ]
+    }
+
+    handler._log_evaluation_feedback(results, run)
+
+    assert client.create_feedback.call_count == 2
+    first_call = client.create_feedback.call_args_list[0][1]
+    second_call = client.create_feedback.call_args_list[1][1]
+    assert first_call["feedback_config"] == {
+        "type": "continuous",
+        "min": 0.0,
+        "max": 1.0,
+    }
+    assert second_call["feedback_config"] == {
+        "type": "continuous",
+        "min": 0.0,
+        "max": 1.0,
+    }


### PR DESCRIPTION
## Summary

Fixes #31802

`EvaluatorCallbackHandler._log_evaluation_feedback` was not forwarding `EvaluationResult.feedback_config` to `client.create_feedback`, causing valid feedback configurations to be silently lost before reaching LangSmith.

## Changes

- Added `feedback_config=res.feedback_config` to the `create_feedback` call in `libs/core/langchain_core/tracers/evaluation.py`
- Added 4 regression tests in `libs/core/tests/unit_tests/tracers/test_evaluation.py`:
  - `test_feedback_config_forwarded` - verifies config is forwarded
  - `test_feedback_config_none_forwarded` - verifies None is forwarded when unset
  - `test_other_fields_still_forwarded` - verifies other fields still work
  - `test_multiple_results_forward_feedback_config` - verifies multiple results work

## Testing

All 4 new tests pass, lint is clean.
