### PR TITLE
fix(langchain): detect 13-19 digit card numbers in PII middleware

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/_redaction.py
+++ b/libs/langchain_v1/langchain/agents/middleware/_redaction.py
@@ -68,8 +68,21 @@ def detect_email(content: str) -> list[PIIMatch]:
     ]
 
 
+# Card numbers are 13-19 digits (ISO/IEC 7812), written either as a single run of
+# digits or split into groups by single spaces or hyphens. Networks group them
+# differently - Visa and Mastercard use 4-4-4-4, American Express 4-6-5 and Diners
+# Club 4-6-4 - so rather than encode one grouping, accept any of them and let the
+# Luhn checksum in `_passes_luhn` reject values that are not card numbers. Bounds
+# are enforced there via `_CARD_NUMBER_MIN_DIGITS` / `_CARD_NUMBER_MAX_DIGITS`.
+_CARD_NUMBER_PATTERN = re.compile(r"\b(?:\d{13,19}|\d{2,13}(?:[\s-]\d{2,13}){1,5})\b")
+
+
 def detect_credit_card(content: str) -> list[PIIMatch]:
     """Detect credit card numbers in content using Luhn validation.
+
+    Detects card numbers between `_CARD_NUMBER_MIN_DIGITS` and
+    `_CARD_NUMBER_MAX_DIGITS` digits long, in the groupings used by the major card
+    networks, and validates every candidate with the Luhn checksum.
 
     Args:
         content: The text content to scan for credit card numbers.
@@ -77,10 +90,9 @@ def detect_credit_card(content: str) -> list[PIIMatch]:
     Returns:
         A list of detected credit card matches.
     """
-    pattern = r"\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b"
     matches = []
 
