### PR TITLE
core: support plus (+) bullet items in MarkdownListOutputParser

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -221,8 +221,12 @@ class NumberedListOutputParser(ListOutputParser):
 class MarkdownListOutputParser(ListOutputParser):
     """Parse a Markdown list."""
 
-    pattern: str = r"^\s*[-*]\s([^\n]+)$"
-    """The pattern to match a Markdown list item."""
+    pattern: str = r"^\s*[-*+]\s([^\n]+)$"
+    """The pattern to match a Markdown list item.
+
+    Matches items prefixed with ``-``, ``*``, or ``+``, all of which are
+    valid unordered list markers in the CommonMark specification.
+    """
 
     @override
     def get_format_instructions(self) -> str:


### PR DESCRIPTION
Fixes #40057

## Problem

`MarkdownListOutputParser` uses the pattern `r"^\s*[-*]\s([^\n]+)$"` which only matches `-` and `*` unordered list markers. The CommonMark specification (§5.3) also allows `+` as a valid bullet. LLMs frequently emit `+`-bulleted lists, causing `OutputParserException` instead of a parsed result.

```python
from langchain_core.output_parsers import MarkdownListOutputParser

parser = MarkdownListOutputParser()
parser.parse("+ item 1\n+ item 2")  # raises OutputParserException
```

## Fix

Extend the character class from `[-*]` to `[-*+]`:

```python
# before
pattern: str = r"^\s*[-*]\s([^\n]+)$"

# after
pattern: str = r"^\s*[-*+]\s([^\n]+)$"
```

All three bullet styles now parse correctly, and the existing `-` and `*` behaviour is unchanged.