### PR TITLE
fix(deepseek): preserve reasoning_content in request payload

### DIFF
--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -342,6 +342,30 @@ class ChatDeepSeek(BaseChatOpenAI):
         **kwargs: Any,
     ) -> dict:
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
+
+        # DeepSeek's thinking mode requires follow-up requests to carry the
+        # previous assistant turn's `reasoning_content`, otherwise the API
+        # returns a 400 ("The `reasoning_content` in the thinking mode must be
+        # passed back to the API"). The base class drops that field on the
+        # outbound path because it is not part of the OpenAI message schema,
+        # so re-attach it from the input messages onto the corresponding
+        # converted assistant dicts. This package writes `reasoning_content`
+        # into `additional_kwargs` on the inbound side, so reading it back from
+        # there keeps the field round-tripping across a tool-calling loop.
+        messages = self._convert_input(input_).to_messages()
+        for message, converted in zip(messages, payload["messages"], strict=False):
+            if (
+                isinstance(message, AIMessage)
+                and converted.get("role") == "assistant"
+                and (
+                    reasoning_content := message.additional_kwargs.get(
+                        "reasoning_content"
+                    )
+                )
+                is not None
+            ):
+                converted["reasoning_content"] = reasoning_content
+
         for message in payload["messages"]:
             if message["role"] == "tool" and isinstance(message["content"], list):
                 message["content"] = json.dumps(message["content"])

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Literal
 from unittest.mock import MagicMock
 
-from langchain_core.messages import AIMessage, AIMessageChunk, ToolMessage
+from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
 from langchain_tests.unit_tests import ChatModelUnitTests
 from openai import BaseModel
 from openai.types import CompletionUsage
@@ -254,6 +254,47 @@ class TestChatDeepSeekCustomUnit:
         tool_message = ToolMessage(content="test string", tool_call_id="test_id")
         payload = chat_model._get_request_payload([tool_message])
         assert payload["messages"][0]["content"] == "test string"
+
+    def test_get_request_payload_preserves_reasoning_content(self) -> None:
+        """Test that reasoning_content on prior assistant messages round-trips.
+
+        DeepSeek's thinking mode requires follow-up requests to carry the
+        previous assistant turn's `reasoning_content`, otherwise the API
+        returns a 400. The base class drops the field, so it must be
+        re-attached from the input messages.
+        """
+        chat_model = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("api_key"))
+
+        messages = [
+            HumanMessage(content="Hello!"),
+            AIMessage(
+                content="Hello, can I help you?",
+                additional_kwargs={
+                    "reasoning_content": "Simple greeting, just greet back.",
+                },
+            ),
+        ]
+
+        payload = chat_model._get_request_payload(messages)
+
+        assistant = payload["messages"][1]
+        assert assistant["role"] == "assistant"
+        assert assistant["reasoning_content"] == "Simple greeting, just greet back."
+
+    def test_get_request_payload_without_reasoning_content(self) -> None:
+        """Test that assistant messages without reasoning_content are unaffected."""
+        chat_model = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("api_key"))
+
+        messages = [
+            HumanMessage(content="Hello!"),
+            AIMessage(content="Hello, can I help you?"),
+        ]
+
+        payload = chat_model._get_request_payload(messages)
+
+        assistant = payload["messages"][1]
+        assert assistant["role"] == "assistant"
+        assert "reasoning_content" not in assistant
 
 
 class SampleTool(PydanticBaseModel):


### PR DESCRIPTION
Fixes #40219

---

Users running `ChatDeepSeek` with a reasoning-capable model (e.g. `deepseek-v4-flash`) in a multi-round tool-calling loop were hitting intermittent `400` errors:

```
openai.BadRequestError: Error code: 400 - {'error': {'message': 'The `reasoning_content` in the thinking mode must be passed back to the API.', ...}}
```

Per DeepSeek's [thinking-mode guide](https://api-docs.deepseek.com/guides/thinking_mode/), a follow-up request must carry the previous assistant turn's `reasoning_content`. `ChatDeepSeek` already writes that field into `additional_kwargs` on the *inbound* side (`_create_chat_result` and the streaming parser), but `_get_request_payload` delegates to `BaseChatOpenAI._get_request_payload`, which drops it on the outbound path (and `_convert_message_to_dict` strips `reasoning_content`-typed content blocks). The field never round-trips, so the first tool round-trip can 400.

## What changed

`ChatDeepSeek._get_request_payload` now walks the input messages alongside the converted message list and re-attaches `additional_kwargs["reasoning_content"]` from each `AIMessage` onto the corresponding assistant dict. This keeps the change scoped to langchain-deepseek, with no behavior change for other OpenAI-compatible providers that don't accept the field. A regression test covering both the present and absent cases is included.

## Note on the approach

@0717lee proposed this exact approach in #40219 (and noted a preference to coordinate with the cross-provider tracking issue #34328). This PR implements that approach; happy to coordinate on anything that lands for #34328.

## Note on the `require-issue-link` bot

This repo's `require-issue-link` bot auto-closes PRs whose author is not yet assigned to the referenced issue. I've posted an assignment request on #40219; if this PR shows as auto-closed before a maintainer assigns me, that's expected and it should reopen once assignment happens.

## Release note

`ChatDeepSeek` now preserves `reasoning_content` from prior assistant messages in follow-up requests, preventing `400` errors in multi-round tool-calling conversations with reasoning models.

---

*This contribution was authored with the assistance of an AI agent (Nous Research Hermes).*
