### PR TITLE
fix(core): forward `feedback_config` in `EvaluatorCallbackHandler`

### DIFF
--- a/libs/core/langchain_core/tracers/evaluation.py
+++ b/libs/core/langchain_core/tracers/evaluation.py
@@ -199,6 +199,9 @@ class EvaluatorCallbackHandler(BaseTracer):
                 source_info=source_info_,
                 source_run_id=res.source_run_id or source_run_id,
                 feedback_source_type=langsmith.schemas.FeedbackSourceType.MODEL,
+                feedback_config=cast(
+                    "langsmith.schemas.FeedbackConfig | None", res.feedback_config
+                ),
             )
         return results
 

--- a/libs/core/tests/unit_tests/tracers/test_evaluation.py
+++ b/libs/core/tests/unit_tests/tracers/test_evaluation.py
@@ -1,0 +1,58 @@
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import langsmith.schemas
+from langsmith.evaluation.evaluator import EvaluationResult
+
+from langchain_core.tracers.evaluation import EvaluatorCallbackHandler
+
+
+def _mock_handler() -> tuple[EvaluatorCallbackHandler, MagicMock]:
+    client = MagicMock()
+    handler = EvaluatorCallbackHandler(
+        evaluators=(),
+        client=client,
+        max_concurrency=0,
+    )
+    return handler, client
+
+
+def test_feedback_config_forwarded_to_create_feedback() -> None:
+    handler, client = _mock_handler()
+    run_id = UUID(int=1)
+    evaluation_result = EvaluationResult(
+        key="sentiment",
+        score=0.8,
+        value="positive",
+        comment="Great",
+        correction={"name": "happy"},
+        source_run_id=UUID(int=2),
+        feedback_config={"type": "continuous", "min": 0, "max": 1},
+    )
+    run = MagicMock()
+    run.id = run_id
+
+    handler._log_evaluation_feedback(evaluation_result, run, source_run_id=run_id)
+
+    client.create_feedback.assert_called_once_with(
+        run_id,
+        "sentiment",
+        score=0.8,
+        value="positive",
+        comment="Great",
+        correction={"name": "happy"},
+        source_info={},
+        source_run_id=UUID(int=2),
+        feedback_source_type=langsmith.schemas.FeedbackSourceType.MODEL,
+        feedback_config={"type": "continuous", "min": 0, "max": 1},
+    )
+
+
+def test_feedback_config_none_when_unset() -> None:
+    handler, client = _mock_handler()
+    evaluation_result = EvaluationResult(key="sentiment", score=0.8)
+    run = MagicMock()
+
+    handler._log_evaluation_feedback(evaluation_result, run)
+
+    assert client.create_feedback.call_args.kwargs["feedback_config"] is None


### PR DESCRIPTION
Fixes #31802

---

### Why

Users who set a `feedback_config` on an `EvaluationResult` (for example, defining threshold ranges for a scoring evaluator) get that configuration silently dropped. `EvaluatorCallbackHandler._log_evaluation_feedback` forwards `score`, `value`, `comment`, and `correction` to `Client.create_feedback`, but never forwards `feedback_config` — so a valid config is lost before the feedback reaches LangSmith.

### What

- Forward `feedback_config` unchanged in `EvaluatorCallbackHandler._log_evaluation_feedback` when calling `Client.create_feedback`, using the same `cast` to `FeedbackConfig | None` the SDK uses, since LangSmith owns validation/normalization of feedback config values.
- Add regression tests covering the config being forwarded, `None` when unset, and other fields still forwarded alongside it.

### Review notes

The constructor-side drop described in the original report was already fixed upstream in LangSmith. This change targets the remaining LangChain-side loss at the `EvaluatorCallbackHandler` callback boundary. Keeping the change scoped to `langchain-core`; no LangSmith SDK or dependency changes.

## Release note

`EvaluatorCallbackHandler` now forwards `EvaluationResult.feedback_config` to LangSmith when logging evaluation feedback.

---

_This contribution was prepared with AI assistance and reviewed before posting._