### PR TITLE
fix(core): register ImagePromptValue in load mapping

### DIFF
--- a/libs/core/langchain_core/load/mapping.py
+++ b/libs/core/langchain_core/load/mapping.py
@@ -209,6 +209,11 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "prompt_values",
         "PromptValue",
     ),
+    ("langchain", "schema", "prompt", "ImagePromptValue"): (
+        "langchain_core",
+        "prompt_values",
+        "ImagePromptValue",
+    ),
     ("langchain", "schema", "runnable", "RunnableBinding"): (
         "langchain_core",
         "runnables",
@@ -903,6 +908,11 @@ OLD_CORE_NAMESPACES_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "langchain_core",
         "prompt_values",
         "ChatPromptValueConcrete",
+    ),
+    ("langchain_core", "prompt_values", "ImagePromptValue"): (
+        "langchain_core",
+        "prompt_values",
+        "ImagePromptValue",
     ),
     ("langchain_core", "runnables", "base", "RunnableBindingBase"): (
         "langchain_core",

--- a/libs/core/tests/unit_tests/load/test_serializable.py
+++ b/libs/core/tests/unit_tests/load/test_serializable.py
@@ -18,6 +18,7 @@ from langchain_core.load.load import (
 from langchain_core.load.serializable import _is_field_useful, _try_neq_default
 from langchain_core.messages import AIMessage
 from langchain_core.outputs import ChatGeneration, Generation
+from langchain_core.prompt_values import ImagePromptValue, ImageURL
 from langchain_core.prompts import (
     ChatPromptTemplate,
     HumanMessagePromptTemplate,
@@ -1258,3 +1259,18 @@ def test_chain_using_pick_roundtrips() -> None:
     revived = load(dumpd(chain))
 
     assert revived.invoke({"a": 1, "b": 2}) == {"a": 1}
+
+
+def test_image_prompt_value_roundtrips() -> None:
+    """Test `ImagePromptValue` can be loaded back after being dumped.
+
+    Regression test: `ImagePromptValue` reports `is_lc_serializable()` and dumps
+    fine, but was missing from the deserialization mapping, so `load` rejected it
+    while its three `PromptValue` siblings in the same module round-tripped.
+    """
+    original = ImagePromptValue(image_url=ImageURL(url="https://example.com/cat.png"))
+
+    revived = load(dumpd(original))
+
+    assert isinstance(revived, ImagePromptValue)
+    assert revived == original


### PR DESCRIPTION
**Description:** `ImagePromptValue` declares itself serializable (`is_lc_serializable()` returns `True`) and `dumps()` produces valid output, but the class was missing from the deserialization mapping in `langchain_core/load/mapping.py`. As a result `loads()` rejected the very id that `dumps()` wrote.

Its three `PromptValue` siblings in the same module all round-trip:

| class | round-trip |
| --- | --- |
| `StringPromptValue` | works |
| `ChatPromptValue` | works |
| `ChatPromptValueConcrete` | works |
| `ImagePromptValue` | `ValueError` (before this PR) |

Three of four being mapped indicates the omission was an oversight rather than a deliberate exclusion. `ImagePromptValue` is what the public `ImagePromptTemplate.format_prompt()` returns, so it is reachable without touching private API.

Before:

```python
from langchain_core.prompts.image import ImagePromptTemplate
from langchain_core.load import dumps, loads

template = ImagePromptTemplate(
    template={"url": "https://example.com/{name}.png"},
    input_variables=["name"],
)
prompt_value = template.format_prompt(name="cat")  # ImagePromptValue
serialized = dumps(prompt_value)                   # succeeds
loads(serialized)                                  # ValueError before this PR
```

After, `loads(dumps(prompt_value))` returns an equal `ImagePromptValue`.

Unlike its siblings, `ImagePromptValue` does not override `get_lc_namespace`, so it inherits the base `PromptValue` namespace and its serialized id is `("langchain", "schema", "prompt", "ImagePromptValue")`. The mapping entry is added under that id in `SERIALIZABLE_MAPPING`, next to the existing `PromptValue` entry, and a matching entry is added to `OLD_CORE_NAMESPACES_MAPPING` for parity with the siblings.

**Issue:** Fixes #39783

**Dependencies:** None

**Changes:**

- `libs/core/langchain_core/load/mapping.py`: register `ImagePromptValue` in `SERIALIZABLE_MAPPING` and `OLD_CORE_NAMESPACES_MAPPING`.
- `libs/core/tests/unit_tests/load/test_serializable.py`: added `test_image_prompt_value_roundtrips`, a regression test mirroring the existing `test_runnable_pick_roundtrips`.

All 63 tests in `tests/unit_tests/load/test_serializable.py` pass.
