### PR TITLE
fix(core): use sanitized+hashed ids for mermaid node ids

### DIFF
--- a/libs/core/langchain_core/runnables/graph_mermaid.py
+++ b/libs/core/langchain_core/runnables/graph_mermaid.py
@@ -7,6 +7,7 @@ import base64
 import random
 import re
 import string
+import hashlib
 import time
 import urllib.parse
 from dataclasses import asdict
@@ -123,11 +124,11 @@ def draw_mermaid(
 
     # Node formatting templates
     default_class_label = "default"
-    format_dict = {default_class_label: "{0}({1})"}
+    format_dict = {default_class_label: '{0}(["{1}"])'}
     if first_node is not None:
-        format_dict[first_node] = "{0}([{1}]):::first"
+        format_dict = {default_class_label: '{0}(["{1}"])'}
     if last_node is not None:
-        format_dict[last_node] = "{0}([{1}]):::last"
+        format_dict = {default_class_label: '{0}(["{1}"])'}
 
     def render_node(key: str, node: Node, indent: str = "\t") -> str:
         """Helper function to render a node with consistent formatting."""
@@ -251,19 +252,26 @@ def draw_mermaid(
         mermaid_graph += _generate_mermaid_graph_styles(node_styles or NodeStyles())
     return mermaid_graph
 
-
 def _to_safe_id(label: str) -> str:
     """Convert a string into a Mermaid-compatible node id.
 
-    Keep [a-zA-Z0-9_-] characters unchanged.
-    Map every other character -> backslash + lowercase hex codepoint.
-
-    Result is guaranteed to be unique and Mermaid-compatible,
-    so nodes with special characters always render correctly.
+    Keep [a-zA-Z0-9_-] characters unchanged. Any other character is
+    replaced with `_`. Because that collapsing can make two different
+    labels map to the same id (e.g. multiple non-ASCII characters all
+    becoming `_`), a short deterministic hash suffix of the original
+    label is appended whenever sanitizing changed anything. This keeps
+    ids both Mermaid-legal and unique, unlike the previous backslash-hex
+    escaping scheme, which produced ids Mermaid could not parse (e.g.
+    for `[` / `]`).
     """
     allowed = string.ascii_letters + string.digits + "_-"
-    out = [ch if ch in allowed else "\\" + format(ord(ch), "x") for ch in label]
-    return "".join(out)
+    sanitized = "".join(ch if ch in allowed else "_" for ch in label)
+
+    if sanitized == label:
+        return sanitized
+
+    digest = hashlib.sha256(label.encode("utf-8")).hexdigest()[:6]
+    return f"{sanitized}_{digest}"
 
 
 def _generate_mermaid_graph_styles(node_colors: NodeStyles) -> str:

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
@@ -7,21 +7,21 @@
       curve: linear
   ---
   graph TD;
-  	__start__([<p>__start__</p>]):::first
-  	parent_1(parent_1)
-  	parent_2(parent_2)
-  	__end__([<p>__end__</p>]):::last
+  	__start__(["<p>__start__</p>"])
+  	parent_1(["parent_1"])
+  	parent_2(["parent_2"])
+  	__end__(["<p>__end__</p>"])
   	__start__ --> parent_1;
-  	child\3achild_2 --> parent_2;
-  	parent_1 --> child\3achild_1\3agrandchild_1;
+  	child_child_2_bf89db --> parent_2;
+  	parent_1 --> child_child_1_grandchild_1_b3a33e;
   	parent_2 --> __end__;
   	subgraph child
-  	child\3achild_2(child_2)
-  	child\3achild_1\3agrandchild_2 --> child\3achild_2;
+  	child_child_2_bf89db(["child_2"])
+  	child_child_1_grandchild_2_b57319 --> child_child_2_bf89db;
   	subgraph child_1
-  	child\3achild_1\3agrandchild_1(grandchild_1)
-  	child\3achild_1\3agrandchild_2(grandchild_2<hr/><small><em>__interrupt = before</em></small>)
-  	child\3achild_1\3agrandchild_1 --> child\3achild_1\3agrandchild_2;
+  	child_child_1_grandchild_1_b3a33e(["grandchild_1"])
+  	child_child_1_grandchild_2_b57319(["grandchild_2<hr/><small><em>__interrupt = before</em></small>"])
+  	child_child_1_grandchild_1_b3a33e --> child_child_1_grandchild_2_b57319;
   	end
   	end
   	classDef default fill:#f2f0ff,line-height:1.2
@@ -34,13 +34,13 @@
   '''
   graph TD;
   	PromptInput --> PromptTemplate_1;
-  	Parallel\3cllm1\2cllm2\3eInput --> FakeListLLM_1;
-  	FakeListLLM_1 --> Parallel\3cllm1\2cllm2\3eOutput;
-  	Parallel\3cllm1\2cllm2\3eInput --> FakeListLLM_2;
-  	FakeListLLM_2 --> Parallel\3cllm1\2cllm2\3eOutput;
-  	PromptTemplate_1 --> Parallel\3cllm1\2cllm2\3eInput;
+  	Parallel_llm1_llm2_Input_4ed3fe --> FakeListLLM_1;
+  	FakeListLLM_1 --> Parallel_llm1_llm2_Output_029055;
+  	Parallel_llm1_llm2_Input_4ed3fe --> FakeListLLM_2;
+  	FakeListLLM_2 --> Parallel_llm1_llm2_Output_029055;
+  	PromptTemplate_1 --> Parallel_llm1_llm2_Input_4ed3fe;
   	PromptTemplate_2 --> PromptTemplateOutput;
-  	Parallel\3cllm1\2cllm2\3eOutput --> PromptTemplate_2;
+  	Parallel_llm1_llm2_Output_029055 --> PromptTemplate_2;
   
   '''
 # ---
@@ -56,8 +56,8 @@
       primaryColor: '#e2e2e2'
   ---
   graph TD;
-  	__start__([<p>__start__</p>]):::first
-  	my_node([my_node]):::last
+  	__start__(["<p>__start__</p>"])
+  	my_node(["my_node"])
   	__start__ --> my_node;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
@@ -73,13 +73,13 @@
       curve: linear
   ---
   graph TD;
-  	__start__([<p>__start__</p>]):::first
-  	\5f00\59cb(开始)
-  	\7ed3\675f(结束)
-  	__end__([<p>__end__</p>]):::last
-  	__start__ --> \5f00\59cb;
-  	\5f00\59cb --> \7ed3\675f;
-  	\7ed3\675f --> __end__;
+  	__start__(["<p>__start__</p>"])
+  	___d2bb02(["开始"])
+  	___c7b24e(["结束"])
+  	__end__(["<p>__end__</p>"])
+  	__start__ --> ___d2bb02;
+  	___d2bb02 --> ___c7b24e;
+  	___c7b24e --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -125,11 +125,11 @@
       curve: linear
   ---
   graph TD;
-  	PromptInput([PromptInput]):::first
-  	PromptTemplate(PromptTemplate)
-  	FakeListLLM(FakeListLLM<hr/><small><em>key = 2</em></small>)
-  	CommaSeparatedListOutputParser(CommaSeparatedListOutputParser)
-  	CommaSeparatedListOutputParserOutput([CommaSeparatedListOutputParserOutput]):::last
+  	PromptInput(["PromptInput"])
+  	PromptTemplate(["PromptTemplate"])
+  	FakeListLLM(["FakeListLLM<hr/><small><em>key = 2</em></small>"])
+  	CommaSeparatedListOutputParser(["CommaSeparatedListOutputParser"])
+  	CommaSeparatedListOutputParserOutput(["CommaSeparatedListOutputParserOutput"])
   	PromptInput --> PromptTemplate;
   	PromptTemplate --> FakeListLLM;
   	CommaSeparatedListOutputParser --> CommaSeparatedListOutputParserOutput;
@@ -1917,15 +1917,15 @@
   graph TD;
   	PromptInput --> PromptTemplate;
   	PromptTemplate --> FakeListLLM;
-  	Parallel\3cas_list\2cas_str\3eInput --> CommaSeparatedListOutputParser;
-  	CommaSeparatedListOutputParser --> Parallel\3cas_list\2cas_str\3eOutput;
+  	Parallel_as_list_as_str_Input_b95db6 --> CommaSeparatedListOutputParser;
+  	CommaSeparatedListOutputParser --> Parallel_as_list_as_str_Output_dc7896;
   	conditional_str_parser_input --> StrOutputParser;
   	StrOutputParser --> conditional_str_parser_output;
   	conditional_str_parser_input --> XMLOutputParser;
   	XMLOutputParser --> conditional_str_parser_output;
-  	Parallel\3cas_list\2cas_str\3eInput --> conditional_str_parser_input;
-  	conditional_str_parser_output --> Parallel\3cas_list\2cas_str\3eOutput;
-  	FakeListLLM --> Parallel\3cas_list\2cas_str\3eInput;
+  	Parallel_as_list_as_str_Input_b95db6 --> conditional_str_parser_input;
+  	conditional_str_parser_output --> Parallel_as_list_as_str_Output_dc7896;
+  	FakeListLLM --> Parallel_as_list_as_str_Input_b95db6;
   
   '''
 # ---
@@ -1937,27 +1937,27 @@
       curve: linear
   ---
   graph TD;
-  	PromptInput([PromptInput]):::first
-  	PromptTemplate(PromptTemplate)
-  	FakeListLLM(FakeListLLM)
-  	Parallel\3cas_list\2cas_str\3eInput(Parallel<as_list,as_str>Input)
-  	Parallel\3cas_list\2cas_str\3eOutput([Parallel<as_list,as_str>Output]):::last
-  	CommaSeparatedListOutputParser(CommaSeparatedListOutputParser)
-  	conditional_str_parser_input(conditional_str_parser_input)
-  	conditional_str_parser_output(conditional_str_parser_output)
-  	StrOutputParser(StrOutputParser)
-  	XMLOutputParser(XMLOutputParser)
+  	PromptInput(["PromptInput"])
+  	PromptTemplate(["PromptTemplate"])
+  	FakeListLLM(["FakeListLLM"])
+  	Parallel_as_list_as_str_Input_b95db6(["Parallel<as_list,as_str>Input"])
+  	Parallel_as_list_as_str_Output_dc7896(["Parallel<as_list,as_str>Output"])
+  	CommaSeparatedListOutputParser(["CommaSeparatedListOutputParser"])
+  	conditional_str_parser_input(["conditional_str_parser_input"])
+  	conditional_str_parser_output(["conditional_str_parser_output"])
+  	StrOutputParser(["StrOutputParser"])
+  	XMLOutputParser(["XMLOutputParser"])
   	PromptInput --> PromptTemplate;
   	PromptTemplate --> FakeListLLM;
-  	Parallel\3cas_list\2cas_str\3eInput --> CommaSeparatedListOutputParser;
-  	CommaSeparatedListOutputParser --> Parallel\3cas_list\2cas_str\3eOutput;
+  	Parallel_as_list_as_str_Input_b95db6 --> CommaSeparatedListOutputParser;
+  	CommaSeparatedListOutputParser --> Parallel_as_list_as_str_Output_dc7896;
   	conditional_str_parser_input --> StrOutputParser;
   	StrOutputParser --> conditional_str_parser_output;
   	conditional_str_parser_input --> XMLOutputParser;
   	XMLOutputParser --> conditional_str_parser_output;
-  	Parallel\3cas_list\2cas_str\3eInput --> conditional_str_parser_input;
-  	conditional_str_parser_output --> Parallel\3cas_list\2cas_str\3eOutput;
-  	FakeListLLM --> Parallel\3cas_list\2cas_str\3eInput;
+  	Parallel_as_list_as_str_Input_b95db6 --> conditional_str_parser_input;
+  	conditional_str_parser_output --> Parallel_as_list_as_str_Output_dc7896;
+  	FakeListLLM --> Parallel_as_list_as_str_Input_b95db6;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -1991,9 +1991,9 @@
       curve: linear
   ---
   graph TD;
-  	StrOutputParserInput([StrOutputParserInput]):::first
-  	StrOutputParser(StrOutputParser)
-  	StrOutputParserOutput([StrOutputParserOutput]):::last
+  	StrOutputParserInput(["StrOutputParserInput"])
+  	StrOutputParser(["StrOutputParser"])
+  	StrOutputParserOutput(["StrOutputParserOutput"])
   	StrOutputParserInput --> StrOutputParser;
   	StrOutputParser --> StrOutputParserOutput;
   	classDef default fill:#f2f0ff,line-height:1.2
@@ -2010,25 +2010,25 @@
       curve: linear
   ---
   graph TD;
-  	__start__([<p>__start__</p>]):::first
-  	outer_1(outer_1)
-  	outer_2(outer_2)
-  	__end__([<p>__end__</p>]):::last
+  	__start__(["<p>__start__</p>"])
+  	outer_1(["outer_1"])
+  	outer_2(["outer_2"])
+  	__end__(["<p>__end__</p>"])
   	__start__ --> outer_1;
-  	inner_1\3ainner_2 --> outer_2;
-  	inner_2\3ainner_2 --> outer_2;
-  	outer_1 --> inner_1\3ainner_1;
-  	outer_1 --> inner_2\3ainner_1;
+  	inner_1_inner_2_e4f465 --> outer_2;
+  	inner_2_inner_2_a87619 --> outer_2;
+  	outer_1 --> inner_1_inner_1_d5fa72;
+  	outer_1 --> inner_2_inner_1_5ef1b3;
   	outer_2 --> __end__;
   	subgraph inner_1
-  	inner_1\3ainner_1(inner_1)
-  	inner_1\3ainner_2(inner_2<hr/><small><em>__interrupt = before</em></small>)
-  	inner_1\3ainner_1 --> inner_1\3ainner_2;
+  	inner_1_inner_1_d5fa72(["inner_1"])
+  	inner_1_inner_2_e4f465(["inner_2<hr/><small><em>__interrupt = before</em></small>"])
+  	inner_1_inner_1_d5fa72 --> inner_1_inner_2_e4f465;
   	end
   	subgraph inner_2
-  	inner_2\3ainner_1(inner_1)
-  	inner_2\3ainner_2(inner_2)
-  	inner_2\3ainner_1 --> inner_2\3ainner_2;
+  	inner_2_inner_1_5ef1b3(["inner_1"])
+  	inner_2_inner_2_a87619(["inner_2"])
+  	inner_2_inner_1_5ef1b3 --> inner_2_inner_2_a87619;
   	end
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
@@ -2044,12 +2044,12 @@
       curve: linear
   ---
   graph TD;
-  	__start__([<p>__start__</p>]):::first
-  	__end__([<p>__end__</p>]):::last
-  	__start__ --> sub\3ameow;
-  	sub\3ameow --> __end__;
+  	__start__(["<p>__start__</p>"])
+  	__end__(["<p>__end__</p>"])
+  	__start__ --> sub_meow_db1313;
+  	sub_meow_db1313 --> __end__;
   	subgraph sub
-  	sub\3ameow(meow)
+  	sub_meow_db1313(["meow"])
   	end
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
@@ -2127,24 +2127,24 @@
       curve: linear
   ---
   graph TD;
-  	__start__([<p>__start__</p>]):::first
-  	parent_1(parent_1)
-  	parent_2(parent_2)
-  	__end__([<p>__end__</p>]):::last
+  	__start__(["<p>__start__</p>"])
+  	parent_1(["parent_1"])
+  	parent_2(["parent_2"])
+  	__end__(["<p>__end__</p>"])
   	__start__ --> parent_1;
-  	child\3achild_2 --> parent_2;
-  	parent_1 --> child\3achild_1\3agrandchild_1;
+  	child_child_2_bf89db --> parent_2;
+  	parent_1 --> child_child_1_grandchild_1_b3a33e;
   	parent_2 --> __end__;
   	subgraph child
-  	child\3achild_2(child_2)
-  	child\3achild_1\3agrandchild_2 --> child\3achild_2;
+  	child_child_2_bf89db(["child_2"])
+  	child_child_1_grandchild_2_b57319 --> child_child_2_bf89db;
   	subgraph child_1
-  	child\3achild_1\3agrandchild_1(grandchild_1)
-  	child\3achild_1\3agrandchild_2(grandchild_2<hr/><small><em>__interrupt = before</em></small>)
-  	child\3achild_1\3agrandchild_1\3agreatgrandchild --> child\3achild_1\3agrandchild_2;
+  	child_child_1_grandchild_1_b3a33e(["grandchild_1"])
+  	child_child_1_grandchild_2_b57319(["grandchild_2<hr/><small><em>__interrupt = before</em></small>"])
+  	child_child_1_grandchild_1_greatgrandchild_160133 --> child_child_1_grandchild_2_b57319;
   	subgraph grandchild_1
-  	child\3achild_1\3agrandchild_1\3agreatgrandchild(greatgrandchild)
-  	child\3achild_1\3agrandchild_1 --> child\3achild_1\3agrandchild_1\3agreatgrandchild;
+  	child_child_1_grandchild_1_greatgrandchild_160133(["greatgrandchild"])
+  	child_child_1_grandchild_1_b3a33e --> child_child_1_grandchild_1_greatgrandchild_160133;
   	end
   	end
   	end

--- a/libs/core/tests/unit_tests/runnables/test_graph.py
+++ b/libs/core/tests/unit_tests/runnables/test_graph.py
@@ -1,5 +1,6 @@
 from typing import Any
 from unittest.mock import MagicMock, patch
+import re
 
 from packaging import version
 from pydantic import BaseModel
@@ -526,10 +527,25 @@ def test_runnable_get_graph_with_invalid_output_type() -> None:
 
 def test_graph_mermaid_to_safe_id() -> None:
     """Test that node labels are correctly preprocessed for draw_mermaid."""
+    # Labels needing no sanitizing are returned unchanged.
     assert _to_safe_id("foo") == "foo"
     assert _to_safe_id("foo-bar") == "foo-bar"
     assert _to_safe_id("foo_1") == "foo_1"
-    assert _to_safe_id("#foo*&!") == "\\23foo\\2a\\26\\21"
+
+    # Labels with disallowed characters are sanitized to `_` and get a
+    # deterministic hash suffix, so different labels never collide even
+    # if they sanitize to the same string.
+    assert _to_safe_id("#foo*&!") == "_foo____1a0ea7"
+
+    # Regression test for https://github.com/langchain-ai/langchain/issues/39816
+    # Backslash-escaping produced ids Mermaid could not parse for '[' / ']'.
+    safe = _to_safe_id("PIIMiddleware[email].before_model")
+    assert re.fullmatch(r"[A-Za-z0-9_-]+", safe)
+
+    # Regression test for the collision this hashing scheme must still avoid
+    # (the original motivation for replacing the naive `_` substitution
+    # in https://github.com/langchain-ai/langchain/pull/32857).
+    assert _to_safe_id("开") != _to_safe_id("始")
 
 
 def test_graph_mermaid_duplicate_nodes(snapshot: SnapshotAssertion) -> None:


### PR DESCRIPTION
## Description

`_to_safe_id()` in `graph_mermaid.py` mapped every character outside
`[A-Za-z0-9_-]` to a backslash followed by its hex codepoint (e.g. `.`
→ `\2e`). Backslashes are not valid in Mermaid node ids. Most characters
happened to render anyway, but `[` and `]` (from `\5b` / `\5d`) caused
Mermaid to reject the entire document, so `draw_mermaid_png()` raised a
400 error for any node name containing brackets -- notably `PIIMiddleware`'s
auto-generated node names (`PIIMiddleware[<pii_type>]`). Since compiled
graphs call this during `_repr_mimebundle_()`, simply displaying such an
agent in a notebook threw a traceback even though the agent itself worked
fine.

## Fix

Replaced the backslash-hex escaping with sanitization to `[A-Za-z0-9_-]`
(replacing disallowed characters with `_`), plus a short deterministic
hash suffix appended whenever sanitizing changes the id. This keeps ids
both Mermaid-legal and unique -- preserving the uniqueness guarantee
from #32857 (which this scheme must not regress) while fixing the
illegal-character bug from #39816.

## Testing

- Updated `test_graph_mermaid_to_safe_id` to reflect the new id format,
  and added assertions for:
  - the bracket case from #39816 (id matches `[A-Za-z0-9_-]+`)
  - the CJK collision case from #32857 (two different labels that both
    sanitize to `_` still produce different ids)
- Regenerated the mermaid snapshot tests affected by the changed id
  format; diagram structure (edges, labels, styling) is unchanged --
  confirmed by diffing old vs. new snapshots.
- Full `libs/core` unit test suite passes locally (excluding 3
  pre-existing symlink test failures caused by Windows permissions,
  unrelated to this change and reproducible on a clean `master`).

Fixes #39816