### PR TITLE
fix: add plus (+) bullet support to MarkdownListOutputParser

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -221,13 +221,13 @@ class NumberedListOutputParser(ListOutputParser):
 class MarkdownListOutputParser(ListOutputParser):
     """Parse a Markdown list."""
 
-    pattern: str = r"^\s*[-*]\s([^\n]+)$"
+    pattern: str = r"^\s*[-*+]\s([^\n]+)$"
     """The pattern to match a Markdown list item."""
 
     @override
     def get_format_instructions(self) -> str:
         """Return the format instructions for the Markdown list output."""
-        return "Your response should be a markdown list, eg: `- foo\n- bar\n- baz`"
+        return "Your response should be a markdown list, eg: `- foo\n- bar\n- baz` (supports `-`, `*`, or `+` bullets)"
 
     def parse(self, text: str) -> list[str]:
         """Parse the output of an LLM call.

--- a/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
@@ -271,6 +271,26 @@ async def test_numbered_list_async() -> None:
         ] == expectedlist
 
 
+def test_markdown_list_plus_bullet() -> None:
+    """Test that MarkdownListOutputParser supports plus (+) bullet items."""
+    parser = MarkdownListOutputParser()
+    
+    # Test with plus bullets
+    text_plus = "+ item 1\n+ item 2\n+ item 3"
+    expected = ["item 1", "item 2", "item 3"]
+    assert parser.parse(text_plus) == expected
+    
+    # Test with mixed bullet types
+    text_mixed = "- dash item\n* star item\n+ plus item"
+    expected_mixed = ["dash item", "star item", "plus item"]
+    assert parser.parse(text_mixed) == expected_mixed
+    
+    # Test with indentation
+    text_indented = "  + indented item\n    + deeply indented"
+    expected_indented = ["indented item", "deeply indented"]
+    assert parser.parse(text_indented) == expected_indented
+
+
 async def test_markdown_list_async() -> None:
     parser = MarkdownListOutputParser()
     text1 = (


### PR DESCRIPTION
## Summary

This PR fixes a bug in MarkdownListOutputParser where plus (+) bullet items were not recognized, causing parsing failures when LLMs generate markdown lists with + markers.

## Problem

The parser's regex pattern only matched dash (-) and asterisk (*) bullet markers:
```python
pattern: str = r"^\s*[-*]\s([^\n]+)$"
```

However, LLMs often generate markdown lists with plus (+) bullets, which caused the parser to throw OutputParserException.

## Solution

Updated the regex pattern to also match plus bullets:
```python
pattern: str = r"^\s*[-*+]\s([^\n]+)$"
```

Also updated the format instructions to document that all three bullet types are supported.

## Changes

1. libs/core/langchain_core/output_parsers/list.py:
   - Updated regex pattern to include + in the character class
   - Updated format instructions to document plus bullet support

2. libs/core/tests/unit_tests/output_parsers/test_list_parser.py:
   - Added test_markdown_list_plus_bullet() test function
   - Tests plus-only bullets, mixed bullet types, and indented bullets

## Related Issue

Fixes #40057