### PR TITLE
fix(core): support '+' bullet items in MarkdownListOutputParser

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -221,7 +221,7 @@ class NumberedListOutputParser(ListOutputParser):
 class MarkdownListOutputParser(ListOutputParser):
     """Parse a Markdown list."""
 
-    pattern: str = r"^\s*[-*]\s([^\n]+)$"
+    pattern: str = r"^\s*[-*+]\s([^\n]+)$"
     """The pattern to match a Markdown list item."""
 
     @override

--- a/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
@@ -136,10 +136,16 @@ def test_markdown_list() -> None:
 
     text3 = "No items in the list."
 
+    text4 = "Items with plus bullets:\n+ item1\n    + item2\n+ item3"
+
+    text5 = "Mixed bullets:\n- dash\n* asterisk\n+ plus"
+
     for text, expected in [
         (text1, ["foo", "bar", "baz"]),
         (text2, ["apple", "banana", "cherry"]),
         (text3, []),
+        (text4, ["item1", "item2", "item3"]),
+        (text5, ["dash", "asterisk", "plus"]),
     ]:
         expectedlist = [[a] for a in expected]
         assert parser.parse(text) == expected
@@ -282,10 +288,16 @@ async def test_markdown_list_async() -> None:
 
     text3 = "No items in the list."
 
+    text4 = "Items with plus bullets:\n+ item1\n+ item2\n+ item3"
+
+    text5 = "Mixed bullets:\n- dash\n* asterisk\n+ plus"
+
     for text, expected in [
         (text1, ["foo", "bar", "baz"]),
         (text2, ["apple", "banana", "cherry"]),
         (text3, []),
+        (text4, ["item1", "item2", "item3"]),
+        (text5, ["dash", "asterisk", "plus"]),
     ]:
         expectedlist = [[a] for a in expected]
         assert await parser.aparse(text) == expected


### PR DESCRIPTION
### Summary
Fixes #39900

In CommonMark and standard Markdown specifications, unordered lists can be created with `-`, `*`, or `+` bullets. `MarkdownListOutputParser` previously only matched `-` and `*` items in its regex pattern (`r"^\s*[-*]\s([^\n]+)$"`), causing list items formatted with `+` (or mixed lists containing `+`) to be silently dropped.

### Changes
- Updated `MarkdownListOutputParser.pattern` to `r"^\s*[-*+]\s([^\n]+)$"` so `+` bullet list items are recognized.
- Added synchronous and asynchronous unit tests in `libs/core/tests/unit_tests/output_parsers/test_list_parser.py` covering plus-only lists and mixed-bullet lists.

### Verification
- Ran `python -m pytest libs/core/tests/unit_tests/output_parsers/test_list_parser.py`: All 10 tests passed cleanly.
- Verified zero whitespace errors with `git diff --check`.
