### PR TITLE
fix(core): support plus (+) bullet items in MarkdownListOutputParser

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -221,7 +221,7 @@ class NumberedListOutputParser(ListOutputParser):
 class MarkdownListOutputParser(ListOutputParser):
     """Parse a Markdown list."""
 
-    pattern: str = r"^\s*[-*]\s([^\n]+)$"
+    pattern: str = r"^\s*[-*+]\s([^\n]+)$"
     """The pattern to match a Markdown list item."""
 
     @override

--- a/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
@@ -136,10 +136,13 @@ def test_markdown_list() -> None:
 
     text3 = "No items in the list."
 
+    text4 = "Items:\n+ apple\n     + banana\n+ cherry"
+
     for text, expected in [
         (text1, ["foo", "bar", "baz"]),
         (text2, ["apple", "banana", "cherry"]),
         (text3, []),
+        (text4, ["apple", "banana", "cherry"]),
     ]:
         expectedlist = [[a] for a in expected]
         assert parser.parse(text) == expected


### PR DESCRIPTION
Fixes #40057

### Summary
Standard Markdown unordered lists support `-`, `*`, and `+` bullet markers.
Previously, `MarkdownListOutputParser.pattern` only checked for `[-*]`, failing on lists generated with `+` bullets.

### Fix
- Updated `MarkdownListOutputParser.pattern` in `libs/core/langchain_core/output_parsers/list.py` to `r"^\s*[-*+]\s([^\n]+)$"`.
- Added test case in `libs/core/tests/unit_tests/output_parsers/test_list_parser.py`.