### PR TITLE
fix(core): keep synthetic root fields out of merged `RunnableParallel` input schemas

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -102,6 +102,7 @@ from langchain_core.utils.pydantic import (
     TypeBaseModel,
     create_model_v2,
     get_fields,
+    is_pydantic_v2_subclass,
     model_json_schema,
 )
 
@@ -3069,6 +3070,19 @@ def _get_schema_field_definition(field: FieldInfo | ModelField) -> tuple[Any, An
     return (field.annotation, field.default)
 
 
+def _get_root_field_name(schema: TypeBaseModel) -> str | None:
+    """Return the name of `schema`'s synthetic root field, or `None` if it has none.
+
+    Root models wrap a single value in a synthetic field: `root` under Pydantic v2 and
+    `__root__` under v1. The v2 name is not reserved, so an ordinary model is free to
+    declare a real field called `root`; only the model being a `RootModel` tells the
+    two apart.
+    """
+    if is_pydantic_v2_subclass(schema):
+        return "root" if issubclass(schema, RootModel) else None
+    return "__root__" if "__root__" in get_fields(schema) else None
+
+
 _RUNNABLE_SEQUENCE_MIN_STEPS = 2
 
 
@@ -4033,25 +4047,46 @@ class RunnableParallel(RunnableSerializable[Input, dict[str, Any]]):
             s.get_input_jsonschema(config).get("type", "object") == "object"
             for s in self.steps__.values()
         ):
-            for step in self.steps__.values():
-                step_input_schema = step.get_input_schema(config)
-                fields = get_fields(step_input_schema)
-                root_field = fields.get("root")
-                if root_field is not None and root_field.annotation != Any:
+            # Each step's schema is paired with the name of its synthetic root field,
+            # if it has one.
+            step_schemas = [
+                (schema, _get_root_field_name(schema))
+                for schema in (
+                    step.get_input_schema(config) for step in self.steps__.values()
+                )
+            ]
+
+            for step_input_schema, root_name in step_schemas:
+                if root_name is None:
+                    continue
+                root_field = get_fields(step_input_schema)[root_name]
+                if root_field.annotation == Any:
+                    # The step takes any value, so it constrains nothing.
+                    continue
+                # The step constrains the input as a whole rather than by key, so
+                # there is nothing to merge with its siblings.
+                if is_pydantic_v2_subclass(step_input_schema):
                     return super().get_input_schema(config)
-                root_field = fields.get("__root__")
-                if root_field is not None and root_field.annotation != Any:
-                    return step_input_schema
+                return step_input_schema
+
+            # A synthetic root field describes how a step's schema is built, not a key
+            # the caller supplies, so it must not become a field of the merged model.
+            field_definitions = {
+                k: _get_schema_field_definition(v)
+                for step_input_schema, root_name in step_schemas
+                for k, v in get_fields(step_input_schema).items()
+                if k != root_name
+            }
+            if not field_definitions:
+                # Every step takes an unconstrained value, so the mapping as a whole
+                # accepts whatever its steps accept. Building an empty object model
+                # here would reject the non-mapping inputs that `invoke` handles.
+                return super().get_input_schema(config)
 
             # This is correct, but pydantic typings/mypy don't think so.
             return create_model_v2(
                 self.get_name("Input"),
-                field_definitions={
-                    k: _get_schema_field_definition(v)
-                    for step in self.steps__.values()
-                    for k, v in get_fields(step.get_input_schema(config)).items()
-                    if k != "__root__"
-                },
+                field_definitions=field_definitions,
             )
 
         return super().get_input_schema(config)

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -5911,6 +5911,56 @@ def test_runnable_parallel_uses_base_schema_for_v1_root_model() -> None:
         schema.parse_obj({"a": "not an int"})
 
 
