### PR TITLE
fix(core): avoid mutating message content in Anthropic translator

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/anthropic.py
+++ b/libs/core/langchain_core/messages/block_translators/anthropic.py
@@ -484,12 +484,19 @@ def _convert_to_v1_from_anthropic(message: AIMessage) -> list[types.ContentBlock
                 yield server_tool_result
 
             else:
-                new_block: types.NonStandardContentBlock = {
-                    "type": "non_standard",
-                    "value": block,
-                }
-                if "index" in new_block["value"]:
-                    new_block["index"] = new_block["value"].pop("index")
+                if "index" in block:
+                    # Copy before lifting `index` off the block: `block` is the
+                    # caller's own dict from `message.content`, and `.pop` would
+                    # otherwise mutate it in place.
+                    value = block.copy()
+                    index = value.pop("index")
+                    new_block: types.NonStandardContentBlock = {
+                        "type": "non_standard",
+                        "value": value,
+                        "index": index,
+                    }
+                else:
+                    new_block = {"type": "non_standard", "value": block}
                 yield new_block
 
     return list(_iter_blocks())

--- a/libs/core/tests/unit_tests/messages/block_translators/test_anthropic.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_anthropic.py
@@ -192,6 +192,36 @@ def test_convert_to_v1_from_anthropic() -> None:
     assert message.content != expected_content  # check no mutation
 
 
+def test_convert_to_v1_from_anthropic_index_no_mutation() -> None:
+    """`index` is lifted onto the `non_standard` wrapper without mutating `content`.
+
+    Regression test: the `else` branch built `non_standard["value"]` from the
+    original block dict (not a copy) and then `.pop("index")`'d off of it, deleting
+    `index` from `message.content` as a side effect of reading `.content_blocks`.
+    """
+    original_block = {"type": "something_else", "foo": "bar", "index": 3}
+    message = AIMessage(
+        content=[dict(original_block)],
+        response_metadata={"model_provider": "anthropic"},
+    )
+
+    first = message.content_blocks
+    second = message.content_blocks
+
+    assert message.content == [original_block]
+    assert (
+        first
+        == second
+        == [
+            {
+                "type": "non_standard",
+                "value": {"type": "something_else", "foo": "bar"},
+                "index": 3,
+            }
+        ]
+    )
+
+
 def test_convert_to_v1_from_anthropic_chunk() -> None:
     chunks = [
         AIMessageChunk(

--- a/libs/core/tests/unit_tests/messages/block_translators/test_bedrock.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_bedrock.py
@@ -129,6 +129,42 @@ def test_convert_to_v1_from_bedrock() -> None:
     assert message.content_blocks == expected_content
 
 
+def test_convert_to_v1_from_bedrock_index_no_mutation() -> None:
+    """`bedrock` inherits `_convert_to_v1_from_anthropic`, so it inherits this fix too.
+
+    Regression test: the `else` branch built `non_standard["value"]` from the
+    original block dict (not a copy) and then `.pop("index")`'d off of it, deleting
+    `index` from `message.content` as a side effect of reading `.content_blocks`.
+    """
+    original_block = {"type": "something_else", "foo": "bar", "index": 3}
+    message = AIMessage(
+        content=[dict(original_block)],
+        # model_name must mention "claude" -- translate_content() only routes
+        # through _convert_to_v1_from_bedrock() for Anthropic-backed models,
+        # else it falls back to best-effort parsing.
+        response_metadata={
+            "model_provider": "bedrock",
+            "model_name": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+        },
+    )
+
+    first = message.content_blocks
+    second = message.content_blocks
+
+    assert message.content == [original_block]
+    assert (
+        first
+        == second
+        == [
+            {
+                "type": "non_standard",
+                "value": {"type": "something_else", "foo": "bar"},
+                "index": 3,
+            }
+        ]
+    )
+
+
 def test_convert_to_v1_from_bedrock_chunk() -> None:
     chunks = [
         AIMessageChunk(


### PR DESCRIPTION
Fixes #40077

`_convert_to_v1_from_anthropic`'s fallback branch for an unrecognized content block wraps the original block by reference (`new_block["value"] = block`) and then pops `"index"` off of it. Since `new_block["value"]` *is* `block`, still referenced by `message.content`, that pop deletes `index` from the message's own stored content as a side effect of reading the read-only-looking `.content_blocks` property. `bedrock.py`'s `_convert_to_v1_from_bedrock` imports and calls this same function directly, so `model_provider="bedrock"` for Claude-backed models inherits the identical bug. Fix: copy the block before lifting `index` off it, mirroring the pattern already accepted for the analogous `bedrock_converse.py` case (#40022).

## Testing

- Added regression tests for both `anthropic` and `bedrock` providers asserting `message.content` is unchanged and repeated `.content_blocks` reads agree, for a block that carries an `index`.
- Confirmed both new tests fail on `master` and pass with this fix.
- `uv run pytest tests/unit_tests/` (full `langchain-core` suite): 2257 passed, 0 failed.
- `ruff check` / `ruff format --diff` / `mypy` on changed files: clean.
- `./scripts/lint_imports.sh`: clean.

## Release note

`AIMessage.content_blocks` (and `AIMessageChunk.content_blocks`) no longer mutates the message's own `content` when a non-standard content block carries an `index` key, for `model_provider` values `"anthropic"` and `"bedrock"`.
