### PR TITLE
fix(langchain): allow the first `before_model` hook to jump to the model

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -2076,7 +2076,10 @@ def _add_middleware_edge(
             destinations.append(end_destination)
         if "tools" in can_jump_to:
             destinations.append("tools")
-        if "model" in can_jump_to and name != model_destination:
+        if "model" in can_jump_to and model_destination not in destinations:
+            # `model_destination` is the loop entry node, which is this very node
+            # when it is the first `before_model` hook. The router can still return
+            # it, so the self-edge has to be declared.
             destinations.append(model_destination)
 
         graph.add_conditional_edges(name, RunnableCallable(jump_edge, trace=False), destinations)

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_framework.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_framework.py
@@ -193,6 +193,52 @@ def test_create_agent_synthetic_tool_messages_reroute_to_model() -> None:
     )
 
 
+def test_before_model_can_jump_to_model() -> None:
+    """The first `before_model` hook may send `jump_to="model"`.
+
+    The model loop is entered at the first `before_model` node, so that hook's
+    `"model"` jump resolves to its own node name. Leaving that self-destination
+    out of the conditional edge's path map made LangGraph raise a bare
+    `KeyError` naming the node, with nothing pointing back at the middleware.
+    """
+    calls: list[str] = []
+
+    class RestartOnceMiddleware(AgentMiddleware):
+        @hook_config(can_jump_to=["model"])
+        @override
+        def before_model(self, state: AgentState[Any], runtime: Runtime) -> dict[str, Any] | None:
+            calls.append("before_model")
+            # Re-enter the loop once, then fall through to the model.
+            if len(calls) == 1:
+                return {"jump_to": "model"}
+            return None
+
+    @tool
+    def my_tool(value: str) -> str:
+        """A great tool."""
+        return value.upper()
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [ToolCall(id="1", name="my_tool", args={"value": "yo"})],
+                [],
+            ],
+        ),
+        tools=[my_tool],
+        middleware=[RestartOnceMiddleware()],
+    )
+
+    result = agent.invoke({"messages": [HumanMessage(content="hello")]})
+
+    # The jump re-runs the hook, so it is entered once more than the two model calls.
+    assert len(calls) == 3
+    assert any(
+        isinstance(message, ToolMessage) and message.tool_call_id == "1"
+        for message in result["messages"]
+    )
+
+
 def test_create_agent_jump(
     snapshot: SnapshotAssertion,
     sync_checkpointer: BaseCheckpointSaver[str],


### PR DESCRIPTION
Closes #40136

---

`JumpTo` allows `"model"` from any middleware hook, but a `before_model` hook that returns `{"jump_to": "model"}` crashes the agent with a bare `KeyError` naming its own graph node, raised from inside LangGraph while it resolves the conditional edge. Anyone writing a guardrail or validation middleware that rewrites state and wants the pre-model pipeline re-run hits this, and the error mentions neither the middleware nor `can_jump_to`, so there is nothing to search for. The identical `"model"` jump from `after_model` or `before_agent` works, as does the same hook when another `before_model` middleware precedes it — only the hook that happens to be the loop entry node breaks.

The model loop is entered at the first `before_model` node, so for that node `model_destination` is its own name, and the `name != model_destination` guard in `_add_middleware_edge` dropped it from the edge's path map while the router still resolved `"model"` to it. This declares the self-destination instead. The `not in destinations` form is a tidy-up rather than a requirement: for the last `before_agent` node `default_destination` already *is* `model_destination`, so the old guard appended it a second time and declared `['model', 'model']` there. `Branch` turns a list path map into `{name: name for name in path_map}`, so that duplicate was always inert — dropping it leaves the compiled path map identical. A bare `if "model" in can_jump_to:` would work equally well; the compiled graph is unchanged for every node except the first `before_model` hook either way, and no routing decision is altered — only which destinations the graph is told to expect.

Worth stating outright, because the `KeyError` never did: `"model"` resolves to the loop *entry* node, which is the first `before_model` hook itself. A hook that returns the jump unconditionally therefore re-enters itself until the recursion limit — exactly the shape any non-first hook has always had, and the reason the jump has to be conditional.

Each regression test fails on the parent commit with exactly the `KeyError` above and passes with the fix, including against deliberately wrong fixes (appending the literal `"model"`, appending the end destination, or falling through to the default destination). Applying the implementation change alone leaves the existing suite at its previous count, so the change adds no behaviour beyond the fix.

## Release note

A `before_model` middleware hook declared with `can_jump_to=["model"]` can now actually return `{"jump_to": "model"}` to re-enter the model loop; previously this raised a `KeyError` from the graph when the hook was the first `before_model` middleware. `"model"` resolves to the loop entry node, so from the first `before_model` hook the jump re-enters that hook and must be conditional.

---

*This contribution was prepared with AI assistance.*
