### PR TITLE
fix(openai): align `login_chatgpt_device` with device auth contract

### DIFF
--- a/libs/partners/openai/langchain_openai/chatgpt_oauth.py
+++ b/libs/partners/openai/langchain_openai/chatgpt_oauth.py
@@ -58,6 +58,7 @@ CHATGPT_AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize"
 CHATGPT_TOKEN_URL = "https://auth.openai.com/oauth/token"  # noqa: S105
 CHATGPT_DEVICE_CODE_URL = "https://auth.openai.com/api/accounts/deviceauth/usercode"
 CHATGPT_DEVICE_TOKEN_URL = "https://auth.openai.com/api/accounts/deviceauth/token"  # noqa: S105
+CHATGPT_DEVICE_VERIFICATION_URL = "https://auth.openai.com/codex/device"
 CHATGPT_DEVICE_REDIRECT_URI = "https://auth.openai.com/deviceauth/callback"
 CHATGPT_AUTH_CLAIMS_NAMESPACE = "https://api.openai.com/auth"
 DEFAULT_REDIRECT_HOST = "localhost"
@@ -407,31 +408,6 @@ def _post_form(
             data=data,
             headers={"Accept": "application/json"},
         )
-    _raise_for_oauth_response(url, resp)
-    return resp.json()
-
-
-_DEVICE_POLL_PENDING_ERRORS = frozenset({"authorization_pending", "slow_down"})
-
-
-def _post_device_poll_form(
-    url: str,
-    data: dict[str, str],
-    *,
-    timeout: float = 30.0,
-) -> dict[str, Any]:
-    """POST a device-code poll and return expected pending error payloads."""
-    with httpx.Client(timeout=timeout) as client:
-        resp = client.post(
-            url,
-            data=data,
-            headers={"Accept": "application/json"},
-        )
-    if resp.status_code < 400:
-        return resp.json()
-    error_code, _ = _parse_oauth_error(resp)
-    if error_code in _DEVICE_POLL_PENDING_ERRORS:
-        return resp.json()
     _raise_for_oauth_response(url, resp)
     return resp.json()
 
