### PR TITLE
fix(langchain): isolate file-search fallback with a subprocess timeout

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -11,7 +11,9 @@ import json
 import operator
 import os
 import re
+import signal
 import subprocess
+import sys
 from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
@@ -20,6 +22,17 @@ from typing import Literal
 from langchain_core.tools import tool
 
 from langchain.agents.middleware.types import AgentMiddleware, AgentState, ContextT, ResponseT
+
+# Hard wall-clock timeout (seconds) for the Python fallback search, matching
+# the timeout the ripgrep subprocess path uses. The fallback regex comes from
+# model output, so the search runs in a worker process under this deadline: a
+# catastrophically backtracking pattern burns at most this many seconds in a
+# throwaway process instead of pinning the agent's worker thread indefinitely.
+_FALLBACK_SEARCH_TIMEOUT = 30
+
+
+class _FallbackSearchTimeoutError(Exception):
+    """The isolated Python fallback search exceeded its deadline."""
 
 
 def _is_within_root(candidate: Path, root: Path) -> bool:
@@ -103,6 +116,87 @@ def _match_include_pattern(basename: str, pattern: str) -> bool:
         return False
 
     return any(fnmatch.fnmatch(basename, candidate) for candidate in expanded)
+
+
+def _search_tree(
+    base_full: Path,
+    root: Path,
+    pattern: str,
+    include: str | None,
+    max_file_size_bytes: int,
+) -> dict[str, list[tuple[int, str]]]:
+    """Regex-search every file under `base_full`, keyed by virtual path.
+
+    Body of the Python fallback search; runs inside the worker subprocess
+    started by `FilesystemFileSearchMiddleware._python_search`.
+    """
+    regex = re.compile(pattern)
+    results: dict[str, list[tuple[int, str]]] = {}
+
+    # Walk directory tree without following symlinked directories so traversal
+    # cannot leave the root via a symlinked subdirectory.
+    for walk_root, _dirs, files in os.walk(base_full, followlinks=False):
+        for name in files:
+            file_path = Path(walk_root) / name
+
+            # Re-check containment after resolving so an in-root symlinked file
+            # pointing outside the root is never read.
+            if not _is_within_root(file_path, root):
+                continue
+
+            if not file_path.is_file():
+                continue
+
+            # Check include filter
+            if include and not _match_include_pattern(file_path.name, include):
+                continue
+
+            # Skip files that are too large
+            if file_path.stat().st_size > max_file_size_bytes:
+                continue
+
+            try:
+                content = file_path.read_text()
+            except (UnicodeDecodeError, PermissionError):
+                continue
+
+            # Search content
+            for line_num, line in enumerate(content.splitlines(), 1):
+                if regex.search(line):
+                    virtual_path = "/" + str(file_path.relative_to(root))
+                    if virtual_path not in results:
+                        results[virtual_path] = []
+                    results[virtual_path].append((line_num, line))
+
+    return results
+
+
+def _worker_main() -> None:
+    """Handle one fallback-search request: JSON on stdin, JSON on stdout.
+
+    Entry point for the isolated worker subprocess started with
+    `sys.executable -m langchain.agents.middleware.file_search`. Byte-level
+    I/O keeps the protocol exact (no locale-dependent encoding of the
+    model-controlled pattern).
+    """
+    if hasattr(signal, "alarm"):
+        # Watchdog: the parent enforces the search deadline, but if it dies
+        # first (crash, kill) the default SIGALRM disposition still terminates
+        # this worker instead of leaving an orphaned runaway search behind.
+        signal.alarm(_FALLBACK_SEARCH_TIMEOUT + 5)
+    request = json.loads(sys.stdin.buffer.read().decode("utf-8"))
+    try:
+        results = _search_tree(
+            base_full=Path(request["base"]),
+            root=Path(request["root"]),
+            pattern=request["pattern"],
+            include=request["include"],
+            max_file_size_bytes=request["max_file_size_bytes"],
+        )
+        payload: dict[str, object] = {"results": results}
+    except Exception as e:
+        payload = {"error": f"{type(e).__name__}: {e}"}
+    sys.stdout.buffer.write(json.dumps(payload).encode("utf-8"))
 
 
 class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT]):
@@ -243,17 +337,23 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
 
             # Try ripgrep first if enabled
             results = None
