### PR TITLE
fix(core): enforce mime_type for base64 in create_image_block

### DIFF
--- a/libs/core/langchain_core/messages/content.py
+++ b/libs/core/langchain_core/messages/content.py
@@ -1034,6 +1034,10 @@ def create_image_block(
         msg = "Must provide one of: url, base64, or file_id"
         raise ValueError(msg)
 
+    if base64 and not mime_type:
+        msg = "mime_type is required when using base64 data"
+        raise ValueError(msg)
+
     block = ImageContentBlock(type="image", id=ensure_id(id))
 
     if url is not None:

--- a/libs/core/tests/unit_tests/messages/test_content_blocks.py
+++ b/libs/core/tests/unit_tests/messages/test_content_blocks.py
@@ -1,0 +1,30 @@
+"""Tests for content block factory helpers."""
+
+import pytest
+
+from langchain_core.messages.content import (
+    create_audio_block,
+    create_file_block,
+    create_image_block,
+    create_video_block,
+)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [create_image_block, create_video_block, create_audio_block, create_file_block],
+)
+def test_base64_requires_mime_type(factory: object) -> None:
+    """base64 without mime_type must raise for all media factories."""
+    with pytest.raises(ValueError, match="mime_type is required when using base64 data"):
+        factory(base64="aGk=")  # type: ignore[operator]
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [create_image_block, create_video_block, create_audio_block, create_file_block],
+)
+def test_base64_with_mime_type_accepted(factory: object) -> None:
+    block = factory(base64="aGk=", mime_type="image/png")  # type: ignore[operator]
+    assert block["base64"] == "aGk="
+    assert block["mime_type"] == "image/png"


### PR DESCRIPTION
## Summary
`create_image_block` documented that `mime_type` is required when using `base64`, and the sibling factories (`create_video_block`, `create_audio_block`, `create_file_block`) already enforce this. The image factory was missing the check, so invalid blocks were accepted and later produced malformed provider payloads.

## Changes
- Add the same `if base64 and not mime_type: raise ValueError(...)` guard used by the other factories
- Add a small parametrized unit test covering all four factories

Fixes #39799

## Test plan
- [x] New unit tests for base64/mime_type validation
- [ ] CI unit suite for `langchain-core`