### PR TITLE
fix(core): avoid mutating Google grounding text blocks (#40008)

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/google_genai.py
+++ b/libs/core/langchain_core/messages/block_translators/google_genai.py
@@ -505,7 +505,7 @@ def _convert_to_v1_from_genai(message: AIMessage) -> list[types.ContentBlock]:
                     server_tool_result_block["extras"]["outcome"] = outcome
                 converted_blocks.append(server_tool_result_block)
             elif item_type == "text":
-                converted_blocks.append(cast("types.TextContentBlock", item))
+                converted_blocks.append(cast("types.TextContentBlock", dict(item)))
             else:
                 # Unknown type, preserve as non-standard
                 converted_blocks.append({"type": "non_standard", "value": item})

--- a/libs/core/tests/unit_tests/messages/block_translators/test_google_genai_regression.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_google_genai_regression.py
@@ -1,0 +1,43 @@
+from copy import deepcopy
+
+from langchain_core.messages import AIMessage, AIMessageChunk
+
+GROUNDING_METADATA = {
+    "grounding_chunks": [{"web": {"uri": "https://example.com", "title": "Example"}}],
+    "grounding_supports": [
+        {
+            "segment": {"start_index": 0, "end_index": 5},
+            "grounding_chunk_indices": [0],
+        }
+    ],
+}
+
+
+def test_google_genai_content_blocks_does_not_mutate_ai_message_content() -> None:
+    message = AIMessage(
+        content=[{"type": "text", "text": "hello"}],
+        response_metadata={
+            "model_provider": "google_genai",
+            "grounding_metadata": GROUNDING_METADATA,
+        },
+    )
+    original = deepcopy(message.content)
+
+    _ = message.content_blocks
+
+    assert message.content == original
+
+
+def test_google_genai_content_blocks_does_not_mutate_ai_message_chunk_content() -> None:
+    message = AIMessageChunk(
+        content=[{"type": "text", "text": "hello"}],
+        response_metadata={
+            "model_provider": "google_genai",
+            "grounding_metadata": GROUNDING_METADATA,
+        },
+    )
+    original = deepcopy(message.content)
+
+    _ = message.content_blocks
+
+    assert message.content == original


### PR DESCRIPTION
## Summary

Fixes #40008.

The Google GenAI content translator reused the original text-block dictionary, then attached grounding citations to it. Reading  consequently mutated  for both  and .

This copies text blocks before citation enrichment, keeping the original message content unchanged.

## Verification

- Added regression coverage for  and .
- Targeted tests: 2 passed.
- Ruff check and format check: passed.