### PR TITLE
fix(core): enforce mime_type requirement in create_image_block

### DIFF
--- a/libs/core/langchain_core/messages/content.py
+++ b/libs/core/langchain_core/messages/content.py
@@ -1034,6 +1034,10 @@ def create_image_block(
         msg = "Must provide one of: url, base64, or file_id"
         raise ValueError(msg)
 
+    if base64 and not mime_type:
+        msg = "mime_type is required when using base64 data"
+        raise ValueError(msg)
+
     block = ImageContentBlock(type="image", id=ensure_id(id))
 
     if url is not None:

--- a/libs/core/tests/unit_tests/messages/test_content_blocks.py
+++ b/libs/core/tests/unit_tests/messages/test_content_blocks.py
@@ -1,0 +1,42 @@
+from collections.abc import Callable
+
+import pytest
+
+from langchain_core.messages import content as types
+
+BlockFactory = Callable[..., dict]
+
+CREATE_CASES = [
+    pytest.param("image", types.create_image_block, id="image"),
+    pytest.param("video", types.create_video_block, id="video"),
+    pytest.param("audio", types.create_audio_block, id="audio"),
+    pytest.param("file", types.create_file_block, id="file"),
+]
+
+MIME_TYPES = {
+    "image": "image/png",
+    "video": "video/mp4",
+    "audio": "audio/mpeg",
+    "file": "application/pdf",
+}
+
+
+@pytest.mark.parametrize(("_type", "factory"), CREATE_CASES)
+def test_base64_without_mime_type_raises(_type: str, factory: BlockFactory) -> None:
+    msg = "mime_type is required when using base64 data"
+    with pytest.raises(ValueError, match=msg):
+        factory(base64="aGVsbG8=")
+
+
+@pytest.mark.parametrize(("_type", "factory"), CREATE_CASES)
+def test_base64_with_mime_type(_type: str, factory: BlockFactory) -> None:
+    block = factory(base64="aGVsbG8=", mime_type=MIME_TYPES[_type])
+    assert block["base64"] == "aGVsbG8="
+    assert block["mime_type"] == MIME_TYPES[_type]
+
+
+@pytest.mark.parametrize(("_type", "factory"), CREATE_CASES)
+def test_no_source_raises(_type: str, factory: BlockFactory) -> None:
+    msg = "Must provide one of: url, base64, or file_id"
+    with pytest.raises(ValueError, match=msg):
+        factory()


### PR DESCRIPTION
Fixes #39799

---

The docstring for `create_image_block` documented that a `ValueError` is raised when `base64` is used without `mime_type`, but the validation was missing. The three sibling functions (`create_video_block`, `create_audio_block`, `create_file_block`) all enforce this -- now `create_image_block` does too.

Added symmetric unit tests covering all four factories: base64 without `mime_type` raises, base64 with `mime_type` succeeds, and no source raises.