### PR TITLE
core: include + bullet marker in MarkdownListOutputParser

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -221,7 +221,7 @@ class NumberedListOutputParser(ListOutputParser):
 class MarkdownListOutputParser(ListOutputParser):
     """Parse a Markdown list."""
 
-    pattern: str = r"^\s*[-*]\s([^\n]+)$"
+    pattern: str = r"^\s*[-*+]\s([^\n]+)$"
     """The pattern to match a Markdown list item."""
 
     @override

--- a/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
@@ -136,10 +136,16 @@ def test_markdown_list() -> None:
 
     text3 = "No items in the list."
 
+    text4 = "Items:\n+ alpha\n+ beta\n+ gamma"
+
+    text5 = "Mixed:\n- dash\n* star\n+ plus"
+
     for text, expected in [
         (text1, ["foo", "bar", "baz"]),
         (text2, ["apple", "banana", "cherry"]),
         (text3, []),
+        (text4, ["alpha", "beta", "gamma"]),
+        (text5, ["dash", "star", "plus"]),
     ]:
         expectedlist = [[a] for a in expected]
         assert parser.parse(text) == expected


### PR DESCRIPTION
## Summary

Fixes #39900

`MarkdownListOutputParser` silently drops `+` bullet items because the regex pattern `r"^\s*[-*]\s([^\n]+)$"` only matches `-` and `*` markers.

The [CommonMark spec](https://spec.commonmark.org/0.31.2/#bullet-list-marker) defines three valid bullet list markers: `-`, `*`, and `+`. All three are widely used by LLMs in their output.

### Change

- **`langchain_core/output_parsers/list.py`**: Update pattern from `[-*]` to `[-*+]`
- **`tests/unit_tests/output_parsers/test_list_parser.py`**: Add test cases for `+` bullets and mixed bullet markers (`-`, `*`, `+`)

### Before
```python
parser = MarkdownListOutputParser()
parser.parse("+ alpha\n+ beta\n+ gamma")
# []  ← silently drops all items
```

### After
```python
parser = MarkdownListOutputParser()
parser.parse("+ alpha\n+ beta\n+ gamma")
# ['alpha', 'beta', 'gamma']
```

## Test plan

- [x] New test: `+` bullet items parsed correctly
- [x] New test: mixed `-`, `*`, `+` bullets parsed correctly
- [x] Existing tests still pass (no behavior change for `-` and `*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)