### PR TITLE
fix(core): prevent metadata keys from overriding `page_content` in `format_document`

### DIFF
--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -432,7 +432,7 @@ class BasePromptTemplate(
 def _get_document_info(
     doc: Document, prompt: BasePromptTemplate[str]
 ) -> dict[str, Any]:
-    base_info = {"page_content": doc.page_content, **doc.metadata}
+    base_info = {**doc.metadata, "page_content": doc.page_content}
     missing_metadata = set(prompt.input_variables).difference(base_info)
     if len(missing_metadata) > 0:
         required_metadata = [

--- a/libs/core/tests/unit_tests/prompts/test_utils.py
+++ b/libs/core/tests/unit_tests/prompts/test_utils.py
@@ -1,6 +1,9 @@
 """Test functionality related to prompt utils."""
 
+from langchain_core.documents import Document
 from langchain_core.example_selectors import sorted_values
+from langchain_core.prompts import PromptTemplate
+from langchain_core.prompts.base import format_document
 
 
 def test_sorted_vals() -> None:
@@ -8,3 +11,30 @@ def test_sorted_vals() -> None:
     test_dict = {"key2": "val2", "key1": "val1"}
     expected_response = ["val1", "val2"]
     assert sorted_values(test_dict) == expected_response
+
+
+def test_format_document_metadata_does_not_override_page_content() -> None:
+    """Regression test for metadata keys not overriding page_content.
+
+    Metadata keys named 'page_content' must not override
+    the actual Document.page_content in format_document.
+    See: https://github.com/langchain-ai/langchain/issues/40075
+    """
+    doc = Document(
+        page_content="actual content",
+        metadata={"page_content": "metadata value", "extra": "data"},
+    )
+    prompt = PromptTemplate.from_template("{page_content}")
+    result = format_document(doc, prompt)
+    assert result == "actual content"
+
+
+def test_format_document_metadata_does_not_override_named_keys() -> None:
+    """Metadata keys should not override any first-class Document attributes."""
+    doc = Document(
+        page_content="real content",
+        metadata={"page_content": "fake", "extra": "data"},
+    )
+    prompt = PromptTemplate.from_template("{page_content} - {extra}")
+    result = format_document(doc, prompt)
+    assert result == "real content - data"


### PR DESCRIPTION
Closes #40075

---

In `_get_document_info()`, the dict spread order `{**doc.metadata, "page_content": doc.page_content}` allowed metadata keys named `page_content` to silently overwrite the actual `Document.page_content`.

This fix reverses the spread order so `page_content` always comes from the document itself.

**Changes:**
- `libs/core/langchain_core/prompts/base.py`: Reversed dict spread order in `_get_document_info()`
- `libs/core/tests/unit_tests/prompts/test_utils.py`: Added regression tests

**Before:**
```python
base_info = {"page_content": doc.page_content, **doc.metadata}
```

**After:**
```python
base_info = {**doc.metadata, "page_content": doc.page_content}
```

## Release note

`format_document` no longer allows metadata keys to override the `page_content` variable.

_AI-agent disclaimer: This PR was prepared with AI assistance and reviewed before submission._