### PR TITLE
fix(deepseek): route strict mode to the beta endpoint

### DIFF
--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -334,6 +334,32 @@ class ChatDeepSeek(BaseChatOpenAI):
     def _resolve_model_profile(self) -> ModelProfile | None:
         return _get_default_model_profile(self.model_name) or None
 
+    def _with_beta_api_base(self) -> Self:
+        """Return a copy of this model that targets DeepSeek's beta endpoint.
+
+        DeepSeek only honors `strict` tool schemas on its beta endpoint, so
+        `bind_tools()` and `with_structured_output()` retarget the model when
+        `strict=True`.
+
+        `model_copy()` does not re-run validators and carries the `openai`
+        clients over by reference, so updating `api_base` alone would leave the
+        copy issuing requests against the original base URL. The clients are
+        cleared so `validate_environment()` rebuilds them against the beta
+        endpoint.
+        """
+        beta_model = self.model_copy(
+            update={
+                "api_base": DEFAULT_BETA_API_BASE,
+                "client": None,
+                "async_client": None,
+                "root_client": None,
+                "root_async_client": None,
+            }
+        )
+        # Pydantic exposes the decorated validator as a descriptor proxy, which
+        # mypy does not consider callable; invoking it directly is intentional.
+        return beta_model.validate_environment()  # type: ignore[operator]
+
     def _get_request_payload(
         self,
         input_: LanguageModelInput,
@@ -521,7 +547,7 @@ class ChatDeepSeek(BaseChatOpenAI):
         # If strict mode is enabled and using default API base, switch to beta endpoint
         if strict is True and self.api_base == DEFAULT_API_BASE:
             # Create a new instance with beta endpoint
-            beta_model = self.model_copy(update={"api_base": DEFAULT_BETA_API_BASE})
+            beta_model = self._with_beta_api_base()
             return beta_model.bind_tools(
                 tools,
                 tool_choice=tool_choice,
@@ -627,7 +653,7 @@ class ChatDeepSeek(BaseChatOpenAI):
         # If strict mode is enabled and using default API base, switch to beta endpoint
         if strict is True and self.api_base == DEFAULT_API_BASE:
             # Create a new instance with beta endpoint
-            beta_model = self.model_copy(update={"api_base": DEFAULT_BETA_API_BASE})
+            beta_model = self._with_beta_api_base()
             return beta_model.with_structured_output(
                 schema,
                 method=method,

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -14,7 +14,11 @@ from openai.types.chat.chat_completion import Choice
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import Field, SecretStr
 
-from langchain_deepseek.chat_models import DEFAULT_API_BASE, ChatDeepSeek
+from langchain_deepseek.chat_models import (
+    DEFAULT_API_BASE,
+    DEFAULT_BETA_API_BASE,
+    ChatDeepSeek,
+)
 
 MODEL_NAME = "deepseek-chat"
 
@@ -262,6 +266,29 @@ class SampleTool(PydanticBaseModel):
     value: str = Field(description="A test value")
 
 
+_MAX_RUNNABLE_DEPTH = 6
+
+
+def _find_chat_model(runnable: Any, depth: int = 0) -> ChatDeepSeek | None:
+    """Walk a composed runnable and return the first `ChatDeepSeek` found."""
+    if isinstance(runnable, ChatDeepSeek):
+        return runnable
+    if depth > _MAX_RUNNABLE_DEPTH:
+        return None
+    for attr in ("bound", "first", "last", "runnable", "steps", "steps__"):
+        value = getattr(runnable, attr, None)
+        if value is None:
+            continue
+        candidates = value if isinstance(value, (list, tuple)) else [value]
+        if isinstance(value, dict):
+            candidates = list(value.values())
+        for candidate in candidates:
+            found = _find_chat_model(candidate, depth + 1)
+            if found is not None:
+                return found
+    return None
+
+
 class TestChatDeepSeekStrictMode:
     """Tests for DeepSeek strict mode support.
 
@@ -283,10 +310,41 @@ class TestChatDeepSeekStrictMode:
         # Bind tools with strict=True
         bound_model = llm.bind_tools([SampleTool], strict=True)
 
-        # The bound model should have its internal model using beta endpoint
-        # We can't directly access the internal model, but we can verify the behavior
-        # by checking that the binding operation succeeds
-        assert bound_model is not None
+        # The bound model must target the beta endpoint, and so must the client
+        # that actually issues the request — updating `api_base` alone leaves
+        # the inherited `openai` clients pointing at the default base URL.
+        beta_model = _find_chat_model(bound_model)
+        assert beta_model is not None
+        assert beta_model.api_base == DEFAULT_BETA_API_BASE
+        assert str(beta_model.root_client.base_url).startswith(DEFAULT_BETA_API_BASE)
+        assert str(beta_model.root_async_client.base_url).startswith(
+            DEFAULT_BETA_API_BASE
+        )
+
+        # The original model is left untouched
+        assert llm.api_base == DEFAULT_API_BASE
+        assert str(llm.root_client.base_url).startswith(DEFAULT_API_BASE)
+
+    def test_beta_copy_rebuilds_clients(self) -> None:
+        """The beta copy must not share the default-endpoint clients.
+
+        `model_copy()` does not re-run validators, so a copy that only updates
+        `api_base` keeps the parent's `openai` clients and still calls the
+        default endpoint.
+        """
+        llm = ChatDeepSeek(
+            model="deepseek-chat",
+            api_key=SecretStr("test_key"),
+        )
+
+        beta_model = llm._with_beta_api_base()
+
+        assert beta_model.root_client is not llm.root_client
+        assert beta_model.root_async_client is not llm.root_async_client
+        assert str(beta_model.root_client.base_url).startswith(DEFAULT_BETA_API_BASE)
+        assert str(beta_model.root_async_client.base_url).startswith(
+            DEFAULT_BETA_API_BASE
+        )
 
     def test_bind_tools_without_strict_mode_uses_default_endpoint(self) -> None:
         """Test bind_tools without strict or with strict=False uses default endpoint."""
@@ -316,8 +374,16 @@ class TestChatDeepSeekStrictMode:
         # Create structured output with strict=True
         structured_model = llm.with_structured_output(SampleTool, strict=True)
 
-        # The structured model should work with beta endpoint
-        assert structured_model is not None
+        # Walk the resulting runnable to the underlying model and assert that
+        # the client it would call is pointed at the beta endpoint.
+        beta_model = _find_chat_model(structured_model)
+        assert beta_model is not None
+        assert beta_model.api_base == DEFAULT_BETA_API_BASE
+        assert str(beta_model.root_client.base_url).startswith(DEFAULT_BETA_API_BASE)
+
+        # The original model is left untouched
+        assert llm.api_base == DEFAULT_API_BASE
+        assert str(llm.root_client.base_url).startswith(DEFAULT_API_BASE)
 
 
 class TestChatDeepSeekAzureToolChoice:


### PR DESCRIPTION
Fixes #40031

---

Anyone calling `ChatDeepSeek.with_structured_output(schema, strict=True)` or `bind_tools(tools, strict=True)` believes DeepSeek is validating the model output against their schema. It is not. The request goes to the default endpoint, which does not honor strict tool schemas, so the flag has silently been doing nothing.

Both methods retargeted the model with `model_copy(update={"api_base": ...})`. `model_copy()` does not re-run validators, and the inherited `openai` clients are carried over by reference, so the copy kept the client that was built against the default base URL — only the field changed, not the object issuing the request. Clearing the four client fields on the copy lets `validate_environment()` rebuild them against the beta endpoint.

This implements option 1 from the issue. If you would rather drop the beta-switching branch altogether (option 2 there), say so and I will rework this.

## Release note

`ChatDeepSeek` now actually reaches DeepSeek's beta endpoint when `strict=True` is passed to `bind_tools()` or `with_structured_output()`, so strict tool schemas are enforced by the provider instead of the flag being silently ignored.

## How did you verify your code works?

The two existing tests named `..._uses_beta_endpoint` asserted only that the returned object was not `None`, so they passed against the broken behavior. They now assert the resolved `base_url` on both the sync and async clients, and a new test pins that the beta copy does not share the parent's clients. All three fail on `master`.

From `libs/partners/deepseek`: `make format`, `make lint`, `make test` (38 passed, 1 skipped) and `make check_imports` are clean. `uv.lock` is untouched.

---

*Disclaimer: an AI agent assisted in preparing this change. Every claim above was verified by running the code.*
