### PR TITLE
fix(core): prevent metadata from shadowing page_content in format_document

### DIFF
--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -432,7 +432,7 @@ class BasePromptTemplate(
 def _get_document_info(
     doc: Document, prompt: BasePromptTemplate[str]
 ) -> dict[str, Any]:
-    base_info = {"page_content": doc.page_content, **doc.metadata}
+    base_info = {**doc.metadata, "page_content": doc.page_content}
     missing_metadata = set(prompt.input_variables).difference(base_info)
     if len(missing_metadata) > 0:
         required_metadata = [

--- a/libs/core/tests/unit_tests/prompts/test_format_document.py
+++ b/libs/core/tests/unit_tests/prompts/test_format_document.py
@@ -1,0 +1,43 @@
+"""Tests for format_document and _get_document_info."""
+
+import pytest
+
+from langchain_core.documents import Document
+from langchain_core.prompts import PromptTemplate
+from langchain_core.prompts.base import _get_document_info, format_document
+
+
+def test_metadata_page_content_key_does_not_override_real_content() -> None:
+    """Regression: a metadata field named 'page_content' must not replace the
+    document's actual page_content in the formatted output."""
+    doc = Document(
+        page_content="real document text",
+        metadata={"page_content": "metadata impostor", "source": "test.pdf"},
+    )
+    prompt = PromptTemplate.from_template("{page_content}")
+    result = format_document(doc, prompt)
+    assert result == "real document text"
+
+
+def test_get_document_info_preserves_page_content_over_metadata() -> None:
+    """_get_document_info must return the document's page_content, not a
+    same-named metadata field."""
+    doc = Document(
+        page_content="the real content",
+        metadata={"page_content": "shadowed", "author": "alice"},
+    )
+    prompt = PromptTemplate.from_template("{page_content} by {author}")
+    info = _get_document_info(doc, prompt)
+    assert info["page_content"] == "the real content"
+    assert info["author"] == "alice"
+
+
+def test_format_document_normal_metadata() -> None:
+    """format_document works normally when metadata does not shadow page_content."""
+    doc = Document(
+        page_content="hello world",
+        metadata={"source": "s3://bucket/key", "page": "42"},
+    )
+    prompt = PromptTemplate.from_template("Content: {page_content}\nPage: {page}")
+    result = format_document(doc, prompt)
+    assert result == "Content: hello world\nPage: 42"


### PR DESCRIPTION
Fixes #40075.

## Problem

`_get_document_info` builds the template variables dict as:

```python
base_info = {"page_content": doc.page_content, **doc.metadata}
```

Because the metadata spread comes *after* the `page_content` key, any metadata
field named `page_content` silently overwrites the document's real content. The
formatted output then contains the metadata value instead of the actual text,
with no error or warning.

This is a silent data corruption: the caller gets a confidently wrong result, and
nothing in the chain signals that the document's content was replaced.

## Fix

Swap the spread order so the explicit key always wins:

```python
base_info = {**doc.metadata, "page_content": doc.page_content}
```

This is the same pattern used in the Bedrock fix (#40022) for an analogous issue.
Metadata fields other than `page_content` are still available as template
variables; only the shadowing is prevented.

## Tests

Three tests in `test_format_document.py`:

- `test_metadata_page_content_key_does_not_override_real_content` — the
  regression case: a document with `metadata={"page_content": "impostor"}`
  formats using the real `page_content`, not the metadata value
- `test_get_document_info_preserves_page_content_over_metadata` — directly
  asserts `_get_document_info` returns the real content
- `test_format_document_normal_metadata` — non-shadowing metadata still works

Verified red-first: the regression test fails with
`AssertionError: assert 'metadata impostor' == 'real document text'`
on the unfixed code.
