### PR TITLE
fix(deepseek): rebuild clients when switching to the beta endpoint for strict mode

### DIFF
--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -34,6 +34,41 @@ from langchain_deepseek.data._profiles import _PROFILES
 DEFAULT_API_BASE = "https://api.deepseek.com/v1"
 DEFAULT_BETA_API_BASE = "https://api.deepseek.com/beta"
 
+
+def _rebuild_clients(model: ChatDeepSeek) -> None:
+    """Build the OpenAI clients of *model* against its current `api_base`.
+
+    Existing clients are preserved; only missing ones are created. Shared by
+    `validate_environment` and the strict-mode beta switch, whose `model_copy`
+    does not re-run validators — without an explicit rebuild the copied
+    model's clients would keep issuing requests to the old base URL.
+    """
+    client_params: dict = {
+        k: v
+        for k, v in {
+            "api_key": model.api_key.get_secret_value() if model.api_key else None,
+            "base_url": model.api_base,
+            "timeout": model.request_timeout,
+            "max_retries": model.max_retries,
+            "default_headers": model.default_headers,
+            "default_query": model.default_query,
+        }.items()
+        if v is not None
+    }
+
+    if not (model.client or None):
+        sync_specific: dict = {"http_client": model.http_client}
+        model.root_client = openai.OpenAI(**client_params, **sync_specific)
+        model.client = model.root_client.chat.completions
+    if not (model.async_client or None):
+        async_specific: dict = {"http_client": model.http_async_client}
+        model.root_async_client = openai.AsyncOpenAI(
+            **client_params,
+            **async_specific,
+        )
+        model.async_client = model.root_async_client.chat.completions
+
+
 _DictOrPydanticClass: TypeAlias = dict[str, Any] | type[BaseModel]
 _DictOrPydantic: TypeAlias = dict[str, Any] | BaseModel
 
@@ -305,34 +340,28 @@ class ChatDeepSeek(BaseChatOpenAI):
         ):
             msg = "If using default api base, DEEPSEEK_API_KEY must be set."
             raise ValueError(msg)
-        client_params: dict = {
-            k: v
-            for k, v in {
-                "api_key": self.api_key.get_secret_value() if self.api_key else None,
-                "base_url": self.api_base,
-                "timeout": self.request_timeout,
-                "max_retries": self.max_retries,
-                "default_headers": self.default_headers,
-                "default_query": self.default_query,
-            }.items()
-            if v is not None
-        }
-
-        if not (self.client or None):
-            sync_specific: dict = {"http_client": self.http_client}
-            self.root_client = openai.OpenAI(**client_params, **sync_specific)
-            self.client = self.root_client.chat.completions
-        if not (self.async_client or None):
-            async_specific: dict = {"http_client": self.http_async_client}
-            self.root_async_client = openai.AsyncOpenAI(
-                **client_params,
-                **async_specific,
-            )
-            self.async_client = self.root_async_client.chat.completions
+        _rebuild_clients(self)
         return self
 
     def _resolve_model_profile(self) -> ModelProfile | None:
         return _get_default_model_profile(self.model_name) or None
