### PR TITLE
fix(huggingface): accept translation_xx_to_yy pipeline tasks

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
+++ b/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
@@ -30,6 +30,17 @@ VALID_TASKS = (
     "translation",
 )
 DEFAULT_BATCH_SIZE = 4
+
+
+def _is_translation_task(task: str) -> bool:
+    """Return True for translation and translation_xx_to_yy tasks."""
+    return task == "translation" or task.startswith("translation_")
+
+
+def _is_supported_task(task: str) -> bool:
+    """Return True if the pipeline task is supported by HuggingFacePipeline."""
+    return task in VALID_TASKS or _is_translation_task(task)
+
 _MIN_OPTIMUM_VERSION = "1.21"
 
 
@@ -159,7 +170,7 @@ class HuggingFacePipeline(BaseLLM):
         tokenizer = AutoTokenizer.from_pretrained(model_id, **_model_kwargs)
 
         if backend in {"openvino", "ipex"}:
-            if task not in VALID_TASKS:
+            if not _is_supported_task(task):
                 msg = (
                     f"Got invalid task {task}, "
                     f"currently only {VALID_TASKS} are supported"
@@ -293,7 +304,7 @@ class HuggingFacePipeline(BaseLLM):
             model_kwargs=_model_kwargs,
             **_pipeline_kwargs,
         )
-        if pipeline.task not in VALID_TASKS:
+        if not _is_supported_task(pipeline.task):
             msg = (
                 f"Got invalid task {pipeline.task}, "
                 f"currently only {VALID_TASKS} are supported"
@@ -356,7 +367,7 @@ class HuggingFacePipeline(BaseLLM):
                     text = response["generated_text"]
                 elif self.pipeline.task == "summarization":
                     text = response["summary_text"]
-                elif self.pipeline.task in "translation":
+                elif _is_translation_task(self.pipeline.task):
                     text = response["translation_text"]
                 else:
                     msg = (

--- a/libs/partners/huggingface/tests/unit_tests/test_huggingface_pipeline_tasks.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_huggingface_pipeline_tasks.py
@@ -1,0 +1,33 @@
+"""Unit tests for HuggingFacePipeline task detection."""
+
+from unittest.mock import MagicMock
+
+from langchain_huggingface.llms.huggingface_pipeline import (
+    HuggingFacePipeline,
+    _is_supported_task,
+    _is_translation_task,
+)
+
+
+def test_is_translation_task() -> None:
+    assert _is_translation_task("translation")
+    assert _is_translation_task("translation_en_to_fr")
+    assert not _is_translation_task("summarization")
+    assert not _is_translation_task("text-generation")
+
+
+def test_is_supported_task_accepts_language_pair_translation() -> None:
+    assert _is_supported_task("translation_en_to_fr")
+    assert _is_supported_task("text-generation")
+    assert not _is_supported_task("feature-extraction")
+
+
+def test_generate_accepts_translation_xx_to_yy_task() -> None:
+    pipe = MagicMock()
+    pipe.task = "translation_en_to_fr"
+    pipe.model.name_or_path = "mock-model-id"
+    pipe.return_value = [{"translation_text": "Bonjour le monde"}]
+
+    llm = HuggingFacePipeline(pipeline=pipe)
+    result = llm._generate(["Hello world"])
+    assert result.generations[0][0].text == "Bonjour le monde"


### PR DESCRIPTION
## Summary
`HuggingFacePipeline._generate` used `self.pipeline.task in "translation"`, which is a character-substring check. Real transformers translation pipelines report tasks like `translation_en_to_fr`, so valid translation jobs were rejected with `ValueError`.

## Changes
- Add `_is_translation_task` / `_is_supported_task` helpers
- Use them in `_generate` and `from_model_id` validation so `translation` and `translation_xx_to_yy` are accepted
- Add unit coverage for task detection and `_generate` with a mocked `translation_en_to_fr` pipeline

Fixes #40095

## Test plan
- [x] New unit tests for translation task helpers and `_generate`
- [ ] CI unit suite for `langchain-huggingface`