-            if self.use_ripgrep:
-                with suppress(
-                    FileNotFoundError,
-                    subprocess.CalledProcessError,
-                    subprocess.TimeoutExpired,
-                ):
-                    results = self._ripgrep_search(pattern, path, include)
+            try:
+                if self.use_ripgrep:
+                    with suppress(
+                        FileNotFoundError,
+                        subprocess.CalledProcessError,
+                        subprocess.TimeoutExpired,
+                    ):
+                        results = self._ripgrep_search(pattern, path, include)
 
-            # Python fallback if ripgrep failed or is disabled
-            if results is None:
-                results = self._python_search(pattern, path, include)
+                # Python fallback if ripgrep failed or is disabled. The
+                # fallback executes the model-controlled regex in a worker
+                # subprocess with a hard timeout, so a pathological pattern is
+                # reported as a timeout rather than blocking this process.
+                if results is None:
+                    results = self._python_search(pattern, path, include)
+            except _FallbackSearchTimeoutError:
+                return f"Search timed out after {_FALLBACK_SEARCH_TIMEOUT} seconds"
 
             if not results:
                 return "No matches found"
@@ -349,7 +449,15 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
     def _python_search(
         self, pattern: str, base_path: str, include: str | None
     ) -> dict[str, list[tuple[int, str]]]:
-        """Search using Python regex (fallback)."""
+        """Search using Python regex (fallback) in an isolated worker process.
+
+        The pattern is model-controlled and CPython's `re` engine can backtrack
+        exponentially, so the search never runs in this process: a worker
+        subprocess (`sys.executable -m <this module>`) receives the request as
+        JSON on stdin and reports JSON on stdout, under the same hard timeout
+        the ripgrep path uses. On timeout or worker failure the caller gets a
+        bounded `_FallbackSearchTimeoutError` instead of a hung tool call.
+        """
         try:
             base_full = self._validate_and_resolve_path(base_path)
         except ValueError:
@@ -358,45 +466,52 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
         if not base_full.exists():
             return {}
 
-        regex = re.compile(pattern)
-        results: dict[str, list[tuple[int, str]]] = {}
+        request = json.dumps(
+            {
+                "base": str(base_full),
+                "root": str(self.root_path),
+                "pattern": pattern,
+                "include": include,
+                "max_file_size_bytes": self.max_file_size_bytes,
+            }
+        )
+        # The worker re-imports this module by name; give it the same import
+        # path this process used (covers source checkouts and installed trees).
+        env = dict(os.environ)
+        env["PYTHONPATH"] = os.pathsep.join(sys.path)
+        try:
+            result = subprocess.run(  # noqa: S603
+                [sys.executable, "-m", __name__],
+                input=request,
+                capture_output=True,
+                encoding="utf-8",
+                timeout=_FALLBACK_SEARCH_TIMEOUT,
+                check=False,
+                env=env,
+            )
+        except subprocess.TimeoutExpired:
+            # subprocess.run has already killed and reaped the worker.
+            raise _FallbackSearchTimeoutError from None
+        except OSError:
+            # The worker could not be spawned at all; fail closed rather than
+            # run an unbounded regex search in this process.
+            raise _FallbackSearchTimeoutError from None
 
-        # Walk directory tree without following symlinked directories so traversal
-        # cannot leave the root via a symlinked subdirectory.
-        for walk_root, _dirs, files in os.walk(base_full, followlinks=False):
-            for name in files:
-                file_path = Path(walk_root) / name
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            # Worker died before reporting (e.g. crashed); bounded failure.
+            raise _FallbackSearchTimeoutError from None
+        if not isinstance(payload, dict) or "results" not in payload:
+            raise _FallbackSearchTimeoutError from None
+        if "error" in payload:
+            msg = f"Fallback search worker failed: {payload['error']}"
+            raise RuntimeError(msg)
 