+
+    def _with_beta_api_base(self) -> Self:
+        """Copy this model pointed at the beta API base with rebuilt clients.
+
+        Pydantic v2's `model_copy` does not re-run validators, so the OpenAI
+        clients are carried over by reference still bound to the default API
+        base — the switch would change only the `api_base` field while the
+        request kept going to the default endpoint. Clearing the clients and
+        rebuilding pins the copy to the beta base URL.
+        """
+        beta_model = self.model_copy(update={"api_base": DEFAULT_BETA_API_BASE})
+        beta_model.client = None
+        beta_model.async_client = None
+        beta_model.root_client = None
+        beta_model.root_async_client = None
+        _rebuild_clients(beta_model)
+        return beta_model
 
     def _get_request_payload(
         self,
@@ -521,7 +550,7 @@ class ChatDeepSeek(BaseChatOpenAI):
         # If strict mode is enabled and using default API base, switch to beta endpoint
         if strict is True and self.api_base == DEFAULT_API_BASE:
             # Create a new instance with beta endpoint
-            beta_model = self.model_copy(update={"api_base": DEFAULT_BETA_API_BASE})
+            beta_model = self._with_beta_api_base()
             return beta_model.bind_tools(
                 tools,
                 tool_choice=tool_choice,
@@ -627,7 +656,7 @@ class ChatDeepSeek(BaseChatOpenAI):
         # If strict mode is enabled and using default API base, switch to beta endpoint
         if strict is True and self.api_base == DEFAULT_API_BASE:
             # Create a new instance with beta endpoint
-            beta_model = self.model_copy(update={"api_base": DEFAULT_BETA_API_BASE})
+            beta_model = self._with_beta_api_base()
             return beta_model.with_structured_output(
                 schema,
                 method=method,

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -14,7 +14,11 @@ from openai.types.chat.chat_completion import Choice
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import Field, SecretStr
 
-from langchain_deepseek.chat_models import DEFAULT_API_BASE, ChatDeepSeek
+from langchain_deepseek.chat_models import (
+    DEFAULT_API_BASE,
+    DEFAULT_BETA_API_BASE,
+    ChatDeepSeek,
+)
 
 MODEL_NAME = "deepseek-chat"
 
@@ -271,7 +275,7 @@ class TestChatDeepSeekStrictMode:
     """
 
     def test_bind_tools_with_strict_mode_uses_beta_endpoint(self) -> None:
-        """Test that bind_tools with strict=True uses the beta endpoint."""
+        """Test that bind_tools with strict=True routes to the beta endpoint."""
         llm = ChatDeepSeek(
             model="deepseek-chat",
             api_key=SecretStr("test_key"),
@@ -283,10 +287,20 @@ class TestChatDeepSeekStrictMode:
         # Bind tools with strict=True
         bound_model = llm.bind_tools([SampleTool], strict=True)
 
-        # The bound model should have its internal model using beta endpoint
-        # We can't directly access the internal model, but we can verify the behavior
-        # by checking that the binding operation succeeds
-        assert bound_model is not None
+        # The strict path copies the model and must rebuild its OpenAI clients
+        # against the beta base URL: model_copy does not re-run validators, so
+        # without the rebuild the carried-over clients would keep issuing
+        # requests to the default endpoint, where strict mode is unavailable.
+        beta_model = bound_model.bound
+        assert isinstance(beta_model, ChatDeepSeek)
+        assert beta_model.api_base == DEFAULT_BETA_API_BASE
+        assert str(beta_model.root_client.base_url).rstrip("/") == DEFAULT_BETA_API_BASE
+        assert (
+            str(beta_model.root_async_client.base_url).rstrip("/")
+            == DEFAULT_BETA_API_BASE
+        )
+        # The original model is untouched.
+        assert str(llm.root_client.base_url).rstrip("/") == DEFAULT_API_BASE
 
     def test_bind_tools_without_strict_mode_uses_default_endpoint(self) -> None:
         """Test bind_tools without strict or with strict=False uses default endpoint."""
@@ -297,11 +311,14 @@ class TestChatDeepSeekStrictMode:
 
         # Test with strict=False
         bound_model_false = llm.bind_tools([SampleTool], strict=False)
-        assert bound_model_false is not None
+        assert bound_model_false.bound is llm
 
         # Test with strict=None (default)
         bound_model_none = llm.bind_tools([SampleTool])
-        assert bound_model_none is not None
+        assert bound_model_none.bound is llm
+
+        # No client rebuild happened: still the default endpoint.
+        assert str(llm.root_client.base_url).rstrip("/") == DEFAULT_API_BASE
 
     def test_with_structured_output_strict_mode_uses_beta_endpoint(self) -> None:
         """Test that with_structured_output with strict=True uses beta endpoint."""
@@ -316,8 +333,32 @@ class TestChatDeepSeekStrictMode:
         # Create structured output with strict=True
         structured_model = llm.with_structured_output(SampleTool, strict=True)
 
-        # The structured model should work with beta endpoint
-        assert structured_model is not None
+        # The structured-output chain is `bound_llm | parser`; its first step
+        # wraps the beta model, whose OpenAI clients must target the beta
+        # base URL.
+        inner = structured_model.first.bound
+        assert isinstance(inner, ChatDeepSeek)
+        assert inner.api_base == DEFAULT_BETA_API_BASE
+        assert str(inner.root_client.base_url).rstrip("/") == DEFAULT_BETA_API_BASE
+        assert (
+            str(inner.root_async_client.base_url).rstrip("/") == DEFAULT_BETA_API_BASE
+        )
+
+    def test_strict_mode_with_custom_api_base_keeps_custom_endpoint(self) -> None:
+        """A custom (non-default) api_base is never overridden by the switch."""
+        custom_base = "https://deepseek.example.com/v1"
+        llm = ChatDeepSeek(
+            model="deepseek-chat",
+            api_key=SecretStr("test_key"),
+            base_url=custom_base,
+        )
+
+        bound_model = llm.bind_tools([SampleTool], strict=True)
+
+        beta_model = bound_model.bound
+        assert isinstance(beta_model, ChatDeepSeek)
+        assert beta_model.api_base == custom_base
+        assert str(beta_model.root_client.base_url).rstrip("/") == custom_base
 
 
 class TestChatDeepSeekAzureToolChoice:


### PR DESCRIPTION
Fixes #40031

## Problem

`ChatDeepSeek.bind_tools(strict=True)` and `ChatDeepSeek.with_structured_output(strict=True)` document that they switch to DeepSeek's beta endpoint (`https://api.deepseek.com/beta`) so the server enforces the schema. The switch never took effect: both branches built the beta instance with

```python
beta_model = self.model_copy(update={"api_base": DEFAULT_BETA_API_BASE})
```

Pydantic v2's `model_copy` does not re-run validators, so the OpenAI clients (`client`, `async_client`, `root_client`, `root_async_client`) were carried over **by reference**, still bound to the default `/v1` base URL. The copy's `api_base` field changed, but the object that actually issues the request did not — `strict=True` silently kept hitting `https://api.deepseek.com/v1`, where strict mode is unavailable. The payload did carry `"strict": true`, confirming only the routing half was broken.

The existing `TestChatDeepSeekStrictMode` tests were named `..._uses_beta_endpoint` but asserted only `bound is not None`, so they passed on a build where the switch did nothing.

## Fix

- Extract the OpenAI client construction into a `_rebuild_clients` helper (same body `validate_environment` already ran) and call it from `validate_environment`.
- In the strict-mode beta switch (`_with_beta_api_base`), clear the copied model's clients and rebuild them against the beta base URL. A custom (non-default) `api_base` never enters the switch, so third-party DeepSeek-compatible endpoints are unaffected.
- Original model instances are untouched: only the copy gets rebuilt clients.

## Tests

- Tightened `test_bind_tools_with_strict_mode_uses_beta_endpoint` and `test_with_structured_output_strict_mode_uses_beta_endpoint` to pin the resolved `base_url` of both the sync and async clients of the beta model (and that the original model still points at the default endpoint).
- `test_bind_tools_without_strict_mode_uses_default_endpoint` now asserts no copy/rebuild happens without strict mode.
- New `test_strict_mode_with_custom_api_base_keeps_custom_endpoint` pins that a custom `api_base` is never overridden.

Verified end-to-end with the issue's local-HTTP-server repro (module constants re-pointed at `127.0.0.1`): the request now reaches `/beta/chat/completions` (it reached `/v1/chat/completions` before the fix).

`uv run --group test pytest tests/unit_tests/` — 38 passed, 1 skipped. `ruff check` / `ruff format` and `mypy` clean.
