### PR TITLE
fix(core): preserve explicit default `recursion_limit`

### DIFF
--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -440,7 +440,11 @@ def merge_configs(*configs: RunnableConfig | None) -> RunnableConfig:
     base: RunnableConfig = {}
     # Even though the keys aren't literals, this is correct
     # because both dicts are the same type
-    for config in (ensure_config(c) for c in configs if c is not None):
+    for raw_config in configs:
+        if raw_config is None:
+            continue
+        recursion_limit_was_set = raw_config.get("recursion_limit") is not None
+        config = ensure_config(raw_config)
         for key in config:
             if key == "metadata":
                 base["metadata"] = _merge_metadata_dicts(
@@ -485,7 +489,10 @@ def merge_configs(*configs: RunnableConfig | None) -> RunnableConfig:
                         # base_callbacks is also a manager
                         base["callbacks"] = base_callbacks.merge(these_callbacks)
             elif key == "recursion_limit":
-                if config["recursion_limit"] != DEFAULT_RECURSION_LIMIT:
+                if (
+                    recursion_limit_was_set
+                    or config["recursion_limit"] != DEFAULT_RECURSION_LIMIT
+                ):
                     base["recursion_limit"] = config["recursion_limit"]
             elif key in COPIABLE_KEYS and config[key] is not None:  # type: ignore[literal-required]
                 base[key] = config[key].copy()  # type: ignore[literal-required]

--- a/libs/core/tests/unit_tests/runnables/test_config.py
+++ b/libs/core/tests/unit_tests/runnables/test_config.py
@@ -306,6 +306,24 @@ async def test_merge_config_callbacks() -> None:
         assert isinstance(merged.handlers[0], StdOutCallbackHandler)
 
 
+def test_merge_configs_preserves_explicit_default_recursion_limit() -> None:
+    merged = merge_configs(
+        {"configurable": {"thread_id": "test"}},
+        RunnableConfig(recursion_limit=25),
+    )
+
+    assert merged["recursion_limit"] == 25
+
+
+def test_merge_configs_omitted_recursion_limit_does_not_override() -> None:
+    merged = merge_configs(
+        RunnableConfig(recursion_limit=10),
+        {"configurable": {"thread_id": "test"}},
+    )
+
+    assert merged["recursion_limit"] == 10
+
+
 def test_config_arbitrary_keys() -> None:
     base: RunnablePassthrough[Any] = RunnablePassthrough()
     bound = base.with_config(my_custom_key="my custom value")


### PR DESCRIPTION
Fixes #39994

---

Applications that compose runnable configs can silently lose an explicit `recursion_limit=25` because `merge_configs` currently uses the numeric default as an absence sentinel. This records whether each input supplied the field before `ensure_config` applies defaults, so an explicit value of `25` is retained while an omitted field still does not overwrite an earlier custom limit.

The regression coverage exercises both the explicit-default case and the omitted-field precedence that the previous sentinel logic protected.

## Release note

`merge_configs` now preserves an explicitly configured `recursion_limit` of `25` instead of dropping it during config composition.

This contribution was prepared with assistance from OpenAI Codex.