### PR TITLE
fix(openai): correct `login_chatgpt_device` to match the real device-code contract

### DIFF
--- a/libs/partners/openai/langchain_openai/chatgpt_oauth.py
+++ b/libs/partners/openai/langchain_openai/chatgpt_oauth.py
@@ -59,6 +59,7 @@ CHATGPT_TOKEN_URL = "https://auth.openai.com/oauth/token"  # noqa: S105
 CHATGPT_DEVICE_CODE_URL = "https://auth.openai.com/api/accounts/deviceauth/usercode"
 CHATGPT_DEVICE_TOKEN_URL = "https://auth.openai.com/api/accounts/deviceauth/token"  # noqa: S105
 CHATGPT_DEVICE_REDIRECT_URI = "https://auth.openai.com/deviceauth/callback"
+CHATGPT_DEVICE_VERIFICATION_URL = "https://auth.openai.com/codex/device"
 CHATGPT_AUTH_CLAIMS_NAMESPACE = "https://api.openai.com/auth"
 DEFAULT_REDIRECT_HOST = "localhost"
 DEFAULT_REDIRECT_PORT = 1455
@@ -411,27 +412,46 @@ def _post_form(
     return resp.json()
 
 
-_DEVICE_POLL_PENDING_ERRORS = frozenset({"authorization_pending", "slow_down"})
+def _post_json(
+    url: str,
+    data: dict[str, Any],
+    *,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """POST a JSON payload and return the parsed JSON body."""
+    with httpx.Client(timeout=timeout) as client:
+        resp = client.post(
+            url,
+            json=data,
+            headers={"Accept": "application/json"},
+        )
+    _raise_for_oauth_response(url, resp)
+    return resp.json()
 
 
-def _post_device_poll_form(
+_DEVICE_POLL_PENDING_STATUSES = frozenset({403, 404})
+
+
+def _post_device_poll_json(
     url: str,
     data: dict[str, str],
     *,
     timeout: float = 30.0,
-) -> dict[str, Any]:
-    """POST a device-code poll and return expected pending error payloads."""
+) -> dict[str, Any] | None:
+    """POST a device-code poll.
+
+    Returns `None` while authorization is still pending (HTTP 403/404, per
+    the device-code endpoint's contract), or the parsed JSON body once the
+    code is available. Any other error status raises.
+    """
     with httpx.Client(timeout=timeout) as client:
         resp = client.post(
             url,
-            data=data,
+            json=data,
             headers={"Accept": "application/json"},
         )
-    if resp.status_code < 400:
-        return resp.json()
-    error_code, _ = _parse_oauth_error(resp)
-    if error_code in _DEVICE_POLL_PENDING_ERRORS:
-        return resp.json()
+    if resp.status_code in _DEVICE_POLL_PENDING_STATUSES:
+        return None
     _raise_for_oauth_response(url, resp)
     return resp.json()
 
@@ -970,11 +990,17 @@ def login_chatgpt_device(
     then exchanges the resulting code via the OAuth token endpoint using
     `CHATGPT_DEVICE_REDIRECT_URI`.
 
+    Unlike `login_chatgpt`, this flow does not generate a local PKCE pair:
+    the device-code endpoint issues its own `code_verifier`/`code_challenge`
+    and returns them once authorization completes, so the token exchange
+    uses the server-issued verifier rather than one generated here.
+
     Args:
         store_path: Where to persist the token. Defaults to
             `DEFAULT_STORE_PATH`.
         client_id: OAuth client ID (defaults to Codex/ChatGPT client).
-        poll_interval: Seconds between polls.
+        poll_interval: Seconds between polls, used only as a fallback when
+            the device-code response omits an `interval`.
         timeout: Total seconds to wait.
 
     Returns:
@@ -989,51 +1015,42 @@ def login_chatgpt_device(
         `login_chatgpt`: Browser-based loopback flow preferred when a local
             browser and free callback port are available.
     """
-    _verifier, challenge = _generate_pkce_pair()
-    start = _post_form(
-        CHATGPT_DEVICE_CODE_URL,
-        {
-            "client_id": client_id,
-            "scope": DEFAULT_SCOPE,
-            "code_challenge": challenge,
-            "code_challenge_method": "S256",
-        },
-    )
-    device_code = start.get("device_code")
-    user_code = start.get("user_code")
-    verification_uri = start.get("verification_uri") or start.get(
-        "verification_uri_complete"
-    )
-    if not (device_code and user_code and verification_uri):
+    start = _post_json(CHATGPT_DEVICE_CODE_URL, {"client_id": client_id})
+    device_auth_id = start.get("device_auth_id")
+    user_code = start.get("user_code") or start.get("usercode")
+    if not (device_auth_id and user_code):
         msg = "ChatGPT device-code response missing required fields."
         raise RuntimeError(msg)
+    current_interval = float(start.get("interval") or poll_interval)
+    print(  # noqa: T201
+        f"\nChatGPT sign-in: open {CHATGPT_DEVICE_VERIFICATION_URL} "
+        f"in a browser and enter user code: {user_code}\n"
+    )
     logger.info(
-        "Open %s in a browser and enter user code: %s", verification_uri, user_code
+        "Open %s in a browser and enter user code: %s",
+        CHATGPT_DEVICE_VERIFICATION_URL,
+        user_code,
     )
 
     deadline = time.monotonic() + timeout
-    authorization_code: str | None = None
-    current_interval = poll_interval
+    code_response: dict[str, Any] | None = None
     while time.monotonic() < deadline:
-        poll = _post_device_poll_form(
+        code_response = _post_device_poll_json(
             CHATGPT_DEVICE_TOKEN_URL,
-            {"client_id": client_id, "device_code": device_code},
+            {"device_auth_id": device_auth_id, "user_code": user_code},
         )
-        if poll.get("authorization_code"):
-            authorization_code = poll["authorization_code"]
+        if code_response is not None:
             break
-        error = poll.get("error")
-        if error == "slow_down":
-            # RFC 8628 §3.5: bump the poll interval by 5 seconds to comply
-            # with server-side rate limiting; otherwise we risk being banned.
-            current_interval += 5
-        elif error and error != "authorization_pending":
-            msg = f"Device authorization failed: {error}"
-            raise RuntimeError(msg)
-        time.sleep(current_interval)
-    if not authorization_code:
+        time.sleep(max(min(current_interval, deadline - time.monotonic()), 0))
+    if code_response is None:
         msg = "Timed out waiting for ChatGPT device authorization."
         raise TimeoutError(msg)
+
+    authorization_code = code_response.get("authorization_code")
+    code_verifier = code_response.get("code_verifier")
+    if not (authorization_code and code_verifier):
+        msg = "ChatGPT device authorization response missing required fields."
+        raise RuntimeError(msg)
 
     response = _post_form(
         CHATGPT_TOKEN_URL,
@@ -1042,7 +1059,7 @@ def login_chatgpt_device(
             "code": authorization_code,
             "redirect_uri": CHATGPT_DEVICE_REDIRECT_URI,
             "client_id": client_id,
-            "code_verifier": _verifier,
+            "code_verifier": code_verifier,
         },
     )
     token = _token_from_response(response)

--- a/libs/partners/openai/tests/unit_tests/test_chatgpt_oauth.py
+++ b/libs/partners/openai/tests/unit_tests/test_chatgpt_oauth.py
@@ -683,53 +683,63 @@ def test_login_chatgpt_skips_browser_when_disabled(
     assert opened == []
 
 
-def test_login_chatgpt_device_honors_slow_down(
+def test_login_chatgpt_device_sends_json_and_polls_until_authorized(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    posts: list[dict[str, Any]] = []
     polls: list[dict[str, Any]] = []
     sleeps: list[float] = []
-    post_responses: list[dict[str, Any]] = [
+    exchanges: list[dict[str, str]] = []
+
+    def _fake_post_json(url: str, data: dict[str, Any], **_: Any) -> dict[str, Any]:
+        assert url == oauth_module.CHATGPT_DEVICE_CODE_URL
+        assert data == {"client_id": oauth_module.CHATGPT_CLIENT_ID}
+        return {"device_auth_id": "dev-auth-1", "user_code": "user", "interval": 2}
+
+    poll_responses: list[dict[str, Any] | None] = [
+        None,
+        None,
         {
-            "device_code": "dev",
-            "user_code": "user",
-            "verification_uri": "https://example.com",
-        },
-        {
-            "access_token": "at",
-            "refresh_token": "rt",
-            "expires_in": 3600,
+            "authorization_code": "auth-code",
+            "code_verifier": "server-verifier",
+            "code_challenge": "server-challenge",
         },
     ]
-    poll_responses: list[dict[str, Any]] = [
-        {"error": "authorization_pending"},
-        {"error": "slow_down"},
-        {"authorization_code": "auth-code"},
-    ]
-    post_iter = iter(post_responses)
     poll_iter = iter(poll_responses)
 
-    def _fake_post(url: str, data: dict[str, str], **_: Any) -> dict[str, Any]:
-        posts.append({"url": url, "data": data})
-        return next(post_iter)
-
-    def _fake_poll(url: str, data: dict[str, str], **_: Any) -> dict[str, Any]:
+    def _fake_poll(url: str, data: dict[str, str], **_: Any) -> dict[str, Any] | None:
         polls.append({"url": url, "data": data})
         return next(poll_iter)
+
+    def _fake_exchange(url: str, data: dict[str, str], **_: Any) -> dict[str, Any]:
+        exchanges.append(data)
+        return {"access_token": "at", "refresh_token": "rt", "expires_in": 3600}
 
     def _track_sleep(seconds: float) -> None:
         sleeps.append(seconds)
 
-    monkeypatch.setattr(oauth_module, "_post_form", _fake_post)
-    monkeypatch.setattr(oauth_module, "_post_device_poll_form", _fake_poll)
+    monkeypatch.setattr(oauth_module, "_post_json", _fake_post_json)
+    monkeypatch.setattr(oauth_module, "_post_device_poll_json", _fake_poll)
+    monkeypatch.setattr(oauth_module, "_post_form", _fake_exchange)
     monkeypatch.setattr(oauth_module.time, "sleep", _track_sleep)
 
-    login_chatgpt_device(store_path=tmp_path / "x.json", poll_interval=2.0)
+    login_chatgpt_device(store_path=tmp_path / "x.json", poll_interval=5.0)
 
     assert len(polls) == 3
-    # First sleep at base interval, then bumped by +5 after `slow_down`.
-    assert sleeps[0] == pytest.approx(2.0)
-    assert sleeps[1] == pytest.approx(7.0)
+    assert polls[0]["url"] == oauth_module.CHATGPT_DEVICE_TOKEN_URL
+    # device_auth_id/user_code, not the old (wrong) device_code field.
+    assert polls[0]["data"] == {"device_auth_id": "dev-auth-1", "user_code": "user"}
+    # Uses the server-provided interval (2s), not the poll_interval fallback (5s).
+    assert sleeps == [pytest.approx(2.0), pytest.approx(2.0)]
+    assert exchanges == [
+        {
+            "grant_type": "authorization_code",
+            "code": "auth-code",
+            "redirect_uri": oauth_module.CHATGPT_DEVICE_REDIRECT_URI,
+            "client_id": oauth_module.CHATGPT_CLIENT_ID,
+            # The server-issued verifier, not a locally generated one.
+            "code_verifier": "server-verifier",
+        }
+    ]
 
 
 def test_login_chatgpt_device_raises_on_fatal_error(
@@ -737,18 +747,24 @@ def test_login_chatgpt_device_raises_on_fatal_error(
 ) -> None:
     monkeypatch.setattr(
         oauth_module,
-        "_post_form",
-        lambda *_a, **_k: {
-            "device_code": "d",
-            "user_code": "u",
-            "verification_uri": "https://example.com",
-        },
+        "_post_json",
+        lambda *_a, **_k: {"device_auth_id": "d", "user_code": "u", "interval": 1},
     )
-    monkeypatch.setattr(
-        oauth_module,
-        "_post_device_poll_form",
-        lambda *_a, **_k: {"error": "access_denied"},
-    )
+
+    class _FakeClient:
+        def __init__(self, **_: Any) -> None:
+            pass
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            pass
+
+        def post(self, *_args: Any, **_kwargs: Any) -> httpx.Response:
+            return _make_response(400, {"error": "access_denied"})
+
+    monkeypatch.setattr(oauth_module.httpx, "Client", _FakeClient)
     monkeypatch.setattr(oauth_module.time, "sleep", lambda _s: None)
     with pytest.raises(RuntimeError, match="access_denied"):
         login_chatgpt_device(store_path=tmp_path / "x.json")
@@ -759,21 +775,17 @@ def test_login_chatgpt_device_times_out(
 ) -> None:
     monkeypatch.setattr(
         oauth_module,
-        "_post_form",
-        lambda *_a, **_k: {
-            "device_code": "d",
-            "user_code": "u",
-            "verification_uri": "https://example.com",
-        },
+        "_post_json",
+        lambda *_a, **_k: {"device_auth_id": "d", "user_code": "u", "interval": 0},
     )
     monkeypatch.setattr(
         oauth_module,
-        "_post_device_poll_form",
-        lambda *_a, **_k: {"error": "authorization_pending"},
+        "_post_device_poll_json",
+        lambda *_a, **_k: None,
     )
     monkeypatch.setattr(oauth_module.time, "sleep", lambda _s: None)
     # Force the monotonic clock to immediately blow past the deadline.
-    times = iter([0.0, 0.0, 9999.0])
+    times = iter([0.0, 0.0, 9999.0, 9999.0])
     monkeypatch.setattr(oauth_module.time, "monotonic", lambda: next(times))
     with pytest.raises(TimeoutError):
         login_chatgpt_device(
@@ -781,7 +793,33 @@ def test_login_chatgpt_device_times_out(
         )
 
 
-def test_post_device_poll_form_returns_pending_400_payload(
+def test_post_device_poll_json_returns_none_when_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 403/404 from the poll endpoint means "still pending", not an error."""
+
+    class _FakeClient:
+        def __init__(self, **_: Any) -> None:
+            pass
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            pass
+
+        def post(self, *_args: Any, **_kwargs: Any) -> httpx.Response:
+            return _make_response(403, {})
+
+    monkeypatch.setattr(oauth_module.httpx, "Client", _FakeClient)
+
+    payload = oauth_module._post_device_poll_json(
+        "https://example.com/poll", {"device_auth_id": "d", "user_code": "u"}
+    )
+    assert payload is None
+
+
+def test_post_device_poll_json_returns_payload_on_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _FakeClient:
@@ -795,17 +833,28 @@ def test_post_device_poll_form_returns_pending_400_payload(
             pass
 
         def post(self, *_args: Any, **_kwargs: Any) -> httpx.Response:
-            return _make_response(400, {"error": "authorization_pending"})
+            return _make_response(
+                200,
+                {
+                    "authorization_code": "auth-code",
+                    "code_verifier": "v",
+                    "code_challenge": "c",
+                },
+            )
 
     monkeypatch.setattr(oauth_module.httpx, "Client", _FakeClient)
 
-    payload = oauth_module._post_device_poll_form(
-        "https://example.com/poll", {"device_code": "d"}
+    payload = oauth_module._post_device_poll_json(
+        "https://example.com/poll", {"device_auth_id": "d", "user_code": "u"}
     )
-    assert payload == {"error": "authorization_pending"}
+    assert payload == {
+        "authorization_code": "auth-code",
+        "code_verifier": "v",
+        "code_challenge": "c",
+    }
 
 
-def test_post_device_poll_form_raises_fatal_400(
+def test_post_device_poll_json_raises_fatal_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _FakeClient:
@@ -824,8 +873,8 @@ def test_post_device_poll_form_raises_fatal_400(
     monkeypatch.setattr(oauth_module.httpx, "Client", _FakeClient)
 
     with pytest.raises(RuntimeError, match="access_denied"):
-        oauth_module._post_device_poll_form(
-            "https://example.com/poll", {"device_code": "d"}
+        oauth_module._post_device_poll_json(
+            "https://example.com/poll", {"device_auth_id": "d", "user_code": "u"}
         )
 
 


### PR DESCRIPTION
Closes #40216

---

Anyone on a ChatGPT subscription plan without a local browser (a remote box, a container, CI) needs `login_chatgpt_device` for headless sign-in. Today it fails before a device code is even issued: OpenAI's device-code endpoint responds with a plain HTTP 400 the instant the first request lands.

The root cause is that `login_chatgpt_device` was built against a guessed, generic device-code shape (form-encoded requests, a locally generated PKCE pair, `device_code`/JSON `error` fields) rather than the endpoint OpenAI actually runs. I verified the real contract against OpenAI's own reference implementation in `codex-rs/login/src/device_code_auth.rs` and `server.rs`:

- The initial device-code request and the polling request are both JSON, not form-encoded.
- The device-code response carries `device_auth_id` (not `device_code`), and the client sends no PKCE fields at all — the server generates `code_verifier`/`code_challenge` itself and returns them once the user completes authorization.
- Polling sends `{device_auth_id, user_code}` and reads HTTP 403/404 as "still pending"; there's no JSON `error`/`slow_down` field to key off, so the old logic could never actually detect a pending state correctly.
- The final token exchange stays form-encoded against the same endpoint, but must use the server-issued `code_verifier`, not a locally generated one.

`login_chatgpt` (the browser-based loopback flow) already matches its endpoint's real contract and is untouched here.

## Release note

Fixed `login_chatgpt_device` in `langchain-openai`: the headless ChatGPT device-code sign-in flow now matches OpenAI's actual endpoint contract (JSON requests, server-issued PKCE, status-code-based polling) instead of failing immediately with an HTTP 400.

---

Disclosure: investigated and fixed with AI-agent assistance (Claude Code), including cross-checking the fix against OpenAI's own Codex device-login source rather than guessing at the contract.