-                # Re-check containment after resolving so an in-root symlinked file
-                # pointing outside the root is never read.
-                if not _is_within_root(file_path, self.root_path):
-                    continue
-
-                if not file_path.is_file():
-                    continue
-
-                # Check include filter
-                if include and not _match_include_pattern(file_path.name, include):
-                    continue
-
-                # Skip files that are too large
-                if file_path.stat().st_size > self.max_file_size_bytes:
-                    continue
-
-                try:
-                    content = file_path.read_text()
-                except (UnicodeDecodeError, PermissionError):
-                    continue
-
-                # Search content
-                for line_num, line in enumerate(content.splitlines(), 1):
-                    if regex.search(line):
-                        virtual_path = "/" + str(file_path.relative_to(self.root_path))
-                        if virtual_path not in results:
-                            results[virtual_path] = []
-                        results[virtual_path].append((line_num, line))
-
-        return results
+        return {
+            virtual_path: [tuple(match) for match in matches]
+            for virtual_path, matches in payload["results"].items()
+        }
 
     @staticmethod
     def _format_grep_results(
@@ -431,3 +546,9 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
 __all__ = [
     "FilesystemFileSearchMiddleware",
 ]
+
+
+if __name__ == "__main__":
+    # Worker mode: `python -m langchain.agents.middleware.file_search`.
+    # Only ever started by FilesystemFileSearchMiddleware._python_search.
+    _worker_main()

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
@@ -1,6 +1,8 @@
 """Unit tests for file search middleware."""
 
+import json
 import os
+import time
 from pathlib import Path
 from typing import Any
 
@@ -601,3 +603,81 @@ class TestGrepEdgeCases:
 
         # Large file should be skipped
         assert "/small.txt" in result
+
+
+class TestFallbackSearchIsolation:
+    """Tests for the isolated worker subprocess behind the Python fallback."""
+
+    def test_fallback_times_out_on_pathological_pattern(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A catastrophically backtracking pattern is bounded, not a hang."""
+        # 40 hex chars + `([0-9a-f]+)+g` backtracks exponentially in CPython's
+        # `re` engine; the worker must be killed at the deadline instead.
+        (tmp_path / "package.lock").write_text('{"sha": "%s"}\n' % ("a" * 40), encoding="utf-8")
+        monkeypatch.setattr("langchain.agents.middleware.file_search._FALLBACK_SEARCH_TIMEOUT", 2)
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path), use_ripgrep=False)
+
+        assert isinstance(middleware.grep_search, StructuredTool)
+        assert middleware.grep_search.func is not None
+        start = time.monotonic()
+        result = middleware.grep_search.func(pattern=r"([0-9a-f]+)+g")
+        elapsed = time.monotonic() - start
+
+        assert result.startswith("Search timed out after")
+        # Bounded well below the default 30s deadline; no unbounded block.
+        assert elapsed < 30
+
+    def test_fallback_pattern_roundtrip_unicode_and_special_chars(self, tmp_path: Path) -> None:
+        """Worker transport (JSON over stdin) must not mangle patterns."""
+        (tmp_path / "u.txt").write_text(
+            "héllo wörld; rm -rf $(pwd) `id` | & <>\x00end\nplain\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "u2.txt").write_text("café über\n", encoding="utf-8")
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path), use_ripgrep=False)
+
+        assert isinstance(middleware.grep_search, StructuredTool)
+        assert middleware.grep_search.func is not None
+
+        assert "/u.txt" in middleware.grep_search.func(pattern="wörld; rm -rf")
+        assert "/u2.txt" in middleware.grep_search.func(pattern="caf[é] über")
+        assert "/u.txt" in middleware.grep_search.func(pattern="\x00end")
+
+    def test_ripgrep_hit_does_not_spawn_fallback_worker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When ripgrep returns results, no fallback worker is started."""
+        (tmp_path / "file1.py").write_text("print('hello')\n", encoding="utf-8")
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path), use_ripgrep=True)
+
+        rg_line = json.dumps(
+            {
+                "type": "match",
+                "data": {
+                    "path": {"text": str(tmp_path / "file1.py")},
+                    "line_number": 1,
+                    "lines": {"text": "print('hello')\n"},
+                },
+            }
+        )
+
+        calls: list[list[str]] = []
+
+        class DummyResult:
+            stdout = rg_line
+
+        def fake_run(*args: Any, **_kwargs: Any) -> DummyResult:
+            calls.append(args[0])
+            return DummyResult()
+
+        monkeypatch.setattr("langchain.agents.middleware.file_search.subprocess.run", fake_run)
+
+        assert isinstance(middleware.grep_search, StructuredTool)
+        assert middleware.grep_search.func is not None
+        result = middleware.grep_search.func(pattern="hello")
+
+        assert "/file1.py" in result
+        # Exactly one subprocess (ripgrep); the fallback worker never ran.
+        assert len(calls) == 1
+        assert calls[0][0] == "rg"


