### PR TITLE
fix(text-splitters): preserve tabs and NBSP in MarkdownHeaderTextSplitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/markdown.py
+++ b/libs/text-splitters/langchain_text_splitters/markdown.py
@@ -85,6 +85,17 @@ class MarkdownHeaderTextSplitter:
                 return True
         return False
 
+    @staticmethod
+    def _strip_non_content_characters(text: str) -> str:
+        """Remove control/format characters while preserving tabs and NBSP.
+
+        ``str.isprintable()`` is false for tab and NBSP, so filtering with it alone
+        silently deletes meaningful whitespace (including indentation inside fenced
+        code blocks). BOM and other non-printable control characters are still
+        dropped.
+        """
+        return "".join(ch for ch in text if ch.isprintable() or ch in "\t\xa0")
+
     def aggregate_lines_to_chunks(self, lines: list[LineType]) -> list[Document]:
         """Combine lines with common metadata into chunks.
 
@@ -161,10 +172,7 @@ class MarkdownHeaderTextSplitter:
         opening_fence = ""
 
         for line in lines:
-            stripped_line = line.strip()
-            # Remove all non-printable characters from the string, keeping only visible
-            # text.
-            stripped_line = "".join(filter(str.isprintable, stripped_line))
+            stripped_line = self._strip_non_content_characters(line.strip())
             if not in_code_block:
                 # Exclude inline code spans
                 if stripped_line.startswith("```") and stripped_line.count("```") == 1:
@@ -178,7 +186,8 @@ class MarkdownHeaderTextSplitter:
                 opening_fence = ""
 
             if in_code_block:
-                current_content.append(stripped_line)
+                # Keep leading indentation inside fences (tabs/spaces).
+                current_content.append(self._strip_non_content_characters(line))
                 continue
 
             # Check each line against each of the header types (e.g., #, ##)

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -1727,6 +1727,40 @@ def test_md_header_text_splitter_with_invisible_characters(characters: str) -> N
     assert output == expected_output
 
 
+def test_md_header_text_splitter_preserves_tab_and_nbsp() -> None:
+    """Tabs and NBSP must survive content sanitization (not treated as droppable)."""
+    headers_to_split_on = [("#", "Header 1")]
+    markdown_splitter = MarkdownHeaderTextSplitter(
+        headers_to_split_on=headers_to_split_on,
+    )
+
+    tab_docs = markdown_splitter.split_text("# Foo\n\nhello\tworld")
+    assert tab_docs == [
+        Document(page_content="hello\tworld", metadata={"Header 1": "Foo"}),
+    ]
+
+    nbsp_docs = markdown_splitter.split_text("# Foo\n\nhello\u00a0world")
+    assert nbsp_docs == [
+        Document(page_content="hello\u00a0world", metadata={"Header 1": "Foo"}),
+    ]
+
+
+def test_md_header_text_splitter_preserves_code_fence_indentation() -> None:
+    """Tab indentation inside fenced code blocks must not be stripped."""
+    headers_to_split_on = [("#", "Header 1")]
+    markdown_splitter = MarkdownHeaderTextSplitter(
+        headers_to_split_on=headers_to_split_on,
+    )
+    markdown_document = "# Foo\n\n```python\ndef foo():\n\treturn 1\n```\n"
+    output = markdown_splitter.split_text(markdown_document)
+    assert output == [
+        Document(
+            page_content="```python\ndef foo():\n\treturn 1\n```",
+            metadata={"Header 1": "Foo"},
+        ),
+    ]
+
+
 def test_md_header_text_splitter_with_custom_headers() -> None:
     """Test markdown splitter with custom header patterns like **Header**."""
     markdown_document = """**Chapter 1**


### PR DESCRIPTION
## Description

`MarkdownHeaderTextSplitter.split_text` sanitized every line with `filter(str.isprintable, ...)`. In Python, both tab and NBSP are not printable, so they were deleted from chunk content. Combined with `line.strip()` inside fenced code blocks, tab indentation was also lost.

Changes:

- Filter control/format characters (e.g. BOM) while keeping tab and NBSP.
- While inside a fence, append the line without stripping leading whitespace so indentation survives.
- Keep existing BOM behavior covered by `test_md_header_text_splitter_with_invisible_characters`.

## Issue

Fixes #40071

## Dependencies

None

## Release note

`MarkdownHeaderTextSplitter` preserves tabs and non-breaking spaces in chunk content, including tab indentation inside fenced code blocks.

## Test plan

```text
$ cd libs/text-splitters
$ uv run --group lint ruff check langchain_text_splitters
All checks passed!
$ uv run --group test pytest tests/unit_tests/test_text_splitters.py -k "md_header_text_splitter" -q --disable-socket
14 passed, 141 deselected
```

Please assign #40071 to @Divyansh151005 so this PR can reopen under the assignment gate.