### PR TITLE
fix(core): accept "+" as a Markdown list bullet marker

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -221,7 +221,7 @@ class NumberedListOutputParser(ListOutputParser):
 class MarkdownListOutputParser(ListOutputParser):
     """Parse a Markdown list."""
 
-    pattern: str = r"^\s*[-*]\s([^\n]+)$"
+    pattern: str = r"^\s*[-*+]\s([^\n]+)$"
     """The pattern to match a Markdown list item."""
 
     @override

--- a/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
@@ -136,10 +136,19 @@ def test_markdown_list() -> None:
 
     text3 = "No items in the list."
 
+    text4 = "Items:\n+ apple\n     + banana\n+ cherry"
+
+    text5 = "Mixed markers:\n- apple\n* banana\n+ cherry"
+
+    text6 = "The sum a + b is not a list item."
+
     for text, expected in [
         (text1, ["foo", "bar", "baz"]),
         (text2, ["apple", "banana", "cherry"]),
         (text3, []),
+        (text4, ["apple", "banana", "cherry"]),
+        (text5, ["apple", "banana", "cherry"]),
+        (text6, []),
     ]:
         expectedlist = [[a] for a in expected]
         assert parser.parse(text) == expected
@@ -282,10 +291,16 @@ async def test_markdown_list_async() -> None:
 
     text3 = "No items in the list."
 
+    text4 = "Items:\n+ apple\n+ banana\n+ cherry"
+
+    text5 = "Mixed markers:\n- apple\n* banana\n+ cherry"
+
     for text, expected in [
         (text1, ["foo", "bar", "baz"]),
         (text2, ["apple", "banana", "cherry"]),
         (text3, []),
+        (text4, ["apple", "banana", "cherry"]),
+        (text5, ["apple", "banana", "cherry"]),
     ]:
         expectedlist = [[a] for a in expected]
         assert await parser.aparse(text) == expected


### PR DESCRIPTION
Fixes #39900

---

`MarkdownListOutputParser` matched only `-` and `*`, so a model that emits CommonMark `+` bullets produced an empty list. On a mixed list the parse partially succeeded and dropped the `+` item with no error, so it surfaces downstream as missing state rather than a failure.

`[-*]` at `list.py:224` is the only place involved — `NumberedListOutputParser` uses a separate `\d+\.\s` pattern and is unaffected. `[-*+]` is a strict superset, so existing `-` and `*` input parses identically. One behavior note: a diff-like block that already matched its `- removed` line now also matches `+ added`. That asymmetry predates this change rather than being a new class of match.

## Release note

`MarkdownListOutputParser` now accepts `+` as a bullet marker, alongside `-` and `*`.

How I verified:

- `make format`, `make lint` and `make test` from `libs/core`. Lint is clean (ruff + mypy, 355 files). `make test` reports 3 failures in `tests/unit_tests/test_ssrf_protection.py` that also fail on an unmodified checkout of master, so they are pre-existing.
- `pytest tests/unit_tests/output_parsers/` -> 126 passed.
- Reverting only the one-character pattern change turns `test_markdown_list` and `test_markdown_list_async` red, so the new cases fail for the intended reason.

Contributed on behalf of [Goatshave](https://github.com/Goatshave).
