### PR TITLE
docs(core): remove stale Args/Raises entries from FileCallbackHandler._write and ChatGeneration.set_text

### DIFF
--- a/libs/core/langchain_core/callbacks/file.py
+++ b/libs/core/langchain_core/callbacks/file.py
@@ -135,7 +135,6 @@ class FileCallbackHandler(BaseCallbackHandler):
             text: The text to write to the file.
             color: Optional color for the text. Defaults to `self.color`.
             end: String appended after the text.
-            file: Optional file to write to. Defaults to `self.file`.
 
         Raises:
             RuntimeError: If the file is closed or not available.

--- a/libs/core/langchain_core/outputs/chat_generation.py
+++ b/libs/core/langchain_core/outputs/chat_generation.py
@@ -43,17 +43,7 @@ class ChatGeneration(Generation):
 
     @model_validator(mode="after")
     def set_text(self) -> Self:
-        """Set the text attribute to be the contents of the message.
-
-        Args:
-            values: The values of the object.
-
-        Returns:
-            The values of the object with the text attribute set.
-
-        Raises:
-            ValueError: If the message is not a string or a list.
-        """
+        """Set the text attribute to be the contents of the message."""
         # Check for legacy blocks with "text" key but no "type" field.
         # Otherwise, delegate to `message.text`.
         if isinstance(self.message.content, list):


### PR DESCRIPTION
Body:

Fixes #40202

## Summary

Three docstring defects in `langchain-core` that misdocument the actual API (all still present on master, verified with the issue's own assertion script):

- `FileCallbackHandler._write` documents a `file` parameter it does not accept (signature is `text`, `color`, `end`)
- `ChatGeneration.set_text` documents a `values` parameter; it is a `model_validator(mode="after")` that takes none
- `ChatGeneration.set_text` documents a `ValueError: If the message is not a string or a list.` that the method never raises (no `raise` statements in its body)

This removes all three stale entries.

Credit: most of this fix existed in #38535 by @eeshsaxena, which was auto-closed for process reasons (author not assigned to the issue) and never reviewed — happy to stand down if that PR is revived.

## Verification

The issue's reproduction script passes against this change (all three assertion groups):

```python
params = set(inspect.signature(FileCallbackHandler._write).parameters) - {"self"}
assert params == {"text", "color", "end"}
assert "file:" not in inspect.getdoc(FileCallbackHandler._write)

params = set(inspect.signature(ChatGeneration.set_text).parameters) - {"self"}
assert params == set()
doc = inspect.getdoc(ChatGeneration.set_text)
assert "values: The values of the object." not in doc
assert "ValueError: If the message is not a string or a list." not in doc
```

`ruff check` and `ruff format --check` pass on both files. Docs-only change; no behavior affected.
