### PR TITLE
fix(core): support plus (+) bullets in MarkdownListOutputParser

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -221,7 +221,7 @@ class NumberedListOutputParser(ListOutputParser):
 class MarkdownListOutputParser(ListOutputParser):
     """Parse a Markdown list."""
 
-    pattern: str = r"^\s*[-*]\s([^\n]+)$"
+    pattern: str = r"^\s*[-*+]\s([^\n]+)$"
     """The pattern to match a Markdown list item."""
 
     @override

--- a/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
@@ -136,10 +136,13 @@ def test_markdown_list() -> None:
 
     text3 = "No items in the list."
 
+    text4 = "+ item 1\n+ item 2"
+
     for text, expected in [
         (text1, ["foo", "bar", "baz"]),
         (text2, ["apple", "banana", "cherry"]),
         (text3, []),
+        (text4, ["item 1", "item 2"]),
     ]:
         expectedlist = [[a] for a in expected]
         assert parser.parse(text) == expected


### PR DESCRIPTION
Fixes #40057

`MarkdownListOutputParser` used the pattern `r"^\s*[-*]\s([^\n]+)$"`, which missed `+` — a valid CommonMark unordered-list bullet alongside `-` and `*`. Callers using LLM output with plus-style lists got an empty result silently. Adding `+` to the character class (`[-*+]`) fixes this. One new test case added.

## Release note

**Fix**: `MarkdownListOutputParser` now correctly parses lists that use `+` as the bullet character, in addition to `-` and `*`.

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.