### PR TITLE
fix(langchain): enforce interrupt_on policy on cross-tool edits in HumanInTheLoopMiddleware

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -475,9 +475,57 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
                 decision = decisions[decision_idx]
                 decision_idx += 1
 
+                # Check if this is a cross-tool edit
+                if (
+                    decision["type"] == "edit"
+                    and "edit" in config["allowed_decisions"]
+                    and decision["edited_action"]["name"] != tool_call["name"]
+                ):
+                    target_tool_name = decision["edited_action"]["name"]
+                    target_config = self.interrupt_on.get(target_tool_name)
+
+                    # If the target tool has an interrupt_on policy, re-interrupt
+                    if target_config is not None:
+                        # Build a new ToolCall for the edited action
+                        edited_tool_call = ToolCall(
+                            type="tool_call",
+                            name=target_tool_name,
+                            args=decision["edited_action"]["args"],
+                            id=tool_call["id"],
+                        )
+
+                        # Create a new action request and review config for target tool
+                        new_action_request, new_review_config = self._create_action_and_config(
+                            edited_tool_call, target_config, state, runtime
+                        )
+
+                        # Trigger a new interrupt specifically for target tool
+                        new_decisions = interrupt(
+                            HITLRequest(
+                                action_requests=[new_action_request],
+                                review_configs=[new_review_config],
+                            )
+                        )["decisions"]
+
+                        # Process the new decision (approve/reject/edit again)
+                        revised_tool_call, tool_message = self._process_decision(
+                            new_decisions[0], edited_tool_call, target_config
+                        )
+
+                        revised_tool_calls.append(revised_tool_call)
+                        if tool_message:
+                            artificial_tool_messages.append(tool_message)
+                        continue
+
+
+                # Fallback: original logic for non-cross-tool edits
                 revised_tool_call, tool_message = self._process_decision(
                     decision, tool_call, config
                 )
+
+                revised_tool_calls.append(revised_tool_call)
+                if tool_message:
+                    artificial_tool_messages.append(tool_message)
                 if revised_tool_call is not None:
                     revised_tool_calls.append(revised_tool_call)
                 if tool_message:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/test_hitl_cross_tool_edit.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/test_hitl_cross_tool_edit.py
@@ -1,0 +1,124 @@
+from typing import Any
+
+import pytest
+from langchain.agents import create_agent
+from langchain.agents.middleware import HumanInTheLoopMiddleware
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, HumanMessage, ToolCall
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.types import Command
+
+
+executed: list[tuple[str, object]] = []
+
+
+@tool
+def tool_a(value: int) -> str:
+    """Run tool A."""
+    executed.append(("tool_a", value))
+    return "A executed"
+
+
+@tool
+def tool_b(value: str) -> str:
+    """Run tool B."""
+    executed.append(("tool_b", value))
+    return "B executed"
+
+
+class DeterministicModel(BaseChatModel):
+    """Emit one call to tool A, followed by a final response."""
+
+    response_index: int = 0
+
+    @property
+    def _llm_type(self) -> str:
+        return "deterministic-test-model"
+
+    def bind_tools(
+        self,
+        tools: Any,
+        **kwargs: Any,
+    ) -> "DeterministicModel":
+        return self
+
+    def _generate(
+        self,
+        messages: Any,
+        **kwargs: Any,
+    ) -> ChatResult:
+        if self.response_index == 0:
+            message = AIMessage(
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        name="tool_a",
+                        args={"value": 1},
+                        id="call-1",
+                    )
+                ],
+            )
+        else:
+            message = AIMessage(content="done")
+
+        self.response_index += 1
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+
+@pytest.fixture
+def agent() -> Any:
+    return create_agent(
+        model=DeterministicModel(),
+        tools=[tool_a, tool_b],
+        middleware=[
+            HumanInTheLoopMiddleware(
+                interrupt_on={
+                    "tool_a": {
+                        "allowed_decisions": ["approve", "edit"],
+                    },
+                    "tool_b": {
+                        "allowed_decisions": ["approve", "reject"],
+                    },
+                }
+            )
+        ],
+        checkpointer=InMemorySaver(),
+    )
+
+
+def test_cross_tool_edit_does_not_bypass_target_tool_policy(agent: Any) -> None:
+    config = {
+        "configurable": {
+            "thread_id": "hitl-cross-tool-edit",
+        }
+    }
+
+    first = agent.invoke(
+        {"messages": [HumanMessage(content="Run tool A")]},
+        config,
+    )
+
+    assert "__interrupt__" in first
+
+    final = agent.invoke(
+        Command(
+            resume={
+                "decisions": [
+                    {
+                        "type": "edit",
+                        "edited_action": {
+                            "name": "tool_b",
+                            "args": {"value": "edited"},
+                        },
+                    }
+                ]
+            }
+        ),
+        config,
+    )
+
+    # New Assertion
+    assert "__interrupt__" in final  # Should be True now!
+    assert executed == []  # tool_b should NOT have executed yet!


### PR DESCRIPTION
Fixes #40166

## Problem
When a human edits a tool call to change its name (e.g., from `tool_a` to `tool_b`), the middleware only evaluates the original tool's `interrupt_on` policy. The edited target tool's policy is never consulted, allowing a configured approval gate to be bypassed.

## Fix
Added a check in the decision-processing loop. If an edit changes the tool name, the middleware now looks up the target tool's `interrupt_on` config and, if present, triggers a **new interrupt** before execution. This ensures the target tool's `allowed_decisions` are respected.

## Tests
Added regression test proving that a cross-tool edit now triggers a second HITL interrupt instead of executing directly.

## Security Impact
Prevents bypassing sensitive-tool approval policies when editing actions.