### PR TITLE
fix(huggingface): support translation language-pair tasks in HuggingFacePipeline

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
+++ b/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
@@ -159,7 +159,9 @@ class HuggingFacePipeline(BaseLLM):
         tokenizer = AutoTokenizer.from_pretrained(model_id, **_model_kwargs)
 
         if backend in {"openvino", "ipex"}:
-            if task not in VALID_TASKS:
+            if task not in VALID_TASKS and not (
+                isinstance(task, str) and task.startswith("translation_")
+            ):
                 msg = (
                     f"Got invalid task {task}, "
                     f"currently only {VALID_TASKS} are supported"
@@ -356,7 +358,10 @@ class HuggingFacePipeline(BaseLLM):
                     text = response["generated_text"]
                 elif self.pipeline.task == "summarization":
                     text = response["summary_text"]
-                elif self.pipeline.task in "translation":
+                elif self.pipeline.task == "translation" or (
+                    isinstance(self.pipeline.task, str)
+                    and self.pipeline.task.startswith("translation_")
+                ):
                     text = response["translation_text"]
                 else:
                     msg = (

--- a/libs/partners/huggingface/tests/unit_tests/test_huggingface_pipeline.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_huggingface_pipeline.py
@@ -45,3 +45,58 @@ def test_initialization_with_from_model_id(
     )
 
     assert llm.model_id == "mock-model-id"
+
+
+def test_generate_translation_task() -> None:
+    """Translation pipelines report a task like ``translation_en_to_fr``.
+
+    The output payload uses the ``translation_text`` key, so ``_generate`` must
+    route these tasks to that key rather than rejecting them as invalid.
+    """
+    mock_pipe = MagicMock()
+    mock_pipe.task = "translation_en_to_fr"
+    mock_pipe.model.name_or_path = "mock-model-id"
+    mock_pipe.return_value = [{"translation_text": "Bonjour le monde"}]
+
+    llm = HuggingFacePipeline(pipeline=mock_pipe)
+    result = llm._generate(["Hello world"])
+
+    assert result.generations[0][0].text == "Bonjour le monde"
+
+
+def test_generate_bare_translation_task() -> None:
+    """A pipeline whose task is exactly ``translation`` must also be handled."""
+    mock_pipe = MagicMock()
+    mock_pipe.task = "translation"
+    mock_pipe.model.name_or_path = "mock-model-id"
+    mock_pipe.return_value = [{"translation_text": "Bonjour"}]
+
+    llm = HuggingFacePipeline(pipeline=mock_pipe)
+    result = llm._generate(["Hello"])
+
+    assert result.generations[0][0].text == "Bonjour"
+
+
+def test_generate_none_or_invalid_task_raises_value_error() -> None:
+    """Pipelines with None or invalid task must raise ValueError, not AttributeError."""
+    import pytest
+
+    # Test None task
+    mock_pipe_none = MagicMock()
+    mock_pipe_none.task = None
+    mock_pipe_none.model.name_or_path = "mock-model-id"
+    mock_pipe_none.return_value = [{"text": "Something"}]
+
+    llm_none = HuggingFacePipeline(pipeline=mock_pipe_none)
+    with pytest.raises(ValueError, match="Got invalid task None"):
+        llm_none._generate(["Hello"])
+
+    # Test invalid string task
+    mock_pipe_inv = MagicMock()
+    mock_pipe_inv.task = "invalid-task"
+    mock_pipe_inv.model.name_or_path = "mock-model-id"
+    mock_pipe_inv.return_value = [{"text": "Something"}]
+
+    llm_inv = HuggingFacePipeline(pipeline=mock_pipe_inv)
+    with pytest.raises(ValueError, match="Got invalid task invalid-task"):
+        llm_inv._generate(["Hello"])


### PR DESCRIPTION
Fixes #40095

### Description
In `HuggingFacePipeline._generate`, the check `elif self.pipeline.task in "translation":` was an inverted substring check. This caused translation tasks specifying language pairs (such as `translation_en_to_fr`) to raise `ValueError("Got invalid task ...")` despite being valid translation pipelines with `translation_text` keys.

### Changes
- Updated `HuggingFacePipeline._generate` to support both `task == "translation"` and `task.startswith("translation_")`.
- Guarded against non-string / `None` tasks with `isinstance(self.pipeline.task, str)` to prevent `AttributeError`.
- Updated `from_model_id` task validation for `openvino` / `ipex` backends to accept `translation_*` tasks.
- Added comprehensive unit tests in `test_huggingface_pipeline.py`.

### Verification
- `pytest libs/partners/huggingface/tests/unit_tests/test_huggingface_pipeline.py` (6/6 passed)
- `ruff check .` (All checks passed, 0 errors)
