### PR TITLE
fix(core): support plus (+) bullet list items in `MarkdownListOutputParser`

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -221,7 +221,7 @@ class NumberedListOutputParser(ListOutputParser):
 class MarkdownListOutputParser(ListOutputParser):
     """Parse a Markdown list."""
 
-    pattern: str = r"^\s*[-*]\s([^\n]+)$"
+    pattern: str = r"^\s*[-*+]\s([^\n]+)$"
     """The pattern to match a Markdown list item."""
 
     @override

--- a/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
@@ -136,10 +136,13 @@ def test_markdown_list() -> None:
 
     text3 = "No items in the list."
 
+    text4 = "Items:\n+ orange\n+ grape\n+ pear"
+
     for text, expected in [
         (text1, ["foo", "bar", "baz"]),
         (text2, ["apple", "banana", "cherry"]),
         (text3, []),
+        (text4, ["orange", "grape", "pear"]),
     ]:
         expectedlist = [[a] for a in expected]
         assert parser.parse(text) == expected


### PR DESCRIPTION
Fixes #39900

---

Fixes a bug where `MarkdownListOutputParser` silently drops list items that use the plus sign (`+`) as their bullet list marker, returning an empty list `[]`. This occurs because the regular expression pattern only includes hyphens (`-`) and asterisks (`*`).

The regular expression pattern has been updated to include `+` in the bullet character class class: `r"^\s*[-*+]\s([^\n]+)$"`

### Value / Benefits
Ensures that the output parser correctly parses valid CommonMark markdown list formats, as `+` is a standard bullet list marker used by LLMs.

## Release note
- fix(core): support plus (+) bullet list markers in `MarkdownListOutputParser`.

### Verification
Added test cases to `unit_tests/output_parsers/test_list_parser.py` covering lists with plus (`+`) bullets, and verified they pass:
```bash
uv run pytest tests/unit_tests/output_parsers/test_list_parser.py -v
make lint
```
