### PR TITLE
test(core): rewrite test_text_accessor to actually test the deprecated .text() method

### DIFF
--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -1,6 +1,8 @@
 import uuid
 from typing import Any, get_args
 
+from langchain_core._api.deprecation import LangChainDeprecationWarning
+
 import pytest
 
 from langchain_core.documents import Document
@@ -1397,45 +1399,46 @@ def test_typed_init() -> None:
 
 def test_text_accessor() -> None:
     """Test that `message.text` property and `.text()` method return the same value."""
-    human_msg = HumanMessage(content="Hello world")
-    assert human_msg.text == "Hello world"
-    assert human_msg.text == "Hello world"
-    assert str(human_msg.text) == str(human_msg.text)
+    test_cases: list[tuple[str, Any, str]] = [
+        ("HumanMessage", HumanMessage(content="Hello world"), "Hello world"),
+        (
+            "SystemMessage",
+            SystemMessage(content="You are a helpful assistant"),
+            "You are a helpful assistant",
+        ),
+        ("AIMessage", AIMessage(content="I can help you with that"), "I can help you with that"),
+        (
+            "ToolMessage",
+            ToolMessage(content="Task completed", tool_call_id="tool_1"),
+            "Task completed",
+        ),
+        (
+            "complex HumanMessage",
+            HumanMessage(
+                content=[{"type": "text", "text": "Hello "}, {"type": "text", "text": "world"}]
+            ),
+            "Hello world",
+        ),
+        (
+            "mixed AIMessage",
+            AIMessage(
+                content=[
+                    {"type": "text", "text": "The answer is "},
+                    {"type": "tool_use", "name": "calculate", "input": {"x": 2}, "id": "1"},
+                    {"type": "text", "text": "42"},
+                ]
+            ),
+            "The answer is 42",
+        ),
+        ("empty HumanMessage", HumanMessage(content=[]), ""),
+    ]
 
-    system_msg = SystemMessage(content="You are a helpful assistant")
-    assert system_msg.text == "You are a helpful assistant"
-    assert system_msg.text == "You are a helpful assistant"
-    assert str(system_msg.text) == str(system_msg.text)
-
-    ai_msg = AIMessage(content="I can help you with that")
-    assert ai_msg.text == "I can help you with that"
-    assert ai_msg.text == "I can help you with that"
-    assert str(ai_msg.text) == str(ai_msg.text)
-
-    tool_msg = ToolMessage(content="Task completed", tool_call_id="tool_1")
-    assert tool_msg.text == "Task completed"
-    assert tool_msg.text == "Task completed"
-    assert str(tool_msg.text) == str(tool_msg.text)
-
-    complex_msg = HumanMessage(
-        content=[{"type": "text", "text": "Hello "}, {"type": "text", "text": "world"}]
-    )
-    assert complex_msg.text == "Hello world"
-    assert complex_msg.text == "Hello world"
-    assert str(complex_msg.text) == str(complex_msg.text)
-
-    mixed_msg = AIMessage(
-        content=[
-            {"type": "text", "text": "The answer is "},
-            {"type": "tool_use", "name": "calculate", "input": {"x": 2}, "id": "1"},
-            {"type": "text", "text": "42"},
-        ]
-    )
-    assert mixed_msg.text == "The answer is 42"
-    assert mixed_msg.text == "The answer is 42"
-    assert str(mixed_msg.text) == str(mixed_msg.text)
-
-    empty_msg = HumanMessage(content=[])
-    assert empty_msg.text == ""
-    assert empty_msg.text == ""
-    assert str(empty_msg.text) == str(empty_msg.text)
+    for name, msg, expected in test_cases:
+        # Property returns the expected text
+        assert msg.text == expected, f"{name}: property returned wrong value"
+        # .text() method returns the same value
+        with pytest.warns(LangChainDeprecationWarning):
+            result = msg.text()
+        assert result == expected, f"{name}: method returned wrong value"
+        # Property and method are consistent
+        assert msg.text == result, f"{name}: property and method disagree"


### PR DESCRIPTION
## Summary

Fixes [#40225](https://github.com/langchain-ai/langchain/issues/40225).

The test `test_text_accessor`'s docstring claims it verifies that the
`message.text` property and `.text()` method return the same value — but
the original implementation only checked the property twice and then ran
`str(msg.text) == str(msg.text)`, a vacuous self-comparison that always
passes regardless of what `.text()` returns.

## Changes

- Rewrites the test as a parametrized loop over the same seven message shapes
- Asserts `msg.text()` returns the same value as `msg.text`
- Uses `pytest.warns(LangChainDeprecationWarning)` to verify the method call
  path emits the expected deprecation warning (coverage that was lost in the
  v1.0.0 release when `.text` became a property backed by `TextAccessor`)
- Removes the duplicate property assertions and vacuous `str` comparisons

## Testing

- All existing message tests pass
- New assertions fail if `TextAccessor.__call__` is replaced with a function
  returning the wrong value or emitting no warning, catching the exact
  regression the original test missed
