### PR TITLE
fix(deepseek): route strict mode to beta endpoint

### DIFF
--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -331,6 +331,29 @@ class ChatDeepSeek(BaseChatOpenAI):
             self.async_client = self.root_async_client.chat.completions
         return self
 
+    def _with_beta_endpoint(self) -> Self:
+        """Return a copy configured for the beta API endpoint.
+
+        `model_copy` does not re-run Pydantic validators, so the cached OpenAI
+        clients are carried over by reference and would keep pointing at the
+        default `/v1` base. Clear them and re-run `validate_environment` so a
+        fresh client targets the beta base URL used for strict schema validation.
+        """
+        beta_model = self.model_copy(
+            update={
+                "client": None,
+                "async_client": None,
+                "root_client": None,
+                "root_async_client": None,
+                "api_base": DEFAULT_BETA_API_BASE,
+            }
+        )
+        # `validate_environment` is a pydantic `model_validator`, whose decorator
+        # makes the attribute appear non-callable to static analyzers; it is safe
+        # to invoke directly at runtime to rebuild the clients.
+        beta_model.validate_environment()  # type: ignore[operator]
+        return beta_model
+
     def _resolve_model_profile(self) -> ModelProfile | None:
         return _get_default_model_profile(self.model_name) or None
 
@@ -521,7 +544,7 @@ class ChatDeepSeek(BaseChatOpenAI):
         # If strict mode is enabled and using default API base, switch to beta endpoint
         if strict is True and self.api_base == DEFAULT_API_BASE:
             # Create a new instance with beta endpoint
-            beta_model = self.model_copy(update={"api_base": DEFAULT_BETA_API_BASE})
+            beta_model = self._with_beta_endpoint()
             return beta_model.bind_tools(
                 tools,
                 tool_choice=tool_choice,
@@ -627,7 +650,7 @@ class ChatDeepSeek(BaseChatOpenAI):
         # If strict mode is enabled and using default API base, switch to beta endpoint
         if strict is True and self.api_base == DEFAULT_API_BASE:
             # Create a new instance with beta endpoint
-            beta_model = self.model_copy(update={"api_base": DEFAULT_BETA_API_BASE})
+            beta_model = self._with_beta_endpoint()
             return beta_model.with_structured_output(
                 schema,
                 method=method,

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Literal, cast
 from unittest.mock import MagicMock
 
 from langchain_core.messages import AIMessage, AIMessageChunk, ToolMessage
+from langchain_core.runnables import RunnableBinding
+from langchain_core.runnables.base import RunnableSequence
 from langchain_tests.unit_tests import ChatModelUnitTests
 from openai import BaseModel
 from openai.types import CompletionUsage
@@ -14,7 +16,11 @@ from openai.types.chat.chat_completion import Choice
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import Field, SecretStr
 
-from langchain_deepseek.chat_models import DEFAULT_API_BASE, ChatDeepSeek
+from langchain_deepseek.chat_models import (
+    DEFAULT_API_BASE,
+    DEFAULT_BETA_API_BASE,
+    ChatDeepSeek,
+)
 
 MODEL_NAME = "deepseek-chat"
 
@@ -281,12 +287,17 @@ class TestChatDeepSeekStrictMode:
         assert llm.api_base == DEFAULT_API_BASE
 
         # Bind tools with strict=True
-        bound_model = llm.bind_tools([SampleTool], strict=True)
+        bound_model = cast("RunnableBinding", llm.bind_tools([SampleTool], strict=True))
 
-        # The bound model should have its internal model using beta endpoint
-        # We can't directly access the internal model, but we can verify the behavior
-        # by checking that the binding operation succeeds
-        assert bound_model is not None
+        # The bound model should have its internal model using beta endpoint,
+        # rebuilt with a fresh client rather than sharing the parent's `/v1` client.
+        bound_chat_model = bound_model.bound
+        assert isinstance(bound_chat_model, ChatDeepSeek)
+        assert bound_chat_model.api_base == DEFAULT_BETA_API_BASE
+        assert bound_chat_model.root_client is not llm.root_client
+        assert str(bound_chat_model.root_client.base_url).rstrip("/") == (
+            DEFAULT_BETA_API_BASE
+        )
 
     def test_bind_tools_without_strict_mode_uses_default_endpoint(self) -> None:
         """Test bind_tools without strict or with strict=False uses default endpoint."""
@@ -314,10 +325,20 @@ class TestChatDeepSeekStrictMode:
         assert llm.api_base == DEFAULT_API_BASE
 
         # Create structured output with strict=True
-        structured_model = llm.with_structured_output(SampleTool, strict=True)
+        structured_model = cast(
+            "RunnableSequence",
+            llm.with_structured_output(SampleTool, strict=True),
+        )
 
-        # The structured model should work with beta endpoint
-        assert structured_model is not None
+        # The structured model's first step should use a ChatDeepSeek rebuilt
+        # against the beta endpoint with a fresh client.
+        bound_chat_model = cast("RunnableBinding", structured_model.first).bound
+        assert isinstance(bound_chat_model, ChatDeepSeek)
+        assert bound_chat_model.api_base == DEFAULT_BETA_API_BASE
+        assert bound_chat_model.root_client is not llm.root_client
+        assert str(bound_chat_model.root_client.base_url).rstrip("/") == (
+            DEFAULT_BETA_API_BASE
+        )
 
 
 class TestChatDeepSeekAzureToolChoice:


### PR DESCRIPTION
Fixes #40031

---

## Why

When a user calls `ChatDeepSeek.bind_tools(tools, strict=True)` or
`ChatDeepSeek.with_structured_output(schema, strict=True)` on the default API
base, the docs promise the request will be routed to DeepSeek's beta endpoint
so the server enforces the schema. In practice it never was: `model_copy` does
not re-run Pydantic validators, so the cached OpenAI clients were copied by
reference and still pointed at `/v1`. The `strict` flag was set on the payload,
but the validation that is supposed to accompany it never ran, silently.

## What

Added a private `_with_beta_endpoint()` helper that copies the model, clears
the four cached client fields (`client`, `async_client`, `root_client`,
`root_async_client`), switches `api_base` to the beta base URL, and re-runs
`validate_environment` so a fresh client targets `/beta`. Both
`bind_tools` and `with_structured_output` now build their beta instance through
this helper, and the strict-mode unit tests were strengthened to assert the
resolved `base_url` and that a fresh client is used, rather than only checking
that the returned object is non-`None`.

## Release note

`langchain-deepseek`: fixed `ChatDeepSeek` strict mode so that
`bind_tools(..., strict=True)` and `with_structured_output(..., strict=True)`
actually route requests to DeepSeek's beta endpoint, where schema validation
runs, instead of silently continuing to use the default `/v1` base URL.

## Review notes

- The fix is scoped to `ChatDeepSeek`; `model_copy(update=...)` is not used
  elsewhere in this package for client-holding objects.
- Tests were confirmed to fail on the unfixed code (client is shared by
  reference and points at `/v1`) and pass with this change.

This contribution was prepared with the assistance of an AI coding agent; all
changes and test results were verified locally.
