### PR TITLE
fix(huggingface): correct translation task detection in HuggingFacePipeline

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
+++ b/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
@@ -356,7 +356,9 @@ class HuggingFacePipeline(BaseLLM):
                     text = response["generated_text"]
                 elif self.pipeline.task == "summarization":
                     text = response["summary_text"]
-                elif self.pipeline.task in "translation":
+                elif self.pipeline.task == "translation" or (
+                    self.pipeline.task.startswith("translation_")
+                ):
                     text = response["translation_text"]
                 else:
                     msg = (

--- a/libs/partners/huggingface/tests/unit_tests/test_huggingface_pipeline.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_huggingface_pipeline.py
@@ -45,3 +45,33 @@ def test_initialization_with_from_model_id(
     )
 
     assert llm.model_id == "mock-model-id"
+
+
+def test_generate_translation_task() -> None:
+    """Translation pipelines report a task like ``translation_en_to_fr``.
+
+    The output payload uses the ``translation_text`` key, so ``_generate`` must
+    route these tasks to that key rather than rejecting them as invalid.
+    """
+    mock_pipe = MagicMock()
+    mock_pipe.task = "translation_en_to_fr"
+    mock_pipe.model.name_or_path = "mock-model-id"
+    mock_pipe.return_value = [{"translation_text": "Bonjour le monde"}]
+
+    llm = HuggingFacePipeline(pipeline=mock_pipe)
+    result = llm._generate(["Hello world"])
+
+    assert result.generations[0][0].text == "Bonjour le monde"
+
+
+def test_generate_bare_translation_task() -> None:
+    """A pipeline whose task is exactly ``translation`` must also be handled."""
+    mock_pipe = MagicMock()
+    mock_pipe.task = "translation"
+    mock_pipe.model.name_or_path = "mock-model-id"
+    mock_pipe.return_value = [{"translation_text": "Bonjour"}]
+
+    llm = HuggingFacePipeline(pipeline=mock_pipe)
+    result = llm._generate(["Hello"])
+
+    assert result.generations[0][0].text == "Bonjour"


### PR DESCRIPTION
Fixes #40095

**Description**

`HuggingFacePipeline._generate` used `self.pipeline.task in "translation"` — a substring test, not an equality check. Transformers translation pipelines report their task as `translation_xx_to_yy` (e.g. `translation_en_to_fr`), and `"translation_en_to_fr" in "translation"` is `False`, so valid translation pipelines fell through to the `else` branch and raised `ValueError: Got invalid task`. The substring check also matched any substring of `"translation"` (including the empty string).

**Fix**

Replace the substring check with an equality check plus a `translation_` prefix check, so both `translation` and `translation_xx_to_yy` task names are handled.

**Reproduction (before fix)**

```python
from unittest.mock import MagicMock
from langchain_huggingface import HuggingFacePipeline

pipe = MagicMock()
pipe.task = "translation_en_to_fr"
pipe.return_value = [{"translation_text": "Bonjour"}]
HuggingFacePipeline(pipeline=pipe)._generate(["Hello"])  # raises ValueError
