### PR TITLE
fix(langchain): emit POSIX virtual paths from `FilesystemFileSearchMiddleware`

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -194,7 +194,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
                 # points outside the root is never enumerated.
                 if match.is_file() and _is_within_root(match, self.root_path):
                     # Convert to virtual path
-                    virtual_path = "/" + str(match.relative_to(self.root_path))
+                    virtual_path = "/" + match.relative_to(self.root_path).as_posix()
                     stat = match.stat()
                     modified_at = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
                     matching.append((virtual_path, modified_at))
@@ -334,7 +334,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
                     if not _is_within_root(Path(path), self.root_path):
                         continue
                     # Convert to virtual path
-                    virtual_path = "/" + str(Path(path).relative_to(self.root_path))
+                    virtual_path = "/" + Path(path).relative_to(self.root_path).as_posix()
                     line_num = data["data"]["line_number"]
                     line_text = data["data"]["lines"]["text"].rstrip("\n")
 
@@ -391,7 +391,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
                 # Search content
                 for line_num, line in enumerate(content.splitlines(), 1):
                     if regex.search(line):
-                        virtual_path = "/" + str(file_path.relative_to(self.root_path))
+                        virtual_path = "/" + file_path.relative_to(self.root_path).as_posix()
                         if virtual_path not in results:
                             results[virtual_path] = []
                         results[virtual_path].append((line_num, line))

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
@@ -1,5 +1,6 @@
 """Unit tests for file search middleware."""
 
+import json
 import os
 from pathlib import Path
 from typing import Any
@@ -75,6 +76,52 @@ class TestFilesystemGrepSearch:
         assert "/file1.py" in result
         assert "/file3.txt" in result
         assert "/file2.py" not in result
+
+    def test_python_grep_emits_posix_virtual_paths(self, tmp_path: Path) -> None:
+        """The Python fallback reports nested matches with `/` separators."""
+        (tmp_path / "src" / "nested").mkdir(parents=True)
+        (tmp_path / "src" / "nested" / "deep.py").write_text("needle\n", encoding="utf-8")
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path), use_ripgrep=False)
+
+        assert isinstance(middleware.grep_search, StructuredTool)
+        assert middleware.grep_search.func is not None
+        result = middleware.grep_search.func(pattern="needle")
+
+        assert "\\" not in result
+        assert "/src/nested/deep.py" in result
+
+    def test_ripgrep_emits_posix_virtual_paths(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Parsed ripgrep matches are keyed by `/`-separated virtual paths."""
+        nested = tmp_path / "src" / "nested"
+        nested.mkdir(parents=True)
+        deep = nested / "deep.py"
+        deep.write_text("needle\n", encoding="utf-8")
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path), use_ripgrep=True)
+
+        class DummyResult:
+            stdout = json.dumps(
+                {
+                    "type": "match",
+                    "data": {
+                        "path": {"text": str(deep)},
+                        "line_number": 1,
+                        "lines": {"text": "needle\n"},
+                    },
+                }
+            )
+
+        monkeypatch.setattr(
+            "langchain.agents.middleware.file_search.subprocess.run",
+            lambda *_args, **_kwargs: DummyResult(),
+        )
+
+        results = middleware._ripgrep_search("needle", "/", None)
+
+        assert list(results) == ["/src/nested/deep.py"]
 
     def test_grep_with_include_filter(self, tmp_path: Path) -> None:
         """Test grep search with include pattern filter."""
@@ -172,6 +219,24 @@ class TestFilesystemGlobSearch:
         result = middleware.glob_search.func(pattern="**/*.py")
 
         assert "/src/test.py" in result
+        assert "/src/nested/deep.py" in result
+
+    def test_glob_emits_posix_virtual_paths(self, tmp_path: Path) -> None:
+        r"""Virtual paths use `/` regardless of the host separator.
+
+        Regression test: the virtual path was built with `str()`, which renders a
+        `Path` with the native separator, so Windows returned `/src\nested\deep.py`.
+        """
+        (tmp_path / "src" / "nested").mkdir(parents=True)
+        (tmp_path / "src" / "nested" / "deep.py").write_text("content", encoding="utf-8")
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path))
+
+        assert isinstance(middleware.glob_search, StructuredTool)
+        assert middleware.glob_search.func is not None
+        result = middleware.glob_search.func(pattern="**/*.py")
+
+        assert "\\" not in result
         assert "/src/nested/deep.py" in result
 
     def test_glob_with_subdirectory_path(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #40062

---

`FilesystemFileSearchMiddleware` hands the agent virtual paths that use the host's path separator. On Windows a nested match comes back as `/src\nested\example.py` where every other platform returns `/src/nested/example.py`.

```python
middleware = FilesystemFileSearchMiddleware(root_path=root, use_ripgrep=False)
middleware.glob_search.invoke({"pattern": "**/*.py"})
# Windows: '/src\\nested\\example.py'
# elsewhere: '/src/nested/example.py'
```

The virtual path is meant to be an abstraction over the real filesystem — it is what the model sees, what it echoes back into follow-up tool calls, and what ends up in persisted traces. Letting the host separator leak through makes that abstraction platform-dependent: prompts and evals written against one platform read differently on another, and a trace captured on Windows no longer matches one captured in CI.

## The fix

Three places build a virtual path by calling `str()` on a relative `Path`, and `Path.__str__` renders with the native separator. All three now use `as_posix()`: glob results, the ripgrep JSON parser, and the Python grep fallback. No public API or dependency changes.

## Release note

`FilesystemFileSearchMiddleware` now returns `/`-separated virtual paths from `glob_search` and `grep_search` on every platform. Previously Windows returned paths containing backslashes.

## Note on existing coverage

Two tests in the suite already asserted forward slashes in nested results and were failing whenever the suite ran on Windows. This change makes them pass. The new tests cover each of the three sites, including a ripgrep case that stubs the subprocess so it does not need `rg` installed.
