### PR TITLE
fix(huggingface): support translation_xx_to_yy tasks in HuggingFacePipeline

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
+++ b/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
@@ -29,6 +29,15 @@ VALID_TASKS = (
     "summarization",
     "translation",
 )
+
+
+def _is_valid_task(task: str) -> bool:
+    """Check if task is supported (including language-specific translation tasks)."""
+    return task in VALID_TASKS or (
+        isinstance(task, str) and task.startswith("translation")
+    )
+
+
 DEFAULT_BATCH_SIZE = 4
 _MIN_OPTIMUM_VERSION = "1.21"
 
@@ -159,7 +168,7 @@ class HuggingFacePipeline(BaseLLM):
         tokenizer = AutoTokenizer.from_pretrained(model_id, **_model_kwargs)
 
         if backend in {"openvino", "ipex"}:
-            if task not in VALID_TASKS:
+            if not _is_valid_task(task):
                 msg = (
                     f"Got invalid task {task}, "
                     f"currently only {VALID_TASKS} are supported"
@@ -293,7 +302,7 @@ class HuggingFacePipeline(BaseLLM):
             model_kwargs=_model_kwargs,
             **_pipeline_kwargs,
         )
-        if pipeline.task not in VALID_TASKS:
+        if not _is_valid_task(pipeline.task):
             msg = (
                 f"Got invalid task {pipeline.task}, "
                 f"currently only {VALID_TASKS} are supported"
@@ -356,7 +365,10 @@ class HuggingFacePipeline(BaseLLM):
                     text = response["generated_text"]
                 elif self.pipeline.task == "summarization":
                     text = response["summary_text"]
-                elif self.pipeline.task in "translation":
+                elif self.pipeline.task == "translation" or (
+                    isinstance(self.pipeline.task, str)
+                    and self.pipeline.task.startswith("translation")
+                ):
                     text = response["translation_text"]
                 else:
                     msg = (

--- a/libs/partners/huggingface/tests/unit_tests/test_huggingface_pipeline.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_huggingface_pipeline.py
@@ -45,3 +45,24 @@ def test_initialization_with_from_model_id(
     )
 
     assert llm.model_id == "mock-model-id"
+
+
+def test_generate_translation_pipeline() -> None:
+    """Test _generate with translation and language-specific translation pipelines."""
+    mock_pipe = MagicMock()
+    mock_pipe.task = "translation_en_to_fr"
+    mock_pipe.model.name_or_path = "mock-translation-model"
+    mock_pipe.return_value = [{"translation_text": "Bonjour le monde"}]
+
+    llm = HuggingFacePipeline(pipeline=mock_pipe)
+    result = llm._generate(["Hello world"])
+    assert result.generations[0][0].text == "Bonjour le monde"
+
+    mock_pipe_generic = MagicMock()
+    mock_pipe_generic.task = "translation"
+    mock_pipe_generic.model.name_or_path = "mock-translation-model"
+    mock_pipe_generic.return_value = [{"translation_text": "Hola mundo"}]
+
+    llm_generic = HuggingFacePipeline(pipeline=mock_pipe_generic)
+    result_generic = llm_generic._generate(["Hello world"])
+    assert result_generic.generations[0][0].text == "Hola mundo"


### PR DESCRIPTION
### Summary

Fixes #40095

In `HuggingFacePipeline._generate()` (`libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py`), translation tasks were checked using:
```python
elif self.pipeline.task in "translation":
    text = response["translation_text"]
```
This was a string substring check that caused transformers pipelines with language-specific task names (such as `translation_en_to_fr`, `translation_en_to_de`, etc.) to fail with a `ValueError: Got invalid task translation_en_to_fr`. In addition, `from_model_id` previously rejected valid language-specific translation task strings.

### Solution
- Added `_is_valid_task()` helper to accept `VALID_TASKS` and `translation_*` tasks.
- Updated `_generate()` to check `self.pipeline.task == "translation" or self.pipeline.task.startswith("translation")`.
- Added unit test coverage in `libs/partners/huggingface/tests/unit_tests/test_huggingface_pipeline.py` verifying both generic `translation` and language-specific `translation_en_to_fr` pipelines.
- Formatted and linted with `ruff`.