### PR TITLE
fix(langchain): propagate `args_schema` to HITL review config

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -304,11 +304,12 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
         )
 
         # Create ReviewConfig
-        # eventually can get tool information and populate args_schema from there
         review_config = ReviewConfig(
             action_name=tool_name,
             allowed_decisions=config["allowed_decisions"],
         )
+        if "args_schema" in config:
+            review_config["args_schema"] = config["args_schema"]
 
         return action_request, review_config
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
@@ -115,6 +115,47 @@ def test_human_in_the_loop_middleware_single_tool_accept() -> None:
     assert result is None
 
 
+def test_human_in_the_loop_middleware_propagates_args_schema() -> None:
+    """Test that a configured `args_schema` is included in the interrupt payload."""
+    args_schema = {
+        "type": "object",
+        "properties": {"input": {"type": "string"}},
+        "required": ["input"],
+    }
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={
+            "test_tool": {
+                "allowed_decisions": ["approve", "edit"],
+                "args_schema": args_schema,
+            }
+        }
+    )
+    ai_message = AIMessage(
+        content="I'll help you",
+        tool_calls=[{"name": "test_tool", "args": {"input": "test"}, "id": "1"}],
+    )
+    state = AgentState[Any](messages=[HumanMessage(content="Hello"), ai_message])
+    interrupt_payloads: list[dict[str, Any]] = []
+
+    def mock_approve(payload: dict[str, Any]) -> dict[str, Any]:
+        interrupt_payloads.append(payload)
+        return {"decisions": [{"type": "approve"}]}
+
+    with patch(
+        "langchain.agents.middleware.human_in_the_loop.interrupt",
+        side_effect=mock_approve,
+    ):
+        middleware.after_model(state, Runtime())
+
+    assert interrupt_payloads[0]["review_configs"] == [
+        {
+            "action_name": "test_tool",
+            "allowed_decisions": ["approve", "edit"],
+            "args_schema": args_schema,
+        }
+    ]
+
+
 def test_human_in_the_loop_middleware_single_tool_edit() -> None:
     """Test HumanInTheLoopMiddleware with single tool edit response."""
     middleware = HumanInTheLoopMiddleware(


### PR DESCRIPTION
Fixes #40164

---

`HumanInTheLoopMiddleware` accepts an explicit `args_schema` in `InterruptOnConfig`, but currently omits it when constructing the corresponding `ReviewConfig`. This change preserves the user-supplied schema in the interrupt payload without inferring schemas or changing edited-call validation and execution behavior.

A focused regression test covers the emitted review configuration. The focused unit test and Ruff lint and format checks pass.

## Release note

`HumanInTheLoopMiddleware` now includes explicitly configured `args_schema` values in human-in-the-loop review payloads.

This contribution was prepared with assistance from an AI coding agent.