### PR TITLE
fix(langchain): allow path segments containing `..` in `FilesystemFileSearchMiddleware`

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -14,7 +14,7 @@ import re
 import subprocess
 from contextlib import suppress
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Literal
 
 from langchain_core.tools import tool
@@ -271,8 +271,9 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
         if not path.startswith("/"):
             path = "/" + path
 
-        # Check for path traversal
-        if ".." in path or "~" in path:
+        # Check for path traversal. Only a full `..` segment escapes the
+        # root; names that merely contain dots (e.g. `src..old`) are valid.
+        if ".." in PurePosixPath(path).parts or "~" in path:
             msg = "Path traversal not allowed"
             raise ValueError(msg)
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
@@ -308,6 +308,36 @@ class TestPathTraversalSecurity:
 
         assert result == "No files found"
 
+    def test_path_with_dotted_segment_is_allowed(self, tmp_path: Path) -> None:
+        """Names that merely contain dots (e.g. `src..old`) are not traversal."""
+        (tmp_path / "src..old").mkdir()
+        (tmp_path / "src..old" / "file.py").write_text("content", encoding="utf-8")
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path))
+
+        assert isinstance(middleware.glob_search, StructuredTool)
+        assert middleware.glob_search.func is not None
+        result = middleware.glob_search.func(pattern="*.py", path="/src..old")
+
+        assert result == "/src..old/file.py"
+
+    def test_dotted_name_does_not_open_traversal(self, tmp_path: Path) -> None:
+        """A traversal segment must stay blocked even next to dotted names."""
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path))
+
+        with pytest.raises(ValueError, match="Path traversal not allowed"):
+            middleware._validate_and_resolve_path("/src..old/../secret")
+
+    def test_validate_path_rejects_full_dotdot_segment(self, tmp_path: Path) -> None:
+        """Only a full `..` segment is traversal, not dots inside a name."""
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path))
+
+        resolved = middleware._validate_and_resolve_path("/src..old/file.py")
+        assert resolved == tmp_path / "src..old" / "file.py"
+
+        with pytest.raises(ValueError, match="Path traversal not allowed"):
+            middleware._validate_and_resolve_path("/..")
+
     def test_grep_path_traversal_protection(self, tmp_path: Path) -> None:
         """Test that grep also protects against path traversal."""
         (tmp_path / "allowed").mkdir()


### PR DESCRIPTION
Closes #38549

---

## Why

`FilesystemFileSearchMiddleware` rejects any search path containing `..` as a substring. That was meant to block directory traversal, but it also blocks perfectly valid file and directory names that happen to contain two dots — `src..old`, `v1..backup`, `notes..archived` — so agents searching those locations silently get `No files found`.

A substring check is the wrong shape for this guard: only a full `..` path *segment* can escape the root; dots inside a name cannot.

## What changed

The traversal check in `_validate_and_resolve_path` now inspects `PurePosixPath(path).parts` instead of the raw string. Every existing protection is preserved:

- real traversal (`/src/../secret`, `/..`) still raises `Path traversal not allowed`
- `~` paths, absolute-path escapes, and symlink escapes still blocked (all pre-existing security tests pass unchanged)
- the `.resolve()` + `relative_to` containment check remains as a second layer

Regression tests in `TestPathTraversalSecurity` cover: a dotted segment resolving correctly, traversal next to a dotted name staying blocked, and a full `..` segment still raising. The behavioral tests fail on current master.

## Release note

Fixed: `FilesystemFileSearchMiddleware` no longer rejects search paths whose directory or file names merely contain `..` (e.g. `src..old`); actual `..` traversal segments are still blocked.

---

🤖 AI-assisted contribution: implemented with an AI coding agent (Sisyphus), human-reviewed.
