### PR TITLE
fix(anthropic): drop empty string items when formatting message content

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -580,7 +580,11 @@ def _format_messages(
             content = []
             for block in message.content:
                 if isinstance(block, str):
-                    content.append({"type": "text", "text": block})
+                    # Only add non-empty strings as empty text blocks are not
+                    # accepted, matching the dict text branch below.
+                    # https://github.com/anthropics/anthropic-sdk-python/issues/461
+                    if block.strip():
+                        content.append({"type": "text", "text": block})
                 elif isinstance(block, dict):
                     if "type" not in block:
                         msg = "Dict content block must have a type key"

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -5081,3 +5081,36 @@ def test_thinking_display_summarized_does_not_enable_beta() -> None:
     )
     payload = llm._get_request_payload([HumanMessage("Hello, world!")])
     assert "betas" not in payload
+
+
+def test__format_messages_drops_empty_string_items_in_content_list() -> None:
+    """Streamed thinking-by-default turns can accumulate a leading ``''`` item.
+
+    Regression test for #39687: an empty or whitespace-only str item in a
+    content list must not become an empty text block (the API rejects those),
+    matching the existing guard on dict text blocks.
+    """
+    human = HumanMessage("hi")
+    ai = AIMessage(
+        [
+            "",
+            {"type": "thinking", "thinking": "Reasoning...", "signature": "abc"},
+            "Paris",
+        ]
+    )
+    _, anthropic_messages = _format_messages([human, ai])
+    assistant_content = anthropic_messages[1]["content"]
+    assert {"type": "text", "text": "Paris"} in assistant_content
+    assert not any(
+        block.get("type") == "text" and not block["text"].strip()
+        for block in assistant_content
+    )
+
+    # Whitespace-only items are dropped too; non-empty ones survive.
+    _, anthropic_messages = _format_messages([human, AIMessage(["  \n", "ok"])])
+    texts = [
+        block
+        for block in anthropic_messages[1]["content"]
+        if block.get("type") == "text"
+    ]
+    assert texts == [{"type": "text", "text": "ok"}]


### PR DESCRIPTION
Fixes #39687

When streaming from models that think by default (`claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`), the accumulated `AIMessage.content` list can start with an empty `""` item. On the next turn `_format_messages` turned that into `{"type": "text", "text": ""}`, which the API rejects with a 400, so every second turn of a streamed conversation failed. This skips empty and whitespace-only str items, mirroring the guard that already exists for dict text blocks (same rationale as anthropics/anthropic-sdk-python#461).

This is part 1 of the split discussed on the issue: the guard stops the failure now, and the follow-up (a `thinking_default` profile field so the payload builder picks the right content shape for these models) is pending maintainer input on the field design.

## Release note
`ChatAnthropic` no longer sends empty text blocks when an `AIMessage` content list contains empty or whitespace-only strings, fixing a 400 on the second turn of streamed conversations with thinking-by-default models.

## How verified
- New unit test `test__format_messages_drops_empty_string_items_in_content_list` fails on `master` and passes with this change.
- `make format`, `make lint`, `make test` pass in `libs/partners/anthropic` (320 tests).
- Reproduced the 400 from the issue against the live API with `claude-opus-5` streaming; the second turn succeeds with this patch.

@sap1110 you offered to review this one on the issue, would appreciate your eyes.
