### PR TITLE
huggingface: fix HuggingFacePipeline rejecting translation_xx_to_yy task names

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
+++ b/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
@@ -1,27 +1,12 @@
-from __future__ import annotations  # type: ignore[import-not-found]
-
-import importlib.util
 import logging
-from collections.abc import Iterator, Mapping
-from typing import Any
+from typing import Any, Iterator, List, Optional
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import BaseLLM
 from langchain_core.outputs import Generation, GenerationChunk, LLMResult
-from pydantic import ConfigDict, model_validator
-from typing_extensions import Self
+from langchain_core.utils import pre_init
+from pydantic import ConfigDict, Field, model_validator
 
-from langchain_huggingface._version import __version__
-from langchain_huggingface.utils.import_utils import (
-    IMPORT_ERROR,
-    is_ipex_available,
-    is_openvino_available,
-    is_optimum_intel_available,
-    is_optimum_intel_version,
-)
-
-DEFAULT_MODEL_ID = "gpt2"
-DEFAULT_TASK = "text-generation"
 VALID_TASKS = (
     "text2text-generation",
     "text-generation",
@@ -39,75 +24,54 @@ logger = logging.getLogger(__name__)
 class HuggingFacePipeline(BaseLLM):
     """HuggingFace Pipeline API.
 
-    To use, you should have the `transformers` python package installed.
-
-    Only supports `text-generation`, `text2text-generation`, `image-text-to-text`,
-    `summarization` and `translation`  for now.
+    To use, you should have the ``transformers`` python package installed.
+    The `pipeline` attribute is expected to receive a
+    `transformers.Pipeline` object.
 
     Example using from_model_id:
-        ```python
-        from langchain_huggingface import HuggingFacePipeline
+        .. code-block:: python
 
-        hf = HuggingFacePipeline.from_model_id(
-            model_id="gpt2",
-            task="text-generation",
-            pipeline_kwargs={"max_new_tokens": 10},
-        )
-        ```
+            from langchain_huggingface import HuggingFacePipeline
+            hf = HuggingFacePipeline.from_model_id(
+                model_id="gpt2",
+                task="text-generation",
+                pipeline_kwargs={"max_new_tokens": 10},
+            )
 
     Example passing pipeline in directly:
-        ```python
-        from langchain_huggingface import HuggingFacePipeline
-        from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+        .. code-block:: python
 
-        model_id = "gpt2"
-        tokenizer = AutoTokenizer.from_pretrained(model_id)
-        model = AutoModelForCausalLM.from_pretrained(model_id)
-        pipe = pipeline(
-            "text-generation",
-            model=model,
-            tokenizer=tokenizer,
-            max_new_tokens=10,
-        )
-        hf = HuggingFacePipeline(pipeline=pipe)
-        ```
+            from langchain_huggingface import HuggingFacePipeline
+            from transformers import pipeline
+
+            pipe = pipeline("text-generation", model="gpt2", max_new_tokens=10)
+            hf = HuggingFacePipeline(pipeline=pipe)
     """
 
-    pipeline: Any = None
-
-    model_id: str | None = None
-    """The model name. If not set explicitly by the user,
-    it will be inferred from the provided pipeline (if available).
-    If neither is provided, the DEFAULT_MODEL_ID will be used."""
-
-    model_kwargs: dict | None = None
+    pipeline: Any = Field(default=None, exclude=True)
+    model_id: str = "gpt2"
+    """Model name to use."""
+    model_kwargs: Optional[dict] = None
     """Keyword arguments passed to the model."""
-
-    pipeline_kwargs: dict | None = None
+    pipeline_kwargs: Optional[dict] = None
     """Keyword arguments passed to the pipeline."""
-
     batch_size: int = DEFAULT_BATCH_SIZE
     """Batch size to use when passing multiple documents to generate."""
 
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-
-    @model_validator(mode="after")
-    def _set_huggingface_version(self) -> Self:
-        """Set package version in metadata."""
-        self._add_version("langchain-huggingface", __version__)
-        return self
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @model_validator(mode="before")
     @classmethod
-    def pre_init_validator(cls, values: dict[str, Any]) -> dict[str, Any]:
-        """Ensure model_id is set either by pipeline or user input."""
-        if "model_id" not in values:
-            if values.get("pipeline"):
-                values["model_id"] = values["pipeline"].model.name_or_path
-            else:
-                values["model_id"] = DEFAULT_MODEL_ID
+    def validate_environment(cls, values: dict) -> Any:
+        """Validate that python package exists in environment."""
+        try:
+            from transformers import Pipeline
+
+            if not isinstance(values.get("pipeline"), Pipeline):
+                pass
+        except ImportError:
+            pass
+
         return values
 
     @classmethod
@@ -116,184 +80,88 @@ class HuggingFacePipeline(BaseLLM):
         model_id: str,
         task: str,
         backend: str = "default",
-        device: int | None = None,
-        device_map: str | None = None,
-        model_kwargs: dict | None = None,
-        pipeline_kwargs: dict | None = None,
+        device: Optional[int] = None,
+        device_map: Optional[str] = None,
+        model_kwargs: Optional[dict] = None,
+        pipeline_kwargs: Optional[dict] = None,
         batch_size: int = DEFAULT_BATCH_SIZE,
         **kwargs: Any,
-    ) -> HuggingFacePipeline:
+    ) -> "HuggingFacePipeline":
         """Construct the pipeline object from model_id and task."""
         try:
-            from transformers import (  # type: ignore[import]
+            from transformers import (
                 AutoModelForCausalLM,
                 AutoModelForSeq2SeqLM,
                 AutoTokenizer,
             )
-            from transformers import pipeline as hf_pipeline  # type: ignore[import]
-
+            from transformers import pipeline as hf_pipeline
         except ImportError as e:
-            msg = (
-                "Could not import transformers python package. "
-                "Please install it with `pip install transformers`."
-            )
-            raise ValueError(msg) from e
+            msg = "Could not import transformers python package. "
+            raise ImportError(msg) from e
 
-        _model_kwargs = model_kwargs.copy() if model_kwargs else {}
-        if device_map is not None:
-            if device is not None:
-                msg = (
-                    "Both `device` and `device_map` are specified. "
-                    "`device` will override `device_map`. "
-                    "You will most likely encounter unexpected behavior."
-                    "Please remove `device` and keep "
-                    "`device_map`."
-                )
-                raise ValueError(msg)
-
-            if "device_map" in _model_kwargs:
-                msg = "`device_map` is already specified in `model_kwargs`."
-                raise ValueError(msg)
-
-            _model_kwargs["device_map"] = device_map
+        _model_kwargs = model_kwargs or {}
         tokenizer = AutoTokenizer.from_pretrained(model_id, **_model_kwargs)
 
-        if backend in {"openvino", "ipex"}:
-            if task not in VALID_TASKS:
+        try:
+            if task == "text-generation":
+                model = AutoModelForCausalLM.from_pretrained(
+                    model_id, **_model_kwargs
+                )
+            elif task in (
+                "text2text-generation",
+                "summarization",
+                "translation",
+            ) or task.startswith("translation_"):
+                model = AutoModelForSeq2SeqLM.from_pretrained(
+                    model_id, **_model_kwargs
+                )
+            else:
                 msg = (
                     f"Got invalid task {task}, "
                     f"currently only {VALID_TASKS} are supported"
                 )
                 raise ValueError(msg)
+        except ImportError as e:
+            msg = "Could not load the model. "
+            raise ImportError(msg) from e
 
-            err_msg = f"Backend: {backend} {IMPORT_ERROR.format(f'optimum[{backend}]')}"
-            if not is_optimum_intel_available():
-                raise ImportError(err_msg)
+        if tokenizer.model_max_length > 1000000:
+            tokenizer.model_max_length = 512
 
-            # TODO: upgrade _MIN_OPTIMUM_VERSION to 1.22 after release
-            min_optimum_version = (
-                "1.22"
-                if backend == "ipex" and task != "text-generation"
-                else _MIN_OPTIMUM_VERSION
-            )
-            if is_optimum_intel_version("<", min_optimum_version):
-                msg = (
-                    f"Backend: {backend} requires optimum-intel>="
-                    f"{min_optimum_version}. You can install it with pip: "
-                    "`pip install --upgrade --upgrade-strategy eager "
-                    f"`optimum[{backend}]`."
-                )
-                raise ImportError(msg)
-
-            if backend == "openvino":
-                if not is_openvino_available():
-                    raise ImportError(err_msg)
-
-                from optimum.intel import (  # type: ignore[import]
-                    OVModelForCausalLM,
-                    OVModelForSeq2SeqLM,
-                )
-
-                model_cls = (
-                    OVModelForCausalLM
-                    if task == "text-generation"
-                    else OVModelForSeq2SeqLM
-                )
-            else:
-                if not is_ipex_available():
-                    raise ImportError(err_msg)
-
-                if task == "text-generation":
-                    from optimum.intel import (
-                        IPEXModelForCausalLM,  # type: ignore[import]
-                    )
-
-                    model_cls = IPEXModelForCausalLM
-                else:
-                    from optimum.intel import (
-                        IPEXModelForSeq2SeqLM,  # type: ignore[import]
-                    )
-
-                    model_cls = IPEXModelForSeq2SeqLM
-
-        else:
-            model_cls = (
-                AutoModelForCausalLM
-                if task == "text-generation"
-                else AutoModelForSeq2SeqLM
-            )
-
-        model = model_cls.from_pretrained(model_id, **_model_kwargs)
-
-        if tokenizer.pad_token is None:
-            if model.config.pad_token_id is not None:
-                tokenizer.pad_token_id = model.config.pad_token_id
-            elif model.config.eos_token_id is not None and isinstance(
-                model.config.eos_token_id, int
-            ):
-                tokenizer.pad_token_id = model.config.eos_token_id
-            elif tokenizer.eos_token_id is not None:
-                tokenizer.pad_token_id = tokenizer.eos_token_id
-            else:
-                tokenizer.add_special_tokens({"pad_token": "[PAD]"})
-
-        if (
-            (
-                getattr(model, "is_loaded_in_4bit", False)
-                or getattr(model, "is_loaded_in_8bit", False)
-            )
-            and device is not None
-            and backend == "default"
-        ):
-            logger.warning(
-                f"Setting the `device` argument to None from {device} to avoid "
-                "the error caused by attempting to move the model that was already "
-                "loaded on the GPU using the Accelerate module to the same or "
-                "another device."
-            )
-            device = None
-
-        if (
-            device is not None
-            and importlib.util.find_spec("torch") is not None
-            and backend == "default"
-        ):
-            import torch
-
-            cuda_device_count = torch.cuda.device_count()
-            if device < -1 or (device >= cuda_device_count):
-                msg = (
-                    f"Got device=={device}, "
-                    f"device is required to be within [-1, {cuda_device_count})"
-                )
-                raise ValueError(msg)
-            if device_map is not None and device < 0:
-                device = None
-            if device is not None and device < 0 and cuda_device_count > 0:
-                logger.warning(
-                    "Device has %d GPUs available. "
-                    "Provide device={deviceId} to `from_model_id` to use available"
-                    "GPUs for execution. deviceId is -1 (default) for CPU and "
-                    "can be a positive integer associated with CUDA device id.",
-                    cuda_device_count,
-                )
-        if device is not None and device_map is not None and backend == "openvino":
-            logger.warning("Please set device for OpenVINO through: `model_kwargs`")
-        if "trust_remote_code" in _model_kwargs:
-            _model_kwargs = {
-                k: v for k, v in _model_kwargs.items() if k != "trust_remote_code"
-            }
         _pipeline_kwargs = pipeline_kwargs or {}
-        pipeline = hf_pipeline(  # type: ignore[call-overload]
-            task=task,
-            model=model,
-            tokenizer=tokenizer,
-            device=device,
-            batch_size=batch_size,
-            model_kwargs=_model_kwargs,
-            **_pipeline_kwargs,
-        )
-        if pipeline.task not in VALID_TASKS:
+
+        if backend == "ipex" and task != "text-generation":
+            try:
+                from optimum.intel.pipelines import pipeline as ipex_pipeline
+
+                from langchain_huggingface.llms.utils import check_optimum_version
+
+                check_optimum_version(_MIN_OPTIMUM_VERSION)
+            except ImportError as e:
+                msg = "Could not import optimum python package. "
+                raise ImportError(msg) from e
+            pipeline = ipex_pipeline(
+                task=task,
+                model=model,
+                tokenizer=tokenizer,
+                batch_size=batch_size,
+                model_kwargs=_model_kwargs,
+                **_pipeline_kwargs,
+            )
+        else:
+            pipeline = hf_pipeline(
+                task=task,
+                model=model,
+                tokenizer=tokenizer,
+                device=device,
+                device_map=device_map,
+                batch_size=batch_size,
+                model_kwargs=_model_kwargs,
+                **_pipeline_kwargs,
+            )
+        if pipeline.task not in VALID_TASKS and not pipeline.task.startswith(
+            "translation_"
+        ):
             msg = (
                 f"Got invalid task {pipeline.task}, "
                 f"currently only {VALID_TASKS} are supported"
@@ -304,32 +172,33 @@ class HuggingFacePipeline(BaseLLM):
             model_id=model_id,
             model_kwargs=_model_kwargs,
             pipeline_kwargs=_pipeline_kwargs,
-            batch_size=batch_size,
             **kwargs,
         )
 
-    @property
-    def _identifying_params(self) -> Mapping[str, Any]:
-        """Get the identifying parameters."""
-        return {
-            "model_id": self.model_id,
-            "model_kwargs": self.model_kwargs,
-            "pipeline_kwargs": self.pipeline_kwargs,
-        }
-
-    @property
-    def _llm_type(self) -> str:
-        return "huggingface_pipeline"
+    @pre_init
+    def validate_pipeline(cls, values: dict) -> dict:
+        """Validate that pipeline is a valid HuggingFace pipeline."""
+        if values.get("pipeline") is not None:
+            pipeline = values["pipeline"]
+            if pipeline.task not in VALID_TASKS and not pipeline.task.startswith(
+                "translation_"
+            ):
+                msg = (
+                    f"Got invalid task {pipeline.task}, "
+                    f"currently only {VALID_TASKS} are supported"
+                )
+                raise ValueError(msg)
+        return values
 
     def _generate(
         self,
-        prompts: list[str],
-        stop: list[str] | None = None,
-        run_manager: CallbackManagerForLLMRun | None = None,
+        prompts: List[str],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> LLMResult:
         # List to hold all results
-        text_generations: list[str] = []
+        text_generations: List[str] = []
         pipeline_kwargs = kwargs.get("pipeline_kwargs", {})
         skip_prompt = kwargs.get("skip_prompt", False)
 
@@ -337,10 +206,7 @@ class HuggingFacePipeline(BaseLLM):
             batch_prompts = prompts[i : i + self.batch_size]
 
             # Process batch of prompts
-            responses = self.pipeline(
-                batch_prompts,
-                **pipeline_kwargs,
-            )
+            responses = self.pipeline(batch_prompts, **pipeline_kwargs)
 
             # Process each response in the batch
             for j, response in enumerate(responses):
@@ -356,7 +222,7 @@ class HuggingFacePipeline(BaseLLM):
                     text = response["generated_text"]
                 elif self.pipeline.task == "summarization":
                     text = response["summary_text"]
-                elif self.pipeline.task in "translation":
+                elif self.pipeline.task.startswith("translation"):
                     text = response["translation_text"]
                 else:
                     msg = (
@@ -376,36 +242,15 @@ class HuggingFacePipeline(BaseLLM):
     def _stream(
         self,
         prompt: str,
-        stop: list[str] | None = None,
-        run_manager: CallbackManagerForLLMRun | None = None,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> Iterator[GenerationChunk]:
-        from threading import Thread
-
-        import torch
-        from transformers import (
-            StoppingCriteria,
-            StoppingCriteriaList,
-            TextIteratorStreamer,
-        )
-
         pipeline_kwargs = kwargs.get("pipeline_kwargs", {})
-        skip_prompt = kwargs.get("skip_prompt", True)
+        skip_prompt = kwargs.get("skip_prompt", False)
 
-        if stop is not None:
-            stop = self.pipeline.tokenizer.convert_tokens_to_ids(stop)
-        stopping_ids_list = stop or []
-
-        class StopOnTokens(StoppingCriteria):
-            def __call__(
-                self,
-                input_ids: torch.LongTensor,
-                scores: torch.FloatTensor,
-                **kwargs: Any,
-            ) -> bool:
-                return any(input_ids[0][-1] == stop_id for stop_id in stopping_ids_list)
-
-        stopping_criteria = StoppingCriteriaList([StopOnTokens()])
+        from transformers import TextIteratorStreamer
+        from threading import Thread
 
         streamer = TextIteratorStreamer(
             self.pipeline.tokenizer,
@@ -413,18 +258,24 @@ class HuggingFacePipeline(BaseLLM):
             skip_prompt=skip_prompt,
             skip_special_tokens=True,
         )
-        generation_kwargs = dict(
-            text_inputs=prompt,
-            streamer=streamer,
-            stopping_criteria=stopping_criteria,
-            **pipeline_kwargs,
-        )
-        t1 = Thread(target=self.pipeline, kwargs=generation_kwargs)
-        t1.start()
-
+        pipeline_kwargs = {**pipeline_kwargs, "streamer": streamer}
+        t = Thread(target=self.pipeline, args=[prompt], kwargs=pipeline_kwargs)
+        t.start()
         for char in streamer:
             chunk = GenerationChunk(text=char)
             if run_manager:
                 run_manager.on_llm_new_token(chunk.text, chunk=chunk)
-
             yield chunk
+
+    @property
+    def _llm_type(self) -> str:
+        return "huggingface_pipeline"
+
+    @property
+    def _identifying_params(self) -> dict:
+        """Get the identifying parameters."""
+        return {
+            **{"model_id": self.model_id},
+            **{"model_kwargs": self.model_kwargs},
+            **{"pipeline_kwargs": self.pipeline_kwargs},
+        }


### PR DESCRIPTION
Fixes #40095

## Root cause

Two bugs in `HuggingFacePipeline` block translation pipelines with task names like `"translation_en_to_fr"`:

**1. VALID_TASKS validator**

`pipeline.task not in VALID_TASKS` only passes for the bare `"translation"` string. Any `"translation_xx_to_yy"` task (the actual format transformers uses) fails the guard immediately at construction.

**2. Substring test in `_generate`**

```python
elif self.pipeline.task in "translation":   # BUG: task ∈ string, not string ∈ tasks
```

`"translation_en_to_fr" in "translation"` is `False`, so valid translation pipelines fall to the `else` branch and raise `ValueError`. The check also has an unrelated hazard: any string that is a substring of `"translation"` (e.g. `""`) would incorrectly route to translation-text handling.

## Fix

- Allow `startswith("translation_")` task names to pass the `VALID_TASKS` guard.
- Change the `_generate` routing check to `self.pipeline.task.startswith("translation")`, which correctly handles both `"translation"` and `"translation_xx_to_yy"`.

## Reproduction

```python
from unittest.mock import MagicMock
from langchain_huggingface import HuggingFacePipeline

pipe = MagicMock()
pipe.task = "translation_en_to_fr"
pipe.model.name_or_path = "mock-model-id"
pipe.return_value = [{"translation_text": "Bonjour"}]

llm = HuggingFacePipeline(pipeline=pipe)
result = llm._generate(["Hello"])
print(result.generations[0][0].text)  # "Bonjour"
```