### PR TITLE
fix(chroma): handle documents without metadata in update_documents

### DIFF
--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
+    cast,
 )
 
 import chromadb
@@ -1231,13 +1232,34 @@ class Chroma(VectorStore):
             ValueError: If the embedding function is not provided.
         """
         text = [document.page_content for document in documents]
-        metadata = [document.metadata for document in documents]
+        metadata = [document.metadata or None for document in documents]
         if self._embedding_function is None:
             msg = "For update, you must specify an embedding function on creation."
             raise ValueError(
                 msg,
             )
         embeddings = self._embedding_function.embed_documents(text)
+
+        # Chroma rejects empty metadata dicts on update, so documents without
+        # metadata are updated separately, omitting the `metadatas` argument.
+        with_idx = [i for i, m in enumerate(metadata) if m is not None]
+        without_idx = [i for i, m in enumerate(metadata) if m is None]
+        groups: list[
+            tuple[list[str], list[dict] | None, list[str], list[list[float]]]
+        ] = [
+            (
+                [ids[i] for i in with_idx],
+                cast("list[dict]", [metadata[i] for i in with_idx]),
+                [text[i] for i in with_idx],
+                [embeddings[i] for i in with_idx],
+            ),
+            (
+                [ids[i] for i in without_idx],
+                None,
+                [text[i] for i in without_idx],
+                [embeddings[i] for i in without_idx],
+            ),
+        ]
 
         if hasattr(
             self._client,
@@ -1248,26 +1270,32 @@ class Chroma(VectorStore):
         ):  # for Chroma 0.4.10 and above
             from chromadb.utils.batch_utils import create_batches
 
-            for batch in create_batches(
-                api=self._client,
-                ids=ids,
-                metadatas=metadata,  # type: ignore[arg-type]
-                documents=text,
-                embeddings=embeddings,  # type: ignore[arg-type]
-            ):
-                self._collection.update(
-                    ids=batch[0],
-                    embeddings=batch[1],
-                    documents=batch[3],
-                    metadatas=batch[2],
-                )
+            for group_ids, group_metadatas, group_texts, group_embeddings in groups:
+                if not group_ids:
+                    continue
+                for batch in create_batches(
+                    api=self._client,
+                    ids=group_ids,
+                    metadatas=group_metadatas,  # type: ignore[arg-type]
+                    documents=group_texts,
+                    embeddings=group_embeddings,  # type: ignore[arg-type]
+                ):
+                    self._collection.update(
+                        ids=batch[0],
+                        embeddings=batch[1],
+                        documents=batch[3],
+                        metadatas=batch[2],
+                    )
         else:
-            self._collection.update(
-                ids=ids,
-                embeddings=embeddings,  # type: ignore[arg-type]
-                documents=text,
-                metadatas=metadata,  # type: ignore[arg-type]
-            )
+            for group_ids, group_metadatas, group_texts, group_embeddings in groups:
+                if not group_ids:
+                    continue
+                self._collection.update(
+                    ids=group_ids,
+                    embeddings=group_embeddings,  # type: ignore[arg-type]
+                    documents=group_texts,
+                    metadatas=group_metadatas,  # type: ignore[arg-type]
+                )
 
     @classmethod
     def from_texts(

--- a/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
+++ b/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
@@ -1,3 +1,4 @@
+from langchain_core.documents import Document
 from langchain_core.embeddings.fake import (
     FakeEmbeddings,
 )
@@ -28,3 +29,50 @@ def test_similarity_search() -> None:
     output = docsearch.similarity_search("foo", k=1)
     docsearch.delete_collection()
     assert len(output) == 1
+
+
+def test_update_document_without_metadata() -> None:
+    """Test updating a document that carries no metadata.
+
+    Chroma rejects empty metadata dicts on update, so a document whose
+    metadata defaults to `{}` must be updated without a `metadatas`
+    argument instead of raising `ValueError`.
+    """
+    docsearch = Chroma.from_texts(
+        collection_name="test_update_without_metadata",
+        texts=["foo"],
+        embedding=FakeEmbeddings(size=10),
+        ids=["doc_1"],
+    )
+    docsearch.update_document(
+        document_id="doc_1",
+        document=Document(page_content="updated"),
+    )
+    result = docsearch.get(ids=["doc_1"])
+    docsearch.delete_collection()
+    assert result["documents"] == ["updated"]
+    # Chroma stores no metadata for the document; nothing was attached.
+    assert not result["metadatas"][0]
+
+
+def test_update_documents_with_mixed_metadata() -> None:
+    """Test updating documents with and without metadata in one call."""
+    docsearch = Chroma.from_texts(
+        collection_name="test_update_mixed_metadata",
+        texts=["foo", "bar"],
+        embedding=FakeEmbeddings(size=10),
+        ids=["doc_1", "doc_2"],
+    )
+    docsearch.update_documents(
+        ids=["doc_1", "doc_2"],
+        documents=[
+            Document(page_content="updated bare"),
+            Document(page_content="updated tagged", metadata={"page": "1"}),
+        ],
+    )
+    result = docsearch.get(ids=["doc_1", "doc_2"])
+    docsearch.delete_collection()
+    assert sorted(result["documents"]) == ["updated bare", "updated tagged"]
+    metadata_by_id = dict(zip(result["ids"], result["metadatas"], strict=True))
+    assert not metadata_by_id["doc_1"]
+    assert metadata_by_id["doc_2"] == {"page": "1"}


### PR DESCRIPTION
Fixes #37452

**What**: `Chroma.update_documents` now splits documents into a with-metadata group and a without-metadata group, updating the latter without the `metadatas` argument — mirroring how `add_texts` already treats them.

**Why**: `Document.metadata` defaults to `{}`, and Chroma rejects empty metadata dicts on `update()` (`ValueError: Expected metadata to be a non-empty dict`). Updating any document without explicit metadata therefore raised. Note that normalizing with `document.metadata or {}` (the approach in earlier attempts on this issue) is a no-op for exactly this reason.

**How checked**: Added regression tests `test_update_document_without_metadata` and `test_update_documents_with_mixed_metadata` (the mixed batch exercises both paths of the Chroma ≥ 0.4.10 batching branch); chroma unit suite: 4 passed against chromadb 1.5.9. `ruff format --check` clean, no lint findings on changed lines.

**Release Notes:**
- Fixed a crash in `Chroma.update_documents` / `Chroma.update_document` when documents have no explicit metadata (`Document.metadata` defaults to `{}`, which Chroma's `update()` rejects).

**AI usage declaration:** This fix was developed with AI coding assistance (ZCode); I reviewed, tested, and verified all changes locally (chroma unit suite + ruff).

Happy to be assigned to #37452 — I've commented there with this diagnosis.