### PR TITLE
fix(huggingface): Allow all translation tasks in HuggingFacePipeline

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
+++ b/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
@@ -356,7 +356,7 @@ class HuggingFacePipeline(BaseLLM):
                     text = response["generated_text"]
                 elif self.pipeline.task == "summarization":
                     text = response["summary_text"]
-                elif self.pipeline.task in "translation":
+                elif self.pipeline.task.startswith("translation"):
                     text = response["translation_text"]
                 else:
                     msg = (


### PR DESCRIPTION
Fixes #40095.

HuggingFacePipeline._generate previously checked if the task was in 'translation', which failed for valid tasks like 'translation_en_to_fr'. Updated the check to use .startswith('translation').