### PR TITLE
fix(langchain): correct `InterruptOnConfig` documentation

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -166,7 +166,7 @@ class InterruptOnConfig(TypedDict):
     Example:
         ```python
         # Static string description
-        config = ToolConfig(
+        config = InterruptOnConfig(
             allowed_decisions=["approve", "reject"],
             description="Please review this tool execution"
         )
@@ -196,12 +196,14 @@ class InterruptOnConfig(TypedDict):
     """Optional predicate controlling whether to interrupt for a given tool call.
 
     Receives a `ToolCallRequest` and returns `True` to interrupt or `False` to
-    auto-approve. Works in both `"batch"` and `"per_call"` modes.
+    auto-approve. The predicate is called during `after_model` before the tool
+    call is added to the batched human-in-the-loop request.
 
-    In `"batch"` mode the request is constructed with `tool=None` and
-    `runtime` set to the node-level `Runtime` (not a `ToolRuntime`), so
-    `request.runtime.tool_call_id` and `request.runtime.tools` are not available.
-    In `"per_call"` mode the full `ToolCallRequest` from `wrap_tool_call` is passed.
+    The request is constructed with `tool=None` and a new `ToolRuntime`. The
+    `ToolRuntime` copies `context`, `store`, `stream_writer`, `execution_info`,
+    and `server_info` from the node-level `Runtime`, while `tool_call_id` is
+    populated from the current tool call. The `tools` argument is not supplied,
+    so it uses its default empty list.
 
     Example:
         ```python

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
@@ -1124,6 +1124,7 @@ def test_when_predicate_receives_correct_args() -> None:
     assert req.state is state
     assert isinstance(req.runtime, ToolRuntime)
     assert req.runtime.tool_call_id == "tc-1"
+    assert req.runtime.tools == []
     assert req.runtime.state is state
     assert req.runtime.context is runtime.context
     assert req.runtime.store is runtime.store


### PR DESCRIPTION
Fixes #40139

Correct the `InterruptOnConfig` examples and `when` predicate documentation so users see the actual public API and request shape: `runtime` is a new `ToolRuntime`, `tool_call_id` is populated, and `tools` defaults to an empty list. The existing request-shape test now also asserts the documented `runtime.tools` value; no runtime behavior changes.

Verified with `make format`, `make lint`, and the focused human-in-the-loop middleware test file (30 passed).

> This PR was developed with AI-agent assistance.