### PR TITLE
fix(anthropic): compare `allowed_prefixes` against POSIX virtual paths

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
@@ -874,8 +874,10 @@ class _FilesystemClaudeFileToolMiddleware(AgentMiddleware):
             msg = f"Path outside root directory: {path}"
             raise ValueError(msg) from None
 
-        # Check allowed prefixes
-        virtual_path = "/" + str(full_path.relative_to(self.root_path))
+        # Check allowed prefixes. `_is_within_allowed_prefix` compares on `/`
+        # boundaries, so the root-relative part has to be rendered as POSIX rather
+        # than with the host separator.
+        virtual_path = "/" + full_path.relative_to(self.root_path).as_posix()
         if self.allowed_prefixes and not _is_within_allowed_prefix(
             virtual_path, self.allowed_prefixes
         ):

--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
@@ -11,6 +11,7 @@ from langgraph.types import Command
 
 from langchain_anthropic.middleware.anthropic_tools import (
     AnthropicToolsState,
+    FilesystemClaudeMemoryMiddleware,
     FilesystemClaudeTextEditorMiddleware,
     StateClaudeMemoryMiddleware,
     StateClaudeTextEditorMiddleware,
@@ -357,6 +358,67 @@ class TestFileOperations:
         message = result.update["messages"][0]
         assert isinstance(message, ToolMessage)
         assert "renamed" in message.content
+
+
+class TestFilesystemAllowedPrefixes:
+    r"""Prefix checks on the filesystem-backed middleware are separator-agnostic.
+
+    Regression tests: the virtual path handed to `_is_within_allowed_prefix` was
+    built with `str()`, which renders a `Path` with the host separator. On Windows
+    `/workspace/nested/file.txt` became `/workspace\nested\file.txt`, which does not
+    match the `/`-boundary comparison, so every path below a prefix was rejected.
+    """
+
+    def test_nested_path_within_prefix_is_allowed(self) -> None:
+        """A file below the allowed prefix directory resolves."""
+        with tempfile.TemporaryDirectory() as root:
+            (Path(root) / "workspace" / "nested").mkdir(parents=True)
+            middleware = FilesystemClaudeTextEditorMiddleware(
+                root_path=root, allowed_prefixes=["/workspace"]
+            )
+
+            resolved = middleware._validate_and_resolve_path(
+                "/workspace/nested/file.txt"
+            )
+
+            expected = Path(root).resolve() / "workspace" / "nested" / "file.txt"
+            assert resolved == expected
+
+    def test_direct_child_of_prefix_is_allowed(self) -> None:
+        """A file directly inside the allowed prefix directory resolves."""
+        with tempfile.TemporaryDirectory() as root:
+            (Path(root) / "workspace").mkdir()
+            middleware = FilesystemClaudeTextEditorMiddleware(
+                root_path=root, allowed_prefixes=["/workspace"]
+            )
+
+            resolved = middleware._validate_and_resolve_path("/workspace/file.txt")
+
+            assert resolved == Path(root).resolve() / "workspace" / "file.txt"
+
+    def test_sibling_sharing_prefix_text_is_rejected(self) -> None:
+        """Normalizing separators must not weaken the segment-boundary check."""
+        with tempfile.TemporaryDirectory() as root:
+            (Path(root) / "workspace2").mkdir()
+            middleware = FilesystemClaudeTextEditorMiddleware(
+                root_path=root, allowed_prefixes=["/workspace"]
+            )
+
+            with pytest.raises(ValueError, match="Path must start with one of"):
+                middleware._validate_and_resolve_path("/workspace2/evil.txt")
+
+    def test_memory_middleware_shares_the_fix(self) -> None:
+        """`FilesystemClaudeMemoryMiddleware` uses the same base path validation."""
+        with tempfile.TemporaryDirectory() as root:
+            (Path(root) / "memories" / "nested").mkdir(parents=True)
+            middleware = FilesystemClaudeMemoryMiddleware(root_path=root)
+
+            resolved = middleware._validate_and_resolve_path(
+                "/memories/nested/note.txt"
+            )
+
+            expected = Path(root).resolve() / "memories" / "nested" / "note.txt"
+            assert resolved == expected
 
 
 class TestFilesystemRenameViaToolDispatch:


### PR DESCRIPTION
Closes #40063

---

On Windows, `FilesystemClaudeTextEditorMiddleware` rejects every path underneath a configured `allowed_prefixes` entry, so the tool is unusable as soon as prefixes are restricted:

```python
middleware = FilesystemClaudeTextEditorMiddleware(
    root_path=str(root),
    allowed_prefixes=["/workspace"],
)
middleware._validate_and_resolve_path("/workspace/nested/file.txt")
# ValueError: Path must start with one of: ['/workspace']
```

Restricting prefixes is the recommended way to keep a file-editing agent inside a sandbox directory, so this hits exactly the users who configured the middleware most carefully. It is worth noting the effect is broader than the issue title suggests: a direct child such as `/workspace/file.txt` fails too, so on Windows nothing below a non-root prefix is reachable at all.

## What is going on

The method builds the virtual path it checks by calling `str()` on a root-relative `Path`, and `Path.__str__` renders with the host separator. On Windows `/workspace/file.txt` becomes `/workspace\file.txt`. The prefix check compares on `/` boundaries — deliberately, so that a sibling like `/workspace2/evil.txt` cannot pass as `/workspace` — and a backslash path never matches. Its docstring already states it expects a forward-slash path, so the caller was the side breaking the contract.

## The fix

Render the root-relative part with `as_posix()`. The state-backed validator already normalized separators, so only the filesystem-backed path needed changing. `FilesystemClaudeTextEditorMiddleware` and `FilesystemClaudeMemoryMiddleware` share this base method, so both are fixed.

## Release note

Fixed `FilesystemClaudeTextEditorMiddleware` and `FilesystemClaudeMemoryMiddleware` rejecting valid paths beneath a configured `allowed_prefixes` entry on Windows.

## Security considerations for review

This is the part worth reviewing closely, since the change touches a path guard.

The bug is fail-closed: it rejected paths that should have been allowed, so the fix only ever admits paths that were always intended to be in scope. It does not relax the guard. The segment-boundary comparison is untouched, and the resolved path is still confined to the root and still screened for traversal before this point. Covered by tests: a sibling directory sharing the prefix text is still rejected, traversal is still blocked, and paths outside the root are still refused.
