### PR TITLE
fix(agents, anthropic): Fix Filesystem middleware path validation on Windows

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -194,7 +194,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
                 # points outside the root is never enumerated.
                 if match.is_file() and _is_within_root(match, self.root_path):
                     # Convert to virtual path
-                    virtual_path = "/" + str(match.relative_to(self.root_path))
+                    virtual_path = "/" + match.relative_to(self.root_path).as_posix()
                     stat = match.stat()
                     modified_at = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
                     matching.append((virtual_path, modified_at))
@@ -334,7 +334,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
                     if not _is_within_root(Path(path), self.root_path):
                         continue
                     # Convert to virtual path
-                    virtual_path = "/" + str(Path(path).relative_to(self.root_path))
+                    virtual_path = "/" + Path(path).relative_to(self.root_path).as_posix()
                     line_num = data["data"]["line_number"]
                     line_text = data["data"]["lines"]["text"].rstrip("\n")
 
@@ -391,7 +391,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
                 # Search content
                 for line_num, line in enumerate(content.splitlines(), 1):
                     if regex.search(line):
-                        virtual_path = "/" + str(file_path.relative_to(self.root_path))
+                        virtual_path = "/" + file_path.relative_to(self.root_path).as_posix()
                         if virtual_path not in results:
                             results[virtual_path] = []
                         results[virtual_path].append((line_num, line))

--- a/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
@@ -871,7 +871,7 @@ class _FilesystemClaudeFileToolMiddleware(AgentMiddleware):
             raise ValueError(msg) from None
 
         # Check allowed prefixes
-        virtual_path = "/" + str(full_path.relative_to(self.root_path))
+        virtual_path = "/" + full_path.relative_to(self.root_path).as_posix()
         if self.allowed_prefixes and not _is_within_allowed_prefix(
             virtual_path, self.allowed_prefixes
         ):


### PR DESCRIPTION
Fixes #40062 and Fixes #40063.

The Filesystem middlewares previously used str() to convert relative paths to strings, which resulted in backslashes on Windows and failed the allowed_prefixes virtual path validation. This replaces str() with .as_posix() to ensure virtual paths always use forward slashes.