### PR TITLE
fix(langchain): detect PII adjacent to non-ASCII text

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/_redaction.py
+++ b/libs/langchain_v1/langchain/agents/middleware/_redaction.py
@@ -46,6 +46,9 @@ class PIIDetectionError(Exception):
 Detector = Callable[[str], list[PIIMatch]]
 """Callable signature for detectors that locate sensitive values."""
 
+_ASCII_BOUNDARY_START = r"(?<![0-9A-Za-z_])"
+_ASCII_BOUNDARY_END = r"(?![0-9A-Za-z_])"
+
 
 def detect_email(content: str) -> list[PIIMatch]:
     """Detect email addresses in content.
@@ -56,7 +59,11 @@ def detect_email(content: str) -> list[PIIMatch]:
     Returns:
         A list of detected email matches.
     """
-    pattern = r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"
+    pattern = (
+        rf"{_ASCII_BOUNDARY_START}"
+        r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"
+        rf"{_ASCII_BOUNDARY_END}"
+    )
     return [
         PIIMatch(
             type="email",
@@ -105,7 +112,11 @@ def detect_ip(content: str) -> list[PIIMatch]:
         A list of detected IP address matches.
     """
     matches: list[PIIMatch] = []
-    ipv4_pattern = r"\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b"
+    ipv4_pattern = (
+        rf"{_ASCII_BOUNDARY_START}"
+        r"(?:[0-9]{1,3}\.){3}[0-9]{1,3}"
+        rf"{_ASCII_BOUNDARY_END}"
+    )
 
     for match in re.finditer(ipv4_pattern, content):
         ip_candidate = match.group()
@@ -134,7 +145,11 @@ def detect_mac_address(content: str) -> list[PIIMatch]:
     Returns:
         A list of detected MAC address matches.
     """
-    pattern = r"\b([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}\b"
+    pattern = (
+        rf"{_ASCII_BOUNDARY_START}"
+        r"([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}"
+        rf"{_ASCII_BOUNDARY_END}"
+    )
     return [
         PIIMatch(
             type="mac_address",

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
@@ -97,6 +97,23 @@ class TestEmailDetection:
         # Should not match invalid formats
         assert len(matches) == 0
 
+    @pytest.mark.parametrize(
+        "prefix",
+        ["contact ", "联系", "メール", "이메일", "почта", "بريد", "café"],
+    )
+    def test_detect_email_adjacent_to_non_ascii(self, prefix: str) -> None:
+        matches = detect_email(prefix + "alice@example.com")
+        assert len(matches) == 1
+        assert matches[0]["value"] == "alice@example.com"
+
+    def test_detect_email_with_trailing_non_ascii(self) -> None:
+        matches = detect_email("alice@example.com联系")
+        assert len(matches) == 1
+        assert matches[0]["value"] == "alice@example.com"
+
+    def test_email_tld_does_not_accept_pipe(self) -> None:
+        assert detect_email("user@example.|com") == []
+
 
 class TestCreditCardDetection:
     """Test credit card detection with Luhn validation."""
@@ -175,6 +192,24 @@ class TestIPDetection:
         matches = detect_ip(content)
         assert len(matches) == 0
 
+    @pytest.mark.parametrize(
+        "prefix",
+        ["contact ", "联系", "メール", "이메일", "почта", "بريد", "café"],
+    )
+    def test_detect_ip_adjacent_to_non_ascii(self, prefix: str) -> None:
+        matches = detect_ip(prefix + "192.168.1.100")
+        assert len(matches) == 1
+        assert matches[0]["value"] == "192.168.1.100"
+
+    def test_detect_ip_with_trailing_non_ascii(self) -> None:
+        matches = detect_ip("192.168.1.100联系")
+        assert len(matches) == 1
+        assert matches[0]["value"] == "192.168.1.100"
+
+    def test_ip_glued_to_ascii_letter_not_detected(self) -> None:
+        assert detect_ip("192.168.1.100cafe") == []
+        assert detect_ip("192.168.1.100café") == []
+
 
 class TestMACAddressDetection:
     """Test MAC address detection."""
@@ -210,6 +245,20 @@ class TestMACAddressDetection:
         content = "Partial: 00:1A:2B:3C"
         matches = detect_mac_address(content)
         assert len(matches) == 0
+
+    @pytest.mark.parametrize(
+        "prefix",
+        ["contact ", "联系", "メール", "이메일", "почта", "بريد", "café"],
+    )
+    def test_detect_mac_adjacent_to_non_ascii(self, prefix: str) -> None:
+        matches = detect_mac_address(prefix + "00:1A:2B:3C:4D:5E")
+        assert len(matches) == 1
+        assert matches[0]["value"] == "00:1A:2B:3C:4D:5E"
+
+    def test_detect_mac_with_trailing_non_ascii(self) -> None:
+        matches = detect_mac_address("00:1A:2B:3C:4D:5E联系")
+        assert len(matches) == 1
+        assert matches[0]["value"] == "00:1A:2B:3C:4D:5E"
 
 
 class TestURLDetection:


### PR DESCRIPTION
Fixes #40002

`\b` is Unicode-aware, so email / IPv4 / MAC detectors missed values
glued to CJK, Cyrillic, Arabic, or accented Latin (e.g. 联系alice@example.com).

This switches those three patterns to ASCII-only lookaround boundaries.
ASCII behavior stays the same. Also fixes the email TLD class `[A-Z|a-z]`,
which accepted a literal `|`.

`credit_card` is left unchanged to avoid colliding with #39996.
Related: #38791, #39998.