### PR TITLE
fix(core): copy block before popping index in Anthropic content translator

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/anthropic.py
+++ b/libs/core/langchain_core/messages/block_translators/anthropic.py
@@ -484,12 +484,17 @@ def _convert_to_v1_from_anthropic(message: AIMessage) -> list[types.ContentBlock
                 yield server_tool_result
 
             else:
-                new_block: types.NonStandardContentBlock = {
-                    "type": "non_standard",
-                    "value": block,
-                }
-                if "index" in new_block["value"]:
-                    new_block["index"] = new_block["value"].pop("index")
+                if "index" in block:
+                    # Copy before lifting `index` off the block.
+                    value = block.copy()
+                    index = value.pop("index")
+                    new_block: types.NonStandardContentBlock = {
+                        "type": "non_standard",
+                        "value": value,
+                        "index": index,
+                    }
+                else:
+                    new_block = {"type": "non_standard", "value": block}
                 yield new_block
 
     return list(_iter_blocks())

--- a/libs/core/tests/unit_tests/messages/block_translators/test_anthropic.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_anthropic.py
@@ -572,3 +572,23 @@ def test_convert_to_v1_from_anthropic_malformed_citations() -> None:
             ],
         },
     ]
+
+
+def test_non_standard_block_does_not_mutate_message_content() -> None:
+    from copy import deepcopy
+
+    message = AIMessage(
+        content=[{"type": "custom", "payload": "value", "index": 3}],
+        response_metadata={"model_provider": "anthropic"},
+    )
+    original = deepcopy(message.content)
+    blocks = message.content_blocks
+    assert blocks == [
+        {
+            "type": "non_standard",
+            "value": {"type": "custom", "payload": "value"},
+            "index": 3,
+        }
+    ]
+    assert message.content == original
+


### PR DESCRIPTION
Fixes #40077

### Problem
In `_convert_to_v1_from_anthropic`, the fallback `else` branch for unrecognized content block types previously assigned the original `block` dict directly to `new_block["value"]`. When `index` was present, `new_block["value"].pop("index")` mutated `block` in place, deleting the `index` key from the stored `message.content` as a side effect of accessing the read-only `.content_blocks` property.

### Fix
- Updated `_convert_to_v1_from_anthropic` in `libs/core/langchain_core/messages/block_translators/anthropic.py` to copy the block before popping `index` (`value = block.copy()`), matching the existing pattern in `bedrock_converse.py`.
- Added unit test `test_non_standard_block_does_not_mutate_message_content` in `libs/core/tests/unit_tests/messages/block_translators/test_anthropic.py` to verify `message.content` remains unmodified.