### PR TITLE
fix(langchain): detect IPv6 addresses in the PII ip detector

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/_redaction.py
+++ b/libs/langchain_v1/langchain/agents/middleware/_redaction.py
@@ -104,24 +104,49 @@ def detect_ip(content: str) -> list[PIIMatch]:
     Returns:
         A list of detected IP address matches.
     """
-    matches: list[PIIMatch] = []
     ipv4_pattern = r"\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b"
+    # Take any colon-bearing run of IPv6 characters as a candidate and let
+    # ``ipaddress`` decide. The lookaround keeps scope tokens such as
+    # ``std::vector`` out, which would otherwise validate as ``d::``.
+    ipv6_pattern = r"(?<![0-9A-Za-z:.])[0-9A-Fa-f:.]*:[0-9A-Fa-f:.]*(?![0-9A-Za-z])"
 
-    for match in re.finditer(ipv4_pattern, content):
-        ip_candidate = match.group()
+    matches: list[PIIMatch] = []
+
+    for match in re.finditer(ipv6_pattern, content):
         try:
-            ipaddress.ip_address(ip_candidate)
+            ipaddress.IPv6Address(match.group())
         except ValueError:
             continue
         matches.append(
             PIIMatch(
                 type="ip",
-                value=ip_candidate,
+                value=match.group(),
                 start=match.start(),
                 end=match.end(),
             )
         )
 
+    ipv6_spans = [(match["start"], match["end"]) for match in matches]
+
+    for match in re.finditer(ipv4_pattern, content):
+        try:
+            ipaddress.IPv4Address(match.group())
+        except ValueError:
+            continue
+        # An IPv4-mapped address such as ``::ffff:192.168.1.1`` is already
+        # covered by the IPv6 match containing it.
+        if any(start <= match.start() and match.end() <= end for start, end in ipv6_spans):
+            continue
+        matches.append(
+            PIIMatch(
+                type="ip",
+                value=match.group(),
+                start=match.start(),
+                end=match.end(),
+            )
+        )
+
+    matches.sort(key=operator.itemgetter("start"))
     return matches
 
 
@@ -276,7 +301,11 @@ def _apply_mask_strategy(content: str, matches: list[PIIMatch]) -> str:
                 masked = f"************{digits_only[-_UNMASKED_CHAR_NUMBER:]}"
         elif pii_type == "ip":
             octets = value.split(".")
-            masked = f"*.*.*.{octets[-1]}" if len(octets) == _IPV4_PARTS_NUMBER else "****"
+            masked = (
+                f"*.*.*.{octets[-1]}"
+                if ":" not in value and len(octets) == _IPV4_PARTS_NUMBER
+                else "****"
+            )
         elif pii_type == "mac_address":
             separator = ":" if ":" in value else "-"
             masked = (

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
@@ -175,6 +175,53 @@ class TestIPDetection:
         matches = detect_ip(content)
         assert len(matches) == 0
 
+    def test_detect_valid_ipv6(self) -> None:
+        content = "Server IP: 2001:db8::1"
+        matches = detect_ip(content)
+
+        assert len(matches) == 1
+        assert matches[0]["type"] == "ip"
+        assert matches[0]["value"] == "2001:db8::1"
+
+    def test_detect_ipv6_loopback(self) -> None:
+        content = "Bound to ::1 on startup"
+        matches = detect_ip(content)
+
+        assert len(matches) == 1
+        assert matches[0]["value"] == "::1"
+
+    def test_detect_link_local_ipv6(self) -> None:
+        content = "Neighbour fe80::1 is unreachable"
+        matches = detect_ip(content)
+
+        assert len(matches) == 1
+        assert matches[0]["value"] == "fe80::1"
+
+    def test_ipv4_still_detected_next_to_stray_colons(self) -> None:
+        # The leading colons make the whole span look like an IPv6 candidate.
+        # It fails validation, and the IPv4 inside it must still be reported.
+        content = "my ip is :::192.168.1.100 ok"
+        matches = detect_ip(content)
+
+        assert len(matches) == 1
+        assert matches[0]["value"] == "192.168.1.100"
+
+    def test_scope_token_not_detected(self) -> None:
+        # ``d::`` on its own is a valid IPv6 address, so ``std::vector`` must not
+        # be taken as a candidate.
+        content = "std::vector<int> v; server at 10.1.2.3"
+        matches = detect_ip(content)
+
+        assert len(matches) == 1
+        assert matches[0]["value"] == "10.1.2.3"
+
+    def test_ipv4_mapped_address_reported_once(self) -> None:
+        content = "Client ::ffff:192.168.1.1 connected"
+        matches = detect_ip(content)
+
+        assert len(matches) == 1
+        assert matches[0]["value"] == "::ffff:192.168.1.1"
+
 
 class TestMACAddressDetection:
     """Test MAC address detection."""
@@ -330,6 +377,30 @@ class TestMaskStrategy:
         content = result["messages"][0].content
         assert "*.*.*.100" in content
         assert "192.168.1.100" not in content
+
+    def test_mask_ipv6(self) -> None:
+        middleware = PIIMiddleware("ip", strategy="mask")
+        state = AgentState[Any](messages=[HumanMessage("IP: 2001:db8::1")])
+
+        result = middleware.before_model(state, Runtime())
+
+        assert result is not None
+        content = result["messages"][0].content
+        assert "****" in content
+        assert "2001:db8::1" not in content
+
+    def test_mask_ipv4_mapped_ipv6(self) -> None:
+        # Splitting on "." would otherwise mask this as if it were IPv4.
+        middleware = PIIMiddleware("ip", strategy="mask")
+        state = AgentState[Any](messages=[HumanMessage("IP: ::ffff:192.168.1.1")])
+
+        result = middleware.before_model(state, Runtime())
+
+        assert result is not None
+        content = result["messages"][0].content
+        assert "****" in content
+        assert "*.*.*.1" not in content
+        assert "192.168.1.1" not in content
 
 
 class TestHashStrategy:


### PR DESCRIPTION
Fixes #39842

`detect_ip` only scans an IPv4 pattern, so IPv6 addresses pass through unredacted. The `"****"` branch in `_apply_mask_strategy` exists for them but is unreachable today.

Adding IPv6 as one combined pattern loses IPv4 results that master currently catches: on `my ip is :::192.168.1.100 ok` the IPv6 alternative matches the whole span, fails `ipaddress`, and the loop continues without rescanning inside it, so nothing is reported. It also picks up scope tokens — `std::vector` yields `d::`, which is a valid address.

So this scans the two families separately and drops IPv4 spans contained in a validated IPv6 match. Every IPv4 result the previous implementation produced is preserved. `::ffff:192.168.1.1` is now reported once as the whole address rather than just its IPv4 tail, and masking branches on address family rather than dot count so it is not masked as `*.*.*.1`.

Six of the new tests fail if only the production change is reverted; two are regression guards for the trap above and pass either way.

`pytest tests/unit_tests/agents/middleware` → 802 passed, 2 skipped. `ruff check`, `ruff format --diff` and `mypy` are clean on both files.

One judgement call for you: a bare `a::b` is a valid IPv6 literal, so `Foo a::b` is now redacted. The lookaround keeps `std::`-style tokens out, but it cannot separate a two-group address from a scope token delimited by whitespace. I kept the permissive side since this is a redactor — happy to require three or more groups instead if you prefer.
