### PR TITLE
fix(text-splitters): preserve whitespace in fenced code blocks

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/markdown.py
+++ b/libs/text-splitters/langchain_text_splitters/markdown.py
@@ -178,7 +178,7 @@ class MarkdownHeaderTextSplitter:
                 opening_fence = ""
 
             if in_code_block:
-                current_content.append(stripped_line)
+                current_content.append(line)
                 continue
 
             # Check each line against each of the header types (e.g., #, ##)

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -1461,6 +1461,29 @@ def test_md_header_text_splitter_1() -> None:
     ]
     assert output == expected_output
 
+def test_md_header_text_splitter_preserves_whitespace_in_code_blocks() -> None:
+    """Test that tabs and NBSP inside fenced code blocks are preserved.
+
+    Regression test for #40071: MarkdownHeaderTextSplitter was silently
+    stripping tabs and non-breaking spaces (NBSP) from lines inside fenced
+    code blocks, corrupting code formatting.
+    """
+    markdown_document = (
+        "# Title\n"
+        "```\n"
+        "\tindented\xa0line\n"
+        "```\n"
+    )
+    headers_to_split_on = [("#", "Header 1")]
+    markdown_splitter = MarkdownHeaderTextSplitter(
+        headers_to_split_on=headers_to_split_on
+    )
+    output = markdown_splitter.split_text(markdown_document)
+
+    assert len(output) == 1
+    content = output[0].page_content
+    assert "\t" in content, "Tab character was stripped from code block"
+    assert "\xa0" in content, "NBSP character was stripped from code block"
 
 def test_md_header_text_splitter_2() -> None:
     """Test markdown splitter by header: Case 2."""


### PR DESCRIPTION
## Description

`MarkdownHeaderTextSplitter.split_text()` was appending `stripped_line`
(a whitespace-stripped, printable-character-filtered version of each line)
to code block content, instead of the original `line`. This silently
dropped leading/trailing whitespace, tabs, and non-breaking spaces (NBSP)
from inside fenced code blocks, corrupting formatting that's semantically
meaningful in code.

## Fix

Changed the code block branch to append the original `line` instead of
`stripped_line`, preserving whitespace exactly as written.

## Testing

Added a regression test,
`test_md_header_text_splitter_preserves_whitespace_in_code_blocks`,
verifying that a tab and NBSP inside a fenced code block survive splitting.
Full test suite passes: 150 passed, 4 skipped (was 149 passed, 4 skipped
before the new test was added).

Fixes #40071