### PR DESCRIPTION
The Grep tool in `FilesystemFileSearchMiddleware` runs a model-controlled regex. When ripgrep is available it already executes in an isolated subprocess with a 30s timeout, but the Python fallback (used when `rg` is missing or times out) compiled and ran the same pattern in-process with no deadline — a nested-quantifier pattern could pin the agent's worker thread indefinitely. This moves the fallback search into a worker subprocess under the same 30s hard timeout the ripgrep path already uses.

---

## Problem

- The `pattern` argument of `grep_search` comes from model output, so a tool call fully controls the regex.
- The ripgrep path was already protected (`subprocess.run` with an argv list, no shell, `timeout=30`). When `rg` is unavailable — the documented default fallback, entered via suppressed `FileNotFoundError` — `_python_search` ran `re.compile(pattern)` + `regex.search(line)` over every line of every ≤10MB file **in the agent process, with no deadline**.
- CPython's `re` engine backtracks exponentially on nested quantifiers, so this is not a "slow query" but an unbounded block. Measured with `([0-9a-f]+)+g` against a hex line (a realistic lockfile sha): length 14 → 0.006s, 18 → 0.025s, 22 → 0.358s, 40 → still running past 10s with no bound. One such tool call blocks the worker thread indefinitely; repeated calls stall tool execution for the whole agent.

## Fix

An in-loop deadline cannot bound this: a CPython `re` match runs in a single C call that never yields to Python, so no per-line check, signal handler, or thread cancellation can interrupt catastrophic backtracking. The only reliable bound is process isolation with an OS-enforced kill — exactly the mechanism the ripgrep path already uses, so the fallback now mirrors it:

- The walk/search logic moved verbatim to a module-level `_search_tree`, executed in a worker subprocess: `subprocess.run([sys.executable, "-m", langchain.agents.middleware.file_search], input=<JSON request>, timeout=30, check=False)`. The request (`base`, `root`, `pattern`, `include`, `max_file_size_bytes`) travels as JSON on stdin — list argv, no shell, and model-controlled data never enters argv. JSON round-trips unicode/NUL/shell-metacharacter patterns exactly.
- Timeout, spawn failure, or a malformed worker reply becomes a bounded error that `grep_search` reports as `"Search timed out after 30 seconds"`.
- The worker arms `signal.alarm(35)` with the default disposition so an orphaned worker (if the parent dies first) still terminates in bounded time.
- Path validation and resolution still happen in the parent, unchanged.

## Behavior notes

- When ripgrep is present and returns results, nothing changes and the fallback worker is never spawned (asserted by a new test).
- A fallback search that legitimately needs >30s on a huge tree now reports a timeout, matching the cap the ripgrep path has always had.
- Each fallback call adds ~0.4s of interpreter startup for the worker; the ripgrep path is unaffected.
- Environments where `sys.executable -m` cannot spawn (e.g. frozen interpreters) fail closed with the timeout message rather than executing in-process.

## Release note

`FilesystemFileSearchMiddleware`'s Grep tool now runs its Python (non-ripgrep) fallback search in an isolated worker subprocess with a 30-second timeout, matching the ripgrep path. Previously a pathological regex (controllable via the tool's `pattern` argument) could block the calling agent indefinitely; it now returns `"Search timed out after 30 seconds"`.

## Verification

From `libs/langchain_v1`, with the repo-pinned toolchain:

- `ruff check` and `ruff format --check` (ruff 0.15.5, per `uv.lock`) pass on both changed files; `mypy` reports no issues on both files.
- `pytest tests/unit_tests/agents/middleware/implementations/test_file_search.py` — **45 passed**: the 42 pre-existing tests (which now exercise the worker subprocess end-to-end, including symlink containment and include/max-size filtering) plus 3 new tests:
  - a catastrophically backtracking pattern is bounded by the deadline (monkeypatched to 2s; previously an unbounded hang),
  - patterns with unicode, NUL, and shell metacharacters round-trip exactly through the JSON/stdin transport,
  - a ripgrep hit spawns exactly one subprocess (`rg`) and never starts the fallback worker.

Found during a security review of this middleware; happy to file a linked issue if maintainers want one (held off to avoid pre-disclosing the unbounded-regex vector in a public issue).

Fixes #40255

Fixes #40255