### PR TITLE
fix(core): anchor NumberedListOutputParser to line starts

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -188,7 +188,7 @@ class CommaSeparatedListOutputParser(ListOutputParser):
 class NumberedListOutputParser(ListOutputParser):
     """Parse a numbered list."""
 
-    pattern: str = r"\d+\.\s([^\n]+)"
+    pattern: str = r"^\s*\d+\.\s([^\n]+)$"
     """The pattern to match a numbered list item."""
 
     @override
@@ -207,11 +207,11 @@ class NumberedListOutputParser(ListOutputParser):
         Returns:
             A list of strings.
         """
-        return re.findall(self.pattern, text)
+        return re.findall(self.pattern, text, re.MULTILINE)
 
     @override
     def parse_iter(self, text: str) -> Iterator[re.Match[str]]:
-        return re.finditer(self.pattern, text)
+        return re.finditer(self.pattern, text, re.MULTILINE)
 
     @property
     def _type(self) -> str:

--- a/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
@@ -100,10 +100,18 @@ def test_numbered_list() -> None:
 
     text3 = "No items in the list."
 
+    # Mid-line "N. " sequences must not be treated as list items.
+    text4 = "The answer is version 2. Something else."
+    text5 = "See fig. 1. for details"
+    text6 = "Chapter 1. Introduction\n2. Next"
+
     for text, expected in [
         (text1, ["foo", "bar", "baz"]),
         (text2, ["apple", "banana", "cherry"]),
         (text3, []),
+        (text4, []),
+        (text5, []),
+        (text6, ["Next"]),
     ]:
         expectedlist = [[a] for a in expected]
         assert parser.parse(text) == expected
@@ -239,10 +247,15 @@ async def test_numbered_list_async() -> None:
 
     text3 = "No items in the list."
 
+    text4 = "The answer is version 2. Something else."
+    text5 = "Chapter 1. Introduction\n2. Next"
+
     for text, expected in [
         (text1, ["foo", "bar", "baz"]),
         (text2, ["apple", "banana", "cherry"]),
         (text3, []),
+        (text4, []),
+        (text5, ["Next"]),
     ]:
         expectedlist = [[a] for a in expected]
         assert await parser.aparse(text) == expected


### PR DESCRIPTION
## Description

`NumberedListOutputParser` used `r"\d+\.\s([^\n]+)"` without line anchors, so mid-line sequences like `version 2. Something` / `fig. 1. for details` were parsed as list items.

This aligns the pattern with `MarkdownListOutputParser`: `r"^\s*\d+\.\s([^\n]+)$"` plus `re.MULTILINE` in `parse` / `parse_iter`. Format instructions already require one item per line.

## Issue

Fixes #40070

## Dependencies

None

## Release note

`NumberedListOutputParser` no longer treats mid-line `N. ` sequences as list items; matching is line-anchored like `MarkdownListOutputParser`.

## Test plan

```text
$ cd libs/core && make format && make lint
All checks passed / mypy: Success: no issues found in 355 source files

$ cd libs/core && uv run pytest tests/unit_tests/output_parsers/test_list_parser.py -q
10 passed
```

Added regression coverage for mid-line false positives while keeping existing numbered-list happy paths.

Please assign #40070 to @Divyansh151005 so this PR can reopen under the assignment gate.