### PR TITLE
fix(openai): route GPT-5.6 family to responses API

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -695,7 +695,7 @@ _RESPONSES_API_ONLY_PREFIXES = (
     "gpt-5.2-pro",
     "gpt-5.4-pro",
     "gpt-5.5-pro",
-    "gpt-5.6-sol",
+    "gpt-5.6",
 )
 
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4616,15 +4616,18 @@ def test_gpt_5_1_temperature_with_reasoning_effort_none(
 
 
 def test_model_prefers_responses_api() -> None:
-    # Pro and Sol models (with and without date snapshots): Responses API only
+    # Pro and GPT-5.6 models (with and without snapshots): Responses API only
     assert _model_prefers_responses_api("gpt-5-pro")
     assert _model_prefers_responses_api("gpt-5-pro-2025-10-06")
     assert _model_prefers_responses_api("gpt-5.2-pro")
     assert _model_prefers_responses_api("gpt-5.2-pro-2025-12-11")
     assert _model_prefers_responses_api("gpt-5.4-pro")
     assert _model_prefers_responses_api("gpt-5.4-pro-2026-03-05")
+    assert _model_prefers_responses_api("gpt-5.6")
     assert _model_prefers_responses_api("gpt-5.6-sol")
     assert _model_prefers_responses_api("gpt-5.6-sol-2026-09-01")
+    assert _model_prefers_responses_api("gpt-5.6-terra")
+    assert _model_prefers_responses_api("gpt-5.6-luna")
     # Codex models: Responses API only
     assert _model_prefers_responses_api("gpt-5.3-codex")
     assert _model_prefers_responses_api("gpt-5.3-codex")


### PR DESCRIPTION
OpenAI's GPT-5.6 guidance states that function tools with reasoning should use the Responses API across the model family. The earlier fix covered only Sol, leaving the `gpt-5.6` alias, Terra, and Luna susceptible to Chat Completions errors at their default reasoning effort.

This broadens model inference to the GPT-5.6 family and adds focused coverage for every variant.

Made by [Open SWE](https://openswe.vercel.app/agents/2eaa47e3-35c8-5a06-b3af-ad8671c0b584)