### PR TITLE
core: fix _convert_to_v1_from_anthropic mutating message.content on unknown blocks

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/anthropic.py
+++ b/libs/core/langchain_core/messages/block_translators/anthropic.py
@@ -486,7 +486,7 @@ def _convert_to_v1_from_anthropic(message: AIMessage) -> list[types.ContentBlock
             else:
                 new_block: types.NonStandardContentBlock = {
                     "type": "non_standard",
-                    "value": block,
+                    "value": dict(block),  # copy so we don't mutate the original message
                 }
                 if "index" in new_block["value"]:
                     new_block["index"] = new_block["value"].pop("index")

--- a/libs/core/tests/unit_tests/messages/block_translators/test_anthropic.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_anthropic.py
@@ -572,3 +572,32 @@ def test_convert_to_v1_from_anthropic_malformed_citations() -> None:
             ],
         },
     ]
+
+
+def test_convert_to_v1_from_anthropic_does_not_mutate_unknown_block() -> None:
+    """Translating a message must not mutate the original content blocks.
+
+    `_convert_to_v1_from_anthropic` lifted ``index`` off unrecognised blocks
+    with ``dict.pop``, which mutated the shared dict inside the AIMessage.
+    Calling ``translate_content`` (or accessing ``.content_blocks``) a second
+    time would then silently drop the ``index`` field.
+    """
+    from copy import deepcopy
+
+    original_block = {"type": "custom", "payload": "value", "index": 3}
+    message = AIMessage(content=[original_block])
+    snapshot = deepcopy(message.content)
+
+    # First access — triggers translation and previously popped "index"
+    _ = message.content_blocks
+
+    # The original content must be unchanged
+    assert message.content == snapshot, (
+        "translate_content mutated message.content: "
+        f"before={snapshot!r}, after={message.content!r}"
+    )
+
+    # Second access must return the same result as the first
+    blocks_1 = message.content_blocks
+    blocks_2 = message.content_blocks
+    assert blocks_1 == blocks_2, "content_blocks is not idempotent after mutation fix"


### PR DESCRIPTION
Fixes #40168.

## Problem

`_convert_to_v1_from_anthropic` in `block_translators/anthropic.py` mutates the original `AIMessage.content` list when it encounters unrecognized (non-standard) content blocks.

In the `else` branch the same `block` dict object is assigned as `new_block["value"]`, then `.pop("index", None)` is called on `new_block["value"]` — which is the exact same dict reference:

```python
# Before — mutates original block
new_block: types.NonStandardContentBlock = {
    "type": "non_standard",
    "value": block,           # same reference as message.content[i]
}
new_block["value"].pop("index", None)   # strips key from the original
```

Any code that accesses `message.content` after this call (retry logic, serialization, logging) sees the `"index"` key silently stripped. Two consecutive calls return inconsistent results.

The same bug was fixed for Bedrock and Google GenAI in #40022 / #40023 but the Anthropic translator was missed.

## Fix

Shallow-copy the block before wrapping it:

```python
new_block: types.NonStandardContentBlock = {
    "type": "non_standard",
    "value": dict(block),   # copy so we don't mutate the original message
}
```

## Test

Added `test_convert_to_v1_from_anthropic_does_not_mutate_unknown_block` in `libs/core/tests/unit_tests/messages/block_translators/test_anthropic.py`:
- Asserts `message.content` is unchanged after accessing `content_blocks`
- Asserts idempotency (two consecutive calls return identical results)