@@ -974,7 +950,8 @@ def login_chatgpt_device(
         store_path: Where to persist the token. Defaults to
             `DEFAULT_STORE_PATH`.
         client_id: OAuth client ID (defaults to Codex/ChatGPT client).
-        poll_interval: Seconds between polls.
+        poll_interval: Minimum seconds between polls. The server-provided interval
+            takes precedence when longer.
         timeout: Total seconds to wait.
 
     Returns:
@@ -989,51 +966,46 @@ def login_chatgpt_device(
         `login_chatgpt`: Browser-based loopback flow preferred when a local
             browser and free callback port are available.
     """
-    _verifier, challenge = _generate_pkce_pair()
-    start = _post_form(
-        CHATGPT_DEVICE_CODE_URL,
-        {
-            "client_id": client_id,
-            "scope": DEFAULT_SCOPE,
-            "code_challenge": challenge,
-            "code_challenge_method": "S256",
-        },
-    )
-    device_code = start.get("device_code")
-    user_code = start.get("user_code")
-    verification_uri = start.get("verification_uri") or start.get(
-        "verification_uri_complete"
-    )
-    if not (device_code and user_code and verification_uri):
-        msg = "ChatGPT device-code response missing required fields."
-        raise RuntimeError(msg)
-    logger.info(
-        "Open %s in a browser and enter user code: %s", verification_uri, user_code
-    )
-
-    deadline = time.monotonic() + timeout
-    authorization_code: str | None = None
-    current_interval = poll_interval
-    while time.monotonic() < deadline:
-        poll = _post_device_poll_form(
-            CHATGPT_DEVICE_TOKEN_URL,
-            {"client_id": client_id, "device_code": device_code},
-        )
-        if poll.get("authorization_code"):
-            authorization_code = poll["authorization_code"]
-            break
-        error = poll.get("error")
-        if error == "slow_down":
-            # RFC 8628 §3.5: bump the poll interval by 5 seconds to comply
-            # with server-side rate limiting; otherwise we risk being banned.
-            current_interval += 5
-        elif error and error != "authorization_pending":
-            msg = f"Device authorization failed: {error}"
+    with httpx.Client(timeout=30.0) as client:
+        resp = client.post(CHATGPT_DEVICE_CODE_URL, json={"client_id": client_id})
+        _raise_for_oauth_response(CHATGPT_DEVICE_CODE_URL, resp)
+        start = resp.json()
+        device_auth_id = start.get("device_auth_id")
+        user_code = start.get("user_code") or start.get("usercode")
+        if not (device_auth_id and user_code):
+            msg = "ChatGPT device-code response missing required fields."
             raise RuntimeError(msg)
-        time.sleep(current_interval)
-    if not authorization_code:
-        msg = "Timed out waiting for ChatGPT device authorization."
-        raise TimeoutError(msg)
+        current_interval = max(poll_interval, float(start.get("interval", 0)))
+        print(  # noqa: T201
+            f"Open {CHATGPT_DEVICE_VERIFICATION_URL} in a browser "
+            f"and enter user code: {user_code}"
+        )
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            resp = client.post(
+                CHATGPT_DEVICE_TOKEN_URL,
+                json={"device_auth_id": device_auth_id, "user_code": user_code},
+            )
+            if resp.is_success:
+                authorization = resp.json()
+                authorization_code = authorization.get("authorization_code")
+                code_verifier = authorization.get("code_verifier")
+                if not (authorization_code and code_verifier):
+                    msg = (
+                        "ChatGPT device authorization response missing required fields."
+                    )
+                    raise RuntimeError(msg)
+                break
+            # OpenAI's device flow signals pending authorization with HTTP status,
+            # rather than RFC 8628's authorization_pending/slow_down error bodies.
+            if resp.status_code not in {403, 404}:
+                _raise_for_oauth_response(CHATGPT_DEVICE_TOKEN_URL, resp)
+                resp.raise_for_status()
+            time.sleep(current_interval)
+        else:
+            msg = "Timed out waiting for ChatGPT device authorization."
+            raise TimeoutError(msg)
 
     response = _post_form(
         CHATGPT_TOKEN_URL,
@@ -1042,7 +1014,7 @@ def login_chatgpt_device(
             "code": authorization_code,
             "redirect_uri": CHATGPT_DEVICE_REDIRECT_URI,
             "client_id": client_id,
-            "code_verifier": _verifier,
+            "code_verifier": code_verifier,
         },
     )
     token = _token_from_response(response)

--- a/libs/partners/openai/tests/unit_tests/test_chatgpt_oauth.py
+++ b/libs/partners/openai/tests/unit_tests/test_chatgpt_oauth.py
@@ -11,10 +11,10 @@ import os
 from datetime import datetime, timedelta, timezone, tzinfo
 from pathlib import Path
 from typing import Any, Literal, overload
+from urllib.parse import parse_qs
 
 import httpx
 import pytest
-from typing_extensions import Self
 
 from langchain_openai import chatgpt_oauth as oauth_module
 from langchain_openai.chatgpt_oauth import (
@@ -683,150 +683,191 @@ def test_login_chatgpt_skips_browser_when_disabled(
     assert opened == []
 
 
-def test_login_chatgpt_device_honors_slow_down(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(("interval", "expected_interval"), [(2, 2), ("2", 2), (0, 1)])
+def test_login_chatgpt_device_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    interval: int | str,
+    expected_interval: float,
 ) -> None:
-    posts: list[dict[str, Any]] = []
-    polls: list[dict[str, Any]] = []
+    requests: list[httpx.Request] = []
     sleeps: list[float] = []
-    post_responses: list[dict[str, Any]] = [
-        {
-            "device_code": "dev",
-            "user_code": "user",
-            "verification_uri": "https://example.com",
-        },
-        {
-            "access_token": "at",
-            "refresh_token": "rt",
-            "expires_in": 3600,
-        },
-    ]
-    poll_responses: list[dict[str, Any]] = [
-        {"error": "authorization_pending"},
-        {"error": "slow_down"},
-        {"authorization_code": "auth-code"},
-    ]
-    post_iter = iter(post_responses)
-    poll_iter = iter(poll_responses)
+    statuses = iter([403, 404, 200])
 
-    def _fake_post(url: str, data: dict[str, str], **_: Any) -> dict[str, Any]:
-        posts.append({"url": url, "data": data})
-        return next(post_iter)
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url == oauth_module.CHATGPT_DEVICE_CODE_URL:
+            if request.headers["content-type"] != "application/json":
+                return httpx.Response(
+                    400,
+                    json={
+                        "error": {
+                            "message": (
+                                "Input should be a valid dictionary or object "
+                                "to extract fields from"
+                            ),
+                            "type": "invalid_request_error",
+                            "param": None,
+                            "code": None,
+                        }
+                    },
+                )
+            assert json.loads(request.content) == {"client_id": "custom-client"}
+            return httpx.Response(
+                200,
+                json={
+                    "device_auth_id": "dev",
+                    "user_code": "user",
+                    "interval": interval,
+                },
+            )
+        if request.url == oauth_module.CHATGPT_DEVICE_TOKEN_URL:
+            assert request.headers["content-type"] == "application/json"
+            assert json.loads(request.content) == {
+                "device_auth_id": "dev",
+                "user_code": "user",
+            }
+            status = next(statuses)
+            if status != 200:
+                return httpx.Response(status, text="Still waiting")
+            return httpx.Response(
+                200,
+                json={
+                    "authorization_code": "auth-code",
+                    "code_verifier": "server-verifier",
+                    "code_challenge": "server-challenge",
+                },
+            )
+        assert request.url == CHATGPT_TOKEN_URL
+        assert request.headers["content-type"] == "application/x-www-form-urlencoded"
+        assert parse_qs(request.content.decode()) == {
+            "grant_type": ["authorization_code"],
+            "code": ["auth-code"],
+            "redirect_uri": [oauth_module.CHATGPT_DEVICE_REDIRECT_URI],
+            "client_id": ["custom-client"],
+            "code_verifier": ["server-verifier"],
+        }
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "at",
+                "refresh_token": "rt",
+                "expires_in": 3600,
+            },
+        )
 
-    def _fake_poll(url: str, data: dict[str, str], **_: Any) -> dict[str, Any]:
-        polls.append({"url": url, "data": data})
-        return next(poll_iter)
+    transport = httpx.MockTransport(handle)
+    client_class = httpx.Client
+    monkeypatch.setattr(
+        oauth_module.httpx,
+        "Client",
+        lambda **kw: client_class(transport=transport, **kw),
+    )
+    monkeypatch.setattr(oauth_module.time, "sleep", sleeps.append)
+    path = tmp_path / "auth.json"
+    provider = login_chatgpt_device(
+        store_path=path, client_id="custom-client", poll_interval=1
+    )
+    assert len(requests) == 5
+    assert sleeps == [expected_interval, expected_interval]
+    assert provider.get_token().access_token == "at"
+    assert json.loads(path.read_text())["refresh_token"] == "rt"
+    output = capsys.readouterr().out
+    assert "https://auth.openai.com/codex/device" in output
+    assert "and enter user code: user" in output
 
-    def _track_sleep(seconds: float) -> None:
-        sleeps.append(seconds)
 
-    monkeypatch.setattr(oauth_module, "_post_form", _fake_post)
-    monkeypatch.setattr(oauth_module, "_post_device_poll_form", _fake_poll)
-    monkeypatch.setattr(oauth_module.time, "sleep", _track_sleep)
-
-    login_chatgpt_device(store_path=tmp_path / "x.json", poll_interval=2.0)
-
-    assert len(polls) == 3
-    # First sleep at base interval, then bumped by +5 after `slow_down`.
-    assert sleeps[0] == pytest.approx(2.0)
-    assert sleeps[1] == pytest.approx(7.0)
-
-
+@pytest.mark.parametrize("status", [400, 429, 500])
 def test_login_chatgpt_device_raises_on_fatal_error(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    status: int,
 ) -> None:
+    def handle(request: httpx.Request) -> httpx.Response:
+        if request.url == oauth_module.CHATGPT_DEVICE_CODE_URL:
+            return httpx.Response(
+                200,
+                json={
+                    "device_auth_id": "dev",
+                    "user_code": "user",
+                    "interval": "5",
+                },
+            )
+        assert request.url == oauth_module.CHATGPT_DEVICE_TOKEN_URL
+        return httpx.Response(status, json={"error": "access_denied"})
+
+    client_class = httpx.Client
     monkeypatch.setattr(
-        oauth_module,
-        "_post_form",
-        lambda *_a, **_k: {
-            "device_code": "d",
-            "user_code": "u",
-            "verification_uri": "https://example.com",
-        },
+        oauth_module.httpx,
+        "Client",
+        lambda **kw: client_class(transport=httpx.MockTransport(handle), **kw),
     )
-    monkeypatch.setattr(
-        oauth_module,
-        "_post_device_poll_form",
-        lambda *_a, **_k: {"error": "access_denied"},
-    )
-    monkeypatch.setattr(oauth_module.time, "sleep", lambda _s: None)
+    path = tmp_path / "auth.json"
     with pytest.raises(RuntimeError, match="access_denied"):
-        login_chatgpt_device(store_path=tmp_path / "x.json")
+        login_chatgpt_device(store_path=path)
+    assert not path.exists()
 
 
 def test_login_chatgpt_device_times_out(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    def handle(request: httpx.Request) -> httpx.Response:
+        if request.url == oauth_module.CHATGPT_DEVICE_CODE_URL:
+            return httpx.Response(
+                200,
+                json={
+                    "device_auth_id": "dev",
+                    "user_code": "user",
+                    "interval": "5",
+                },
+            )
+        assert request.url == oauth_module.CHATGPT_DEVICE_TOKEN_URL
+        return httpx.Response(403)
+
+    client_class = httpx.Client
     monkeypatch.setattr(
-        oauth_module,
-        "_post_form",
-        lambda *_a, **_k: {
-            "device_code": "d",
-            "user_code": "u",
-            "verification_uri": "https://example.com",
-        },
+        oauth_module.httpx,
+        "Client",
+        lambda **kw: client_class(transport=httpx.MockTransport(handle), **kw),
     )
-    monkeypatch.setattr(
-        oauth_module,
-        "_post_device_poll_form",
-        lambda *_a, **_k: {"error": "authorization_pending"},
-    )
-    monkeypatch.setattr(oauth_module.time, "sleep", lambda _s: None)
-    # Force the monotonic clock to immediately blow past the deadline.
+    monkeypatch.setattr(oauth_module.time, "sleep", lambda _: None)
     times = iter([0.0, 0.0, 9999.0])
     monkeypatch.setattr(oauth_module.time, "monotonic", lambda: next(times))
+    path = tmp_path / "auth.json"
     with pytest.raises(TimeoutError):
-        login_chatgpt_device(
-            store_path=tmp_path / "x.json", poll_interval=0.0, timeout=1.0
-        )
+        login_chatgpt_device(store_path=path, timeout=1)
+    assert not path.exists()
 
 
-def test_post_device_poll_form_returns_pending_400_payload(
+@pytest.mark.parametrize(
+    "missing", ["device_auth_id", "user_code", "authorization_code", "code_verifier"]
+)
+def test_login_chatgpt_device_rejects_missing_fields(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    missing: str,
 ) -> None:
-    class _FakeClient:
-        def __init__(self, **_: Any) -> None:
-            pass
+    def handle(request: httpx.Request) -> httpx.Response:
+        if request.url == oauth_module.CHATGPT_DEVICE_CODE_URL:
+            payload = {"device_auth_id": "dev", "user_code": "user", "interval": "5"}
+        else:
+            assert request.url == oauth_module.CHATGPT_DEVICE_TOKEN_URL
+            payload = {"authorization_code": "code", "code_verifier": "verifier"}
+        payload.pop(missing, None)
+        return httpx.Response(200, json=payload)
 
-        def __enter__(self) -> Self:
-            return self
-
-        def __exit__(self, *_args: object) -> None:
-            pass
-
-        def post(self, *_args: Any, **_kwargs: Any) -> httpx.Response:
-            return _make_response(400, {"error": "authorization_pending"})
-
-    monkeypatch.setattr(oauth_module.httpx, "Client", _FakeClient)
-
-    payload = oauth_module._post_device_poll_form(
-        "https://example.com/poll", {"device_code": "d"}
+    client_class = httpx.Client
+    monkeypatch.setattr(
+        oauth_module.httpx,
+        "Client",
+        lambda **kw: client_class(transport=httpx.MockTransport(handle), **kw),
     )
-    assert payload == {"error": "authorization_pending"}
-
-
-def test_post_device_poll_form_raises_fatal_400(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    class _FakeClient:
-        def __init__(self, **_: Any) -> None:
-            pass
-
-        def __enter__(self) -> Self:
-            return self
-
-        def __exit__(self, *_args: object) -> None:
-            pass
-
-        def post(self, *_args: Any, **_kwargs: Any) -> httpx.Response:
-            return _make_response(400, {"error": "access_denied"})
-
-    monkeypatch.setattr(oauth_module.httpx, "Client", _FakeClient)
-
-    with pytest.raises(RuntimeError, match="access_denied"):
-        oauth_module._post_device_poll_form(
-            "https://example.com/poll", {"device_code": "d"}
-        )
+    path = tmp_path / "auth.json"
+    with pytest.raises(RuntimeError, match="missing required fields"):
+        login_chatgpt_device(store_path=path)
+    assert not path.exists()
 
 
 def test_callback_handler_extracts_code_and_state() -> None:


### PR DESCRIPTION
Fixes #40216

---

`login_chatgpt_device` fails with HTTP 400 before users receive a device code. This aligns the requests and token exchange with OpenAI's device-auth flow so users can complete headless sign-in, respecting the server polling interval and using its returned PKCE verifier.

HTTP transport tests cover request encoding, pending responses, token exchange, and failure paths. All 62 OAuth tests pass; the unchanged code reproduced the reported 400 against the live endpoint, while the fix completed sign-in and token persistence. The public function signature is unchanged.

## Release note

Fixed `login_chatgpt_device` failing with HTTP 400 during ChatGPT device authorization. Login instructions are now printed even when info logging is disabled.

Prepared with assistance from Codex.
