### PR TITLE
docs(xai): point structured outputs guide link to official xAI docs

### DIFF
--- a/libs/partners/xai/langchain_xai/chat_models.py
+++ b/libs/partners/xai/langchain_xai/chat_models.py
@@ -767,7 +767,7 @@ class ChatXAI(BaseChatOpenAI):  # type: ignore[override]
             strict:
                 - `True`:
                     Model output is guaranteed to exactly match the schema.
-                    The input schema will also be validated according to the [supported schemas](https://platform.openai.com/docs/guides/structured-outputs/supported-schemas?api-mode=responses#supported-schemas).
+                    The input schema will also be validated according to the [supported schemas](https://docs.x.ai/docs/guides/structured-outputs).
                 - `False`:
                     Input schema will not be validated and model output will not be
                     validated.


### PR DESCRIPTION
Fixes #40025

In `ChatXAI.with_structured_output`, the `strict` parameter docstring linked to OpenAI's documentation (`platform.openai.com/docs/guides/structured-outputs/...`) instead of xAI's official documentation.

This updates the reference link to `https://docs.x.ai/docs/guides/structured-outputs`.

Docstring update only, no behavioral changes.