### PR TITLE
fix(core): ensure document page_content takes precedence over metadata in format_document

### DIFF
--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -432,7 +432,7 @@ class BasePromptTemplate(
 def _get_document_info(
     doc: Document, prompt: BasePromptTemplate[str]
 ) -> dict[str, Any]:
-    base_info = {"page_content": doc.page_content, **doc.metadata}
+    base_info = {**doc.metadata, "page_content": doc.page_content}
     missing_metadata = set(prompt.input_variables).difference(base_info)
     if len(missing_metadata) > 0:
         required_metadata = [

--- a/libs/core/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/core/tests/unit_tests/prompts/test_prompt.py
@@ -12,6 +12,8 @@ from packaging import version
 from syrupy.assertion import SnapshotAssertion
 
 from langchain_core._api import LangChainDeprecationWarning
+from langchain_core.documents import Document
+from langchain_core.prompts.base import aformat_document, format_document
 from langchain_core.prompts.prompt import PromptTemplate
 from langchain_core.prompts.string import PromptTemplateFormat
 from langchain_core.tracers.run_collector import RunCollectorCallbackHandler
@@ -744,3 +746,24 @@ def test_prompt_template_add(
         variable="template",
         another_variable="other_template",
     )
+
+
+def test_format_document_page_content_precedence() -> None:
+    doc = Document(
+        page_content="Hello world",
+        metadata={"page_content": "OVERRIDDEN", "author": "Alice"},
+    )
+    prompt = PromptTemplate.from_template("Author: {author}, Content: {page_content}")
+    result = format_document(doc, prompt)
+    assert result == "Author: Alice, Content: Hello world"
+
+
+@pytest.mark.asyncio
+async def test_aformat_document_page_content_precedence() -> None:
+    doc = Document(
+        page_content="Hello world",
+        metadata={"page_content": "OVERRIDDEN", "author": "Alice"},
+    )
+    prompt = PromptTemplate.from_template("Author: {author}, Content: {page_content}")
+    result = await aformat_document(doc, prompt)
+    assert result == "Author: Alice, Content: Hello world"


### PR DESCRIPTION
### Summary

Fixes #40075

In `_get_document_info()` (`libs/core/langchain_core/prompts/base.py`), `base_info` was previously constructed as:
```python
base_info = {"page_content": doc.page_content, **doc.metadata}
```
Because `**doc.metadata` was unpacked after `"page_content"`, any metadata dictionary containing a `"page_content"` key (e.g. from loaders embedding chunk fields) unintentionally overwrote `doc.page_content`.

This PR updates the unpacking order to:
```python
base_info = {**doc.metadata, "page_content": doc.page_content}
```
ensuring that `doc.page_content` is always the authoritative source for the `{page_content}` template variable while preserving all other metadata attributes.

### Changes
- Updated `_get_document_info` in `libs/core/langchain_core/prompts/base.py`.
- Added unit test coverage in `libs/core/tests/unit_tests/prompts/test_prompt.py` for both `format_document` and `aformat_document` when `page_content` exists in `doc.metadata`.
- Verified formatting and linting with `ruff`.