### PR TITLE
fix(core): parse '+' bullets in MarkdownListOutputParser

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -221,8 +221,11 @@ class NumberedListOutputParser(ListOutputParser):
 class MarkdownListOutputParser(ListOutputParser):
     """Parse a Markdown list."""
 
-    pattern: str = r"^\s*[-*]\s([^\n]+)$"
-    """The pattern to match a Markdown list item."""
+    pattern: str = r"^\s*[-*+]\s([^\n]+)$"
+    """The pattern to match a Markdown list item.
+
+    Matches the three CommonMark bullet list markers (``-``, ``*``, ``+``).
+    """
 
     @override
     def get_format_instructions(self) -> str:

--- a/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
@@ -160,6 +160,15 @@ def test_markdown_list() -> None:
         assert list(parser.transform(iter([text]))) == expectedlist
 
 
+def test_markdown_list_bullet_markers() -> None:
+    """All three CommonMark bullet markers (``-``, ``*``, ``+``) are parsed."""
+    parser = MarkdownListOutputParser()
+
+    for marker in ("-", "*", "+"):
+        text = f"{marker} a\n{marker} b"
+        assert parser.parse(text) == ["a", "b"]
+
+
 T = TypeVar("T")
 
 


### PR DESCRIPTION
**Description:** `MarkdownListOutputParser` only matched `-` and `*` bullet markers, so a valid Markdown list that uses `+` markers parsed to an empty list. Nothing was raised, so the caller silently received `[]`.

CommonMark defines all three characters (`-`, `+`, `*`) as bullet list markers ([spec section 5.2, "List items"](https://spec.commonmark.org/0.31.2/#bullet-list-marker)), so `+ item` is valid Markdown that a model can legitimately produce. Since `*` was already accepted, supporting only `-` and `*` while dropping `+` looks unintentional rather than by design.

Before:

```python
from langchain_core.output_parsers import MarkdownListOutputParser

parser = MarkdownListOutputParser()
parser.parse("- a\n- b")  # ['a', 'b']
parser.parse("* a\n* b")  # ['a', 'b']
parser.parse("+ a\n+ b")  # []   <- expected ['a', 'b']
```

After, all three markers return `['a', 'b']`.

The fix adds `+` to the marker character class in the parser pattern. Both `parse` and the streaming `parse_iter` path use this same pattern, so streaming is covered as well.

**Issue:** Fixes #39900

**Dependencies:** None

**Changes:**

- `libs/core/langchain_core/output_parsers/list.py`: pattern `r"^\s*[-*]\s([^\n]+)$"` becomes `r"^\s*[-*+]\s([^\n]+)$"`, with an expanded docstring noting the three CommonMark markers.
- `libs/core/tests/unit_tests/output_parsers/test_list_parser.py`: added `test_markdown_list_bullet_markers`, a regression test asserting all three markers (`-`, `*`, `+`) parse to `['a', 'b']`.

All unit tests in `tests/unit_tests/output_parsers/test_list_parser.py` pass.
