### PR TITLE
fix(openrouter): use seconds for request timeout

### DIFF
--- a/libs/partners/openrouter/langchain_openrouter/chat_models.py
+++ b/libs/partners/openrouter/langchain_openrouter/chat_models.py
@@ -136,7 +136,7 @@ class ChatOpenRouter(BaseChatModel):
         | ----- | ---- | ----------- |
         | `api_key` | `str | None` | OpenRouter API key. |
         | `base_url` | `str | None` | Base URL for API requests. |
-        | `timeout` | `int | None` | Timeout in milliseconds. |
+        | `timeout` | `float | None` | Timeout in seconds. |
         | `app_url` | `str | None` | App URL for attribution. |
         | `app_title` | `str | None` | App title for attribution. |
         | `app_categories` | `list[str] | None` | Marketplace attribution categories. |
@@ -220,8 +220,8 @@ class ChatOpenRouter(BaseChatModel):
     See https://openrouter.ai/docs/app-attribution for recognized categories.
     """
 
-    request_timeout: int | None = Field(default=None, alias="timeout")
-    """Timeout for requests in milliseconds. Maps to SDK `timeout_ms`."""
+    request_timeout: float | None = Field(default=None, alias="timeout")
+    """Timeout for requests in seconds. Converted to milliseconds for the SDK."""
 
     max_retries: int = 2
     """Maximum number of retries.
@@ -453,7 +453,7 @@ class ChatOpenRouter(BaseChatModel):
                 headers=extra_headers, follow_redirects=True
             )
         if self.request_timeout is not None:
-            client_kwargs["timeout_ms"] = self.request_timeout
+            client_kwargs["timeout_ms"] = int(self.request_timeout * 1000)
         if self.max_retries > 0:
             client_kwargs["retry_config"] = RetryConfig(
                 strategy="backoff",

--- a/libs/partners/openrouter/tests/unit_tests/__snapshots__/test_standard.ambr
+++ b/libs/partners/openrouter/tests/unit_tests/__snapshots__/test_standard.ambr
@@ -20,7 +20,7 @@
         'lc': 1,
         'type': 'secret',
       }),
-      'request_timeout': 60,
+      'request_timeout': 60.0,
       'stop': list([
       ]),
       'stream_usage': True,

--- a/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
@@ -2866,17 +2866,18 @@ class TestOpenRouterSpecificParams:
             call_kwargs = mock_cls.call_args[1]
             assert call_kwargs["server_url"] == "https://custom.openrouter.ai/api/v1"
 
-    def test_timeout_passed_to_client(self) -> None:
-        """Test that timeout is passed as timeout_ms to the SDK client."""
+    @pytest.mark.parametrize(("timeout", "timeout_ms"), [(30, 30_000), (0.1, 100)])
+    def test_timeout_passed_to_client(self, timeout: float, timeout_ms: int) -> None:
+        """Test that timeout seconds are converted to milliseconds for the SDK."""
         with patch("openrouter.OpenRouter") as mock_cls:
             mock_cls.return_value = MagicMock()
             ChatOpenRouter(
                 model=MODEL_NAME,
                 api_key=SecretStr("test-key"),
-                timeout=30000,
+                timeout=timeout,
             )
             call_kwargs = mock_cls.call_args[1]
-            assert call_kwargs["timeout_ms"] == 30000
+            assert call_kwargs["timeout_ms"] == timeout_ms
 
     def test_all_openrouter_params_in_single_payload(self) -> None:
         """Test that all OpenRouter-specific params coexist in a payload."""


### PR DESCRIPTION
Fixes #39812

---

OpenRouter users expect `timeout` to follow LangChain's seconds-based convention. This converts seconds to the SDK's `timeout_ms` value and accepts fractional timeouts while preserving the existing SDK boundary.

Regression coverage verifies both whole-second and fractional-second timeout values.

## Release note

`ChatOpenRouter` now interprets `timeout` in seconds and accepts fractional values, consistent with other LangChain chat models.

This contribution was implemented with assistance from an AI coding agent and manually verified with package formatting, linting, type checking, and unit tests.