-    for match in re.finditer(pattern, content):
+    for match in _CARD_NUMBER_PATTERN.finditer(content):
         card_number = match.group()
         if _passes_luhn(card_number):
             matches.append(
@@ -248,6 +260,34 @@ _UNMASKED_CHAR_NUMBER = 4
 _IPV4_PARTS_NUMBER = 4
 
 
+def _mask_card_number(value: str) -> str:
+    """Mask every digit of a card number except the last four.
+
+    Separator characters and the overall length are preserved so the masked value
+    keeps the shape of the original. Card numbers range from 13 to 19 digits with
+    network-specific groupings, so a fixed 4-4-4-4 template would misreport the
+    length of, for example, a 15-digit American Express number.
+
+    Args:
+        value: The card number as it appeared in the content, including any
+            spaces or hyphens used to group the digits.
+
+    Returns:
+        The card number with all but its final four digits replaced by `*`.
+    """
+    digit_count = sum(1 for char in value if char.isdigit())
+    first_unmasked = digit_count - _UNMASKED_CHAR_NUMBER
+    digits_seen = 0
+    chars: list[str] = []
+    for char in value:
+        if not char.isdigit():
+            chars.append(char)
+            continue
+        chars.append(char if digits_seen >= first_unmasked else "*")
+        digits_seen += 1
+    return "".join(chars)
+
+
 def _apply_mask_strategy(content: str, matches: list[PIIMatch]) -> str:
     result = content
     for match in sorted(matches, key=operator.itemgetter("start"), reverse=True):
@@ -265,15 +305,7 @@ def _apply_mask_strategy(content: str, matches: list[PIIMatch]) -> str:
             else:
                 masked = "****"
         elif pii_type == "credit_card":
-            digits_only = "".join(c for c in value if c.isdigit())
-            separator = "-" if "-" in value else " " if " " in value else ""
-            if separator:
-                masked = (
-                    f"****{separator}****{separator}****{separator}"
-                    f"{digits_only[-_UNMASKED_CHAR_NUMBER:]}"
-                )
-            else:
-                masked = f"************{digits_only[-_UNMASKED_CHAR_NUMBER:]}"
+            masked = _mask_card_number(value)
         elif pii_type == "ip":
             octets = value.split(".")
             masked = f"*.*.*.{octets[-1]}" if len(octets) == _IPV4_PARTS_NUMBER else "****"

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
@@ -28,7 +28,11 @@ from langchain.agents import AgentState
 from langchain.agents import middleware as middleware_package
 from langchain.agents.factory import create_agent
 from langchain.agents.middleware import PIIMatch as PublicPIIMatch
-from langchain.agents.middleware._redaction import RedactionRule
+from langchain.agents.middleware._redaction import (
+    RedactionRule,
+    _CARD_NUMBER_MAX_DIGITS,
+    _CARD_NUMBER_MIN_DIGITS,
+)
 from langchain.agents.middleware.pii import (
     PIIDetectionError,
     PIIMatch,
@@ -135,6 +139,73 @@ class TestCreditCardDetection:
         content = "No cards here."
         matches = detect_credit_card(content)
         assert len(matches) == 0
+
+    def test_detect_amex_15_digit(self) -> None:
+        content = "Card: 378282246310005"
+        matches = detect_credit_card(content)
+
+        assert len(matches) == 1
+        assert matches[0]["value"] == "378282246310005"
+
+    def test_detect_diners_club_14_digit(self) -> None:
+        content = "Card: 30569309025904"
+        matches = detect_credit_card(content)
+
+        assert len(matches) == 1
+        assert matches[0]["value"] == "30569309025904"
+
+    def test_detect_visa_legacy_13_digit(self) -> None:
+        content = "Card: 4222222222222"
+        matches = detect_credit_card(content)
+
+        assert len(matches) == 1
+        assert matches[0]["value"] == "4222222222222"
+
+    def test_pattern_covers_luhn_length_bounds(self) -> None:
+        """The pattern and the Luhn length bounds must not drift apart."""
+        detected_lengths = {
+            len(matches[0]["value"])
+            for card in (
+                "4307418529637",
+                "43074185296302",
+                "430741852963072",
+                "4307418529630747",
+                "43074185296307416",
+                "430741852963074189",
+                "4307418529630741857",
+            )
+            if (matches := detect_credit_card(f"Card: {card}"))
+        }
+
+        assert detected_lengths == set(
+            range(_CARD_NUMBER_MIN_DIGITS, _CARD_NUMBER_MAX_DIGITS + 1)
+        )
+
+    def test_reported_cards_from_issue_33924(self) -> None:
+        """Regression test for the numbers reported in #33924."""
+        cards = [
+            "378282246310005",
+            "371449635398431",
+            "378734493671000",
+            "5610591081018250",
+            "30569309025904",
+            "38520000023237",
+            "6011111111111117",
+            "6011000990139424",
+            "3530111333300000",
+            "3566002020360505",
+            "5555555555554444",
+            "5105105105105100",
+            "4111111111111111",
+            "4012888888881881",
+            "4222222222222",
+        ]
+
+        undetected = [
+            card for card in cards if not detect_credit_card(f"my card number is {card}")
+        ]
+
+        assert undetected == []
 
 
 class TestIPDetection:
@@ -319,6 +390,28 @@ class TestMaskStrategy:
         content = result["messages"][0].content
         assert "0366" in content  # Last 4 digits visible
         assert "4532015112830366" not in content
+
+    def test_mask_credit_card_preserves_length(self) -> None:
+        middleware = PIIMiddleware("credit_card", strategy="mask")
+        state = AgentState[Any](messages=[HumanMessage("Card: 378282246310005")])
+
+        result = middleware.before_model(state, Runtime())
+
+        assert result is not None
+        content = result["messages"][0].content
+        assert "Card: ***********0005" in content
+        assert "378282246310005" not in content
+
+    def test_mask_credit_card_preserves_grouping(self) -> None:
+        middleware = PIIMiddleware("credit_card", strategy="mask")
+        state = AgentState[Any](messages=[HumanMessage("Card: 3782-822463-10005")])
+
+        result = middleware.before_model(state, Runtime())
+
+        assert result is not None
+        content = result["messages"][0].content
+        assert "Card: ****-******-*0005" in content
+        assert "3782-822463-10005" not in content
 
     def test_mask_ip(self) -> None:
         middleware = PIIMiddleware("ip", strategy="mask")


### PR DESCRIPTION
Fixes #40000

## Summary
- Detect 13–19 digit card numbers (Visa legacy, Amex, Diners Club, etc.) via a grouped-digit regex plus existing Luhn validation.
- Preserve separator shape when masking non-16-digit cards.

## Test plan
- [x] `pytest libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCreditCardDetection`
- [x] `pytest libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMaskStrategy -k credit_card`

AI disclosure: prepared with AI assistance; changes were reviewed and tests run locally before submission.