### PR TITLE
fix(core): recognize + as a valid Markdown list bullet in MarkdownListOutputParser

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -221,7 +221,7 @@ class NumberedListOutputParser(ListOutputParser):
 class MarkdownListOutputParser(ListOutputParser):
     """Parse a Markdown list."""
 
-    pattern: str = r"^\s*[-*]\s([^\n]+)$"
+    pattern: str = r"^\s*[-*+]\s([^\n]+)$"
     """The pattern to match a Markdown list item."""
 
     @override

--- a/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
@@ -160,6 +160,13 @@ def test_markdown_list() -> None:
         assert list(parser.transform(iter([text]))) == expectedlist
 
 
+def test_markdown_list_plus_bullet() -> None:
+    parser = MarkdownListOutputParser()
+    assert parser.parse("+ a\n+ b") == ["a", "b"]
+    assert parser.parse("+ a\n- b\n* c") == ["a", "b", "c"]
+    assert parser.parse("  + indented") == ["indented"]
+
+
 T = TypeVar("T")
 
 


### PR DESCRIPTION
## Summary

Fixes #39900 — `MarkdownListOutputParser` silently drops items that use `+` as the bullet marker, returning an empty list instead of the expected parsed items.

**Root cause:** The regex `pattern` uses `[-*]` in the character class, which matches `-` and `*` bullets but not `+`. Per the CommonMark specification, `+` is a valid unordered list marker alongside `-` and `*`.

**Fix:** Add `+` to the character class: `[-*+]`.

## Changed files

- `libs/core/langchain_core/output_parsers/list.py` — add `+` to the bullet character class in `pattern` (1 character)
- `libs/core/tests/unit_tests/output_parsers/test_list_parser.py` — add regression test `test_markdown_list_plus_bullet` covering `+`-only, mixed bullets, and indented `+` items

## Test plan

- [x] `pytest tests/unit_tests/output_parsers/test_list_parser.py` — 11 passed
- [x] Manual verification: `parser.parse("+ a\n+ b")` returns `['a', 'b']`