### PR TITLE
fix(mistralai): preserve index zero when merging streamed tool calls

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -385,7 +385,9 @@ def _convert_chunk_to_message_chunk(
             try:
                 tool_call_chunks = []
                 for raw_tool_call in raw_tool_calls:
-                    if not raw_tool_call.get("index") and not raw_tool_call.get("id"):
+                    if raw_tool_call.get("index") is None and not raw_tool_call.get(
+                        "id"
+                    ):
                         tool_call_id = uuid.uuid4().hex[:]
                     else:
                         tool_call_id = raw_tool_call.get("id")

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -707,6 +707,60 @@ def test__convert_chunk_to_message_chunk_with_citations() -> None:
     assert str(full.text) == "The answer is 42"
 
 
+def test__convert_chunk_to_message_chunk_preserves_tool_call_index_zero() -> None:
+    """Streaming tool call chunks with index 0 merge by index, not fresh IDs."""
+    name_chunk = {
+        "choices": [
+            {
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "function": {"name": "search", "arguments": ""},
+                        }
+                    ]
+                },
+                "finish_reason": None,
+            }
+        ],
+    }
+    args_chunk = {
+        "choices": [
+            {
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "function": {"arguments": '{"q": "weather"}'},
+                        }
+                    ]
+                },
+                "finish_reason": None,
+            }
+        ],
+    }
+
+    result_1, index, index_type = _convert_chunk_to_message_chunk(
+        name_chunk, AIMessageChunk, -1, "", None
+    )
+    result_2, _, _ = _convert_chunk_to_message_chunk(
+        args_chunk, AIMessageChunk, index, index_type, None
+    )
+
+    full = result_1 + result_2
+
+    assert isinstance(full, AIMessageChunk)
+    assert full.tool_calls == [
+        {
+            "name": "search",
+            "args": {"q": "weather"},
+            "id": None,
+            "type": "tool_call",
+        }
+    ]
+    assert full.invalid_tool_calls == []
+
+
 def test_citation_round_trip() -> None:
     """Round-trip through v1 preserves text and reference metadata."""
     from langchain_mistralai._compat import (


### PR DESCRIPTION
Closes #38677

---

When Mistral streams a tool call, it emits several chunks for the same call: an early chunk carries the tool name with `index: 0` and no `id`, and later chunks carry the arguments, also with `index: 0` and no `id`. The chunk converter decided whether to generate a fresh ID with `not raw_tool_call.get("index")`. Since `not 0` is `True` in Python, a legitimate `index: 0` was treated as a missing index, so every chunk received its own random ID and the chunks never merged into a single tool call — callers observed inconsistent IDs for the same streamed call.

This change checks `index is None` explicitly, so `index: 0` follows the same path as any other explicit index: chunks keep `id=None` and merge by index.

A regression test in `test_chat_models.py` streams a name chunk and an arguments chunk at index 0 and asserts they merge into one tool call.

## Release note

Fixed Mistral streamed tool calls at index 0 generating inconsistent IDs and failing to merge their chunks.

---

This PR was prepared with assistance from an AI coding agent (DeepSeek Harness). I reviewed the change and ran the unit tests locally (`pytest tests/unit_tests/test_chat_models.py` — 78 passed; `ruff check` and `ruff format` clean).