+def test_runnable_parallel_input_schema_accepts_what_invoke_accepts() -> None:
+    """Steps that take any value must not add a required `root` key to the schema.
+
+    Regression test: the merged schema filtered out the Pydantic v1 root field name
+    (`__root__`) but not the v2 spelling (`root`), so the synthetic root of an
+    unconstrained step was merged in as if a caller had to supply it. That made the
+    input schema reject every value `invoke` accepts.
+    """
+    parallel = RunnableParallel(a=RunnablePassthrough(), b=RunnableLambda(lambda x: x))
+    schema = parallel.input_schema
+
+    for value in ({"k": 1}, "x", 5, [1]):
+        assert parallel.invoke(value) == {"a": value, "b": value}
+        assert schema.model_validate(value).root == value
+
+
+def test_runnable_parallel_input_schema_keeps_constraining_fields() -> None:
+    """An unconstrained step must not relax the fields a sibling step requires."""
+
+    class InputModel(BaseModel):
+        a: int
+
+    parallel = RunnableParallel(
+        foo=RunnablePassthrough(),
+        bar=_RunnableWithInputSchema(InputModel),
+    )
+    schema = cast("type[BaseModel]", parallel.input_schema)
+
+    assert schema.model_json_schema()["required"] == ["a"]
+    assert schema.model_validate({"a": 1}).a == 1
+    with pytest.raises(ValidationError):
+        schema.model_validate({"b": 1})
+
+
+def test_runnable_parallel_input_schema_preserves_field_named_root() -> None:
+    """A step may legitimately declare a field called `root`; it must survive."""
+
+    class InputModel(BaseModel):
+        root: str
+
+    parallel = RunnableParallel(
+        foo=RunnablePassthrough(),
+        bar=_RunnableWithInputSchema(InputModel),
+    )
+    schema = cast("type[BaseModel]", parallel.input_schema)
+
+    assert schema.model_json_schema()["required"] == ["root"]
+    assert schema.model_validate({"root": "x"}).root == "x"
+
+
 @skip_if_no_pydantic_v1
 def test_runnable_sequence_v1_input_schema() -> None:
     """A `RunnableSequence` exposes a Pydantic v1 first-step input schema.


### PR DESCRIPTION
Closes #39792

---

`RunnableParallel.get_input_schema()` returns a schema that rejects every value `invoke()` accepts:

```python
from langchain_core.runnables import RunnableLambda, RunnableParallel, RunnablePassthrough

parallel = RunnableParallel(a=RunnablePassthrough(), b=RunnableLambda(lambda x: x))
schema = parallel.get_input_schema()

parallel.invoke({"k": 1})        # {'a': {'k': 1}, 'b': {'k': 1}}
schema.model_validate({"k": 1})  # ValidationError
```

Anyone who builds on a chain's declared input schema — request validation at an API boundary, form generation, a JSON Schema handed to a client — gets a contract nothing can satisfy. The chain itself keeps working, so the mismatch usually surfaces later as a validation error that looks like bad caller data.

## What is going on

`RunnableParallel` passes the same input to every step, so its input schema is the merge of its steps' input schemas. A step that accepts any value should contribute no constraints. That kind of step has a root model for its schema, and a root model wraps its single value in a synthetic field: `__root__` under Pydantic v1, `root` under v2.

The merge filtered out the v1 name but never the v2 one. The synthetic `root` field was therefore merged in as if a caller had to supply a key called `root`, and as a required one. That single field is what makes the whole schema unsatisfiable.

## The fix

The v2 name is not reserved, so an ordinary model may declare a real field called `root` that has to be kept. Filtering by name alone would silently drop it. The synthetic field is instead identified by whether the schema is a `RootModel`, and the same check now covers the earlier per-step branches, which made the identical conflation.

When no step constrains the input, the merged model has no fields at all, and an empty object model still rejects the strings, numbers, and lists `invoke` handles. That case now falls back to the base implementation's schema, which accepts them.

## Release note

Fixed `RunnableParallel.get_input_schema()` returning a schema that rejected every valid input whenever one of its steps accepted an unconstrained value. A step schema that declares a genuine field named `root` is now preserved instead of being discarded.

## Areas worth a careful look

The `RootModel` test is the load-bearing part of this change. It is what separates a synthetic root from a real field named `root`, and it alters the behavior of the pre-existing early-return branches rather than only the merge. There is a regression test for each of the three cases: the unconstrained mapping, a mix of constrained and unconstrained steps, and a schema with a real `root` field.
