### PR TITLE
fix(core): preserve explicit recursion_limit equal to the default in merge_configs

### DIFF
--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -438,9 +438,17 @@ def merge_configs(*configs: RunnableConfig | None) -> RunnableConfig:
         The merged config.
     """
     base: RunnableConfig = {}
+    # Record which raw configs explicitly supply recursion_limit before
+    # ensure_config fills in the default, so an explicit value equal to
+    # DEFAULT_RECURSION_LIMIT is not silently discarded.
+    non_none = [c for c in configs if c is not None]
+    has_explicit_limit = [
+        "recursion_limit" in c and c["recursion_limit"] is not None
+        for c in non_none
+    ]
     # Even though the keys aren't literals, this is correct
     # because both dicts are the same type
-    for config in (ensure_config(c) for c in configs if c is not None):
+    for idx, config in enumerate(ensure_config(c) for c in non_none):
         for key in config:
             if key == "metadata":
                 base["metadata"] = _merge_metadata_dicts(
@@ -485,7 +493,10 @@ def merge_configs(*configs: RunnableConfig | None) -> RunnableConfig:
                         # base_callbacks is also a manager
                         base["callbacks"] = base_callbacks.merge(these_callbacks)
             elif key == "recursion_limit":
-                if config["recursion_limit"] != DEFAULT_RECURSION_LIMIT:
+                if (
+                    has_explicit_limit[idx]
+                    or config["recursion_limit"] != DEFAULT_RECURSION_LIMIT
+                ):
                     base["recursion_limit"] = config["recursion_limit"]
             elif key in COPIABLE_KEYS and config[key] is not None:  # type: ignore[literal-required]
                 base[key] = config[key].copy()  # type: ignore[literal-required]

--- a/libs/core/tests/unit_tests/runnables/test_config.py
+++ b/libs/core/tests/unit_tests/runnables/test_config.py
@@ -406,6 +406,31 @@ class TestMergeMetadataDicts:
         )
         assert merged["metadata"] == {"lc_versions": {"a": "1"}}
 
+    def test_merge_configs_explicit_default_recursion_limit(self) -> None:
+        from langchain_core.runnables.config import DEFAULT_RECURSION_LIMIT
+
+        merged = merge_configs(
+            {"configurable": {"thread_id": "test"}},
+            RunnableConfig(recursion_limit=DEFAULT_RECURSION_LIMIT),
+        )
+        assert merged.get("recursion_limit") == DEFAULT_RECURSION_LIMIT
+
+    def test_merge_configs_omitted_limit_does_not_overwrite_custom(self) -> None:
+        merged = merge_configs(
+            RunnableConfig(recursion_limit=50),
+            {"configurable": {"thread_id": "test"}},
+        )
+        assert merged.get("recursion_limit") == 50
+
+    def test_merge_configs_explicit_default_overwrites_custom(self) -> None:
+        from langchain_core.runnables.config import DEFAULT_RECURSION_LIMIT
+
+        merged = merge_configs(
+            RunnableConfig(recursion_limit=50),
+            RunnableConfig(recursion_limit=DEFAULT_RECURSION_LIMIT),
+        )
+        assert merged.get("recursion_limit") == DEFAULT_RECURSION_LIMIT
+
     def test_three_config_merge_accumulates_lc_versions(self) -> None:
         c1: RunnableConfig = {"metadata": {"lc_versions": {"a": "1"}}}
         c2: RunnableConfig = {"metadata": {"lc_versions": {"b": "2"}}}


### PR DESCRIPTION
## Summary

Fixes #39994 — `merge_configs` silently drops an explicit `recursion_limit=25` because it is indistinguishable from the default injected by `ensure_config`.

**Root cause:** `merge_configs` calls `ensure_config` on every input, which fills in `DEFAULT_RECURSION_LIMIT` (25) when the field is absent. The merge loop then skips any `recursion_limit` equal to that default to prevent an omitted field from overwriting an earlier custom value. This makes an explicitly supplied value of 25 look identical to the injected default, so it is silently discarded.

**Fix:** Before calling `ensure_config`, record which raw inputs explicitly carry a non-`None` `recursion_limit`. The merge loop now preserves the value when the caller explicitly set it, regardless of whether it equals the default. An omitted field still does not overwrite an earlier custom value.

## Changed files

- `libs/core/langchain_core/runnables/config.py` — track explicit `recursion_limit` presence before `ensure_config`; use it in the merge condition
- `libs/core/tests/unit_tests/runnables/test_config.py` — three regression tests: explicit default is preserved, omitted does not overwrite custom, explicit default overwrites custom

## Test plan

- [x] `pytest tests/unit_tests/runnables/test_config.py` — 24 passed
- [x] Manual verification of all five edge cases (explicit 25, explicit 26, omitted, omitted after custom, explicit 25 after custom)