### PR TITLE
fix(openai): route `gpt-5.6-sol` to responses API

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -695,6 +695,7 @@ _RESPONSES_API_ONLY_PREFIXES = (
     "gpt-5.2-pro",
     "gpt-5.4-pro",
     "gpt-5.5-pro",
+    "gpt-5.6-sol",
 )
 
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4616,13 +4616,15 @@ def test_gpt_5_1_temperature_with_reasoning_effort_none(
 
 
 def test_model_prefers_responses_api() -> None:
-    # Pro models (with and without date snapshots): Responses API only
+    # Pro and Sol models (with and without date snapshots): Responses API only
     assert _model_prefers_responses_api("gpt-5-pro")
     assert _model_prefers_responses_api("gpt-5-pro-2025-10-06")
     assert _model_prefers_responses_api("gpt-5.2-pro")
     assert _model_prefers_responses_api("gpt-5.2-pro-2025-12-11")
     assert _model_prefers_responses_api("gpt-5.4-pro")
     assert _model_prefers_responses_api("gpt-5.4-pro-2026-03-05")
+    assert _model_prefers_responses_api("gpt-5.6-sol")
+    assert _model_prefers_responses_api("gpt-5.6-sol-2026-09-01")
     # Codex models: Responses API only
     assert _model_prefers_responses_api("gpt-5.3-codex")
     assert _model_prefers_responses_api("gpt-5.3-codex")


### PR DESCRIPTION
`ChatOpenAI` recognized `gpt-5.6-sol` as a reasoning model but did not infer that it requires the Responses API. Requests using function tools and reasoning were therefore sent to Chat Completions and rejected by OpenAI.

This adds `gpt-5.6-sol` and its dated snapshots to the Responses-only model inference, with focused unit coverage.

Made by [Open SWE](https://openswe.vercel.app/agents/2eaa47e3-35c8-5a06-b3af-ad8671c0b584)