### PR TITLE
fix(langchain): default blob resource MIME type when server omits it

### DIFF
--- a/libs/langchain_v1/langchain/mcp/tools.py
+++ b/libs/langchain_v1/langchain/mcp/tools.py
@@ -143,8 +143,10 @@ def _convert_content_block(content: ContentBlock) -> ToolMessageContentBlock:
         if isinstance(resource, TextResourceContents):
             return create_text_block(text=resource.text)
         if isinstance(resource, BlobResourceContents):
-            mime_type = resource.mime_type or None
-            if mime_type and mime_type.startswith("image/"):
+            # mimeType is optional per the MCP spec, but a base64 file block
+            # needs one, so fall back instead of crashing on valid output.
+            mime_type = resource.mime_type or "application/octet-stream"
+            if mime_type.startswith("image/"):
                 return create_image_block(base64=resource.blob, mime_type=mime_type)
             return create_file_block(base64=resource.blob, mime_type=mime_type)
         # Unreachable while the SDK's resource union holds; see the note below.

--- a/libs/langchain_v1/tests/unit_tests/mcp/test_tools.py
+++ b/libs/langchain_v1/tests/unit_tests/mcp/test_tools.py
@@ -280,6 +280,20 @@ def test_embedded_blob_resource_type_follows_its_mime_type(
     assert block["base64"] == "AAAA"
 
 
+def test_embedded_blob_resource_without_mime_type_falls_back() -> None:
+    """A blob resource without a MIME type becomes a file block by default."""
+    block = _convert_content_block(
+        EmbeddedResource(
+            type="resource",
+            resource=BlobResourceContents(uri="file:///blob", blob="AAAA"),
+        )
+    )
+
+    assert block["type"] == "file"
+    assert block["base64"] == "AAAA"
+    assert block["mime_type"] == "application/octet-stream"
+
+
 def test_audio_content_is_not_yet_supported() -> None:
     with pytest.raises(NotImplementedError, match="audio"):
         _convert_content_block(AudioContent(type="audio", data="AAAA", mimeType="audio/wav"))


### PR DESCRIPTION
Fixes #40186

Falling back to `application/octet-stream` when a blob resource has no MIME type, so valid server output no longer crashes the tool call.

## Release note

Users of the new `langchain.mcp` alpha no longer get a `ValueError` when a server returns a blob resource without a MIME type — it comes through as a file block instead.
