### PR TITLE
fix(core): avoid mutating message content blocks

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/anthropic.py
+++ b/libs/core/langchain_core/messages/block_translators/anthropic.py
@@ -241,19 +241,20 @@ def _convert_to_v1_from_anthropic(message: AIMessage) -> list[types.ContentBlock
         for block in content:
             if not isinstance(block, dict):
                 continue
-            block_type = block.get("type")
+            block_copy = block.copy()
+            block_type = block_copy.get("type")
 
             if block_type == "text":
-                if citations := block.get("citations"):
+                if citations := block_copy.get("citations"):
                     text_block: types.TextContentBlock = {
                         "type": "text",
-                        "text": block.get("text", ""),
+                        "text": block_copy.get("text", ""),
                         "annotations": [_convert_citation_to_v1(a) for a in citations],
                     }
                 else:
-                    text_block = {"type": "text", "text": block["text"]}
-                if "index" in block:
-                    text_block["index"] = block["index"]
+                    text_block = {"type": "text", "text": block_copy["text"]}
+                if "index" in block_copy:
+                    text_block["index"] = block_copy["index"]
                 yield text_block
 
             elif block_type == "thinking":
@@ -486,10 +487,10 @@ def _convert_to_v1_from_anthropic(message: AIMessage) -> list[types.ContentBlock
             else:
                 new_block: types.NonStandardContentBlock = {
                     "type": "non_standard",
-                    "value": block,
+                    "value": block_copy,
                 }
-                if "index" in new_block["value"]:
-                    new_block["index"] = new_block["value"].pop("index")
+                if "index" in block_copy:
+                    new_block["index"] = block_copy.pop("index")
                 yield new_block
 
     return list(_iter_blocks())

--- a/libs/core/langchain_core/messages/block_translators/google_genai.py
+++ b/libs/core/langchain_core/messages/block_translators/google_genai.py
@@ -385,6 +385,8 @@ def _convert_to_v1_from_genai(message: AIMessage) -> list[types.ContentBlock]:
     converted_blocks: list[types.ContentBlock] = []
 
     for item in message.content:
+        if isinstance(item, dict):
+            item = item.copy()  # noqa: PLW2901
         # Where this item's blocks start, so they can inherit its `index` below.
         block_start = len(converted_blocks)
         if isinstance(item, str):

--- a/libs/core/tests/unit_tests/messages/block_translators/test_anthropic.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_anthropic.py
@@ -192,6 +192,24 @@ def test_convert_to_v1_from_anthropic() -> None:
     assert message.content != expected_content  # check no mutation
 
 
+def test_convert_to_v1_from_anthropic_does_not_mutate_index() -> None:
+    content = [{"type": "custom", "payload": "value", "index": 3}]
+    message = AIMessage(
+        content=content, response_metadata={"model_provider": "anthropic"}
+    )
+
+    first = message.content_blocks
+    second = message.content_blocks
+
+    assert message.content == content
+    assert first == second
+    assert first[0] == {
+        "type": "non_standard",
+        "value": {"type": "custom", "payload": "value"},
+        "index": 3,
+    }
+
+
 def test_convert_to_v1_from_anthropic_chunk() -> None:
     chunks = [
         AIMessageChunk(

--- a/libs/core/tests/unit_tests/messages/block_translators/test_google_genai.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_google_genai.py
@@ -252,6 +252,34 @@ def test_content_blocks_preserve_index_for_images() -> None:
     assert [block.get("index") for block in blocks] == [0, 1]
 
 
+def test_content_blocks_does_not_mutate_text_for_grounding_citations() -> None:
+    content = [{"type": "text", "text": "hello"}]
+    message = AIMessageChunk(
+        response_metadata={
+            "model_provider": "google_genai",
+            "grounding_metadata": {
+                "grounding_chunks": [
+                    {"web": {"uri": "https://example.com", "title": "Example"}}
+                ],
+                "grounding_supports": [
+                    {
+                        "segment": {"start_index": 0, "end_index": 5},
+                        "grounding_chunk_indices": [0],
+                    }
+                ],
+            },
+        },
+        content=content,
+    )
+
+    first = message.content_blocks
+    second = message.content_blocks
+
+    assert message.content == content
+    assert first[0]["annotations"]
+    assert second[0]["annotations"]
+
+
 def test_content_blocks_preserve_index_for_parallel_tool_calls() -> None:
     """Tool calls rebuilt from `tool_calls` must recover their chunk index."""
     message = _genai_chunk(


### PR DESCRIPTION
Closes #40001

---

Reading `AIMessage.content_blocks` should not modify the message content supplied by the caller. The Anthropic translator currently removes `index` from non-standard blocks, while the Google GenAI translator adds grounding annotations directly to text blocks owned by the message.

This change copies input dictionaries before translator-local updates, preserving the existing converted output while keeping `message.content` unchanged. The regression tests cover both translators and verify that repeated reads retain the expected converted data.

## Release note

Prevent `AIMessage.content_blocks` from mutating provider message content during Anthropic and Google GenAI translation.

Validation: 220 message unit tests passed; focused translator tests passed (17); Ruff format/check and `git diff --check` passed. A targeted mypy run reports an existing unrelated error in `langchain_core/_api/beta_decorator.py`.

This contribution was prepared with assistance from an AI agent.