### PR TITLE
test(core): cover the deprecated `.text()` access path

### DIFF
--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -3,6 +3,7 @@ from typing import Any, get_args
 
 import pytest
 
+from langchain_core._api import LangChainDeprecationWarning
 from langchain_core.documents import Document
 from langchain_core.load import dumpd, load
 from langchain_core.messages import (
@@ -1395,34 +1396,40 @@ def test_typed_init() -> None:
     )
 
 
+# Calling `.text()` as a method is the deprecated path under test here, so the
+# warning it emits is expected rather than something to fix.
+@pytest.mark.filterwarnings(
+    r"ignore:Calling \.text\(\) as a method is deprecated:"
+    r"langchain_core._api.deprecation.LangChainDeprecationWarning"
+)
 def test_text_accessor() -> None:
     """Test that `message.text` property and `.text()` method return the same value."""
     human_msg = HumanMessage(content="Hello world")
     assert human_msg.text == "Hello world"
-    assert human_msg.text == "Hello world"
-    assert str(human_msg.text) == str(human_msg.text)
+    assert human_msg.text() == "Hello world"
+    assert str(human_msg.text) == str(human_msg.text())
 
     system_msg = SystemMessage(content="You are a helpful assistant")
     assert system_msg.text == "You are a helpful assistant"
-    assert system_msg.text == "You are a helpful assistant"
-    assert str(system_msg.text) == str(system_msg.text)
+    assert system_msg.text() == "You are a helpful assistant"
+    assert str(system_msg.text) == str(system_msg.text())
 
     ai_msg = AIMessage(content="I can help you with that")
     assert ai_msg.text == "I can help you with that"
-    assert ai_msg.text == "I can help you with that"
-    assert str(ai_msg.text) == str(ai_msg.text)
+    assert ai_msg.text() == "I can help you with that"
+    assert str(ai_msg.text) == str(ai_msg.text())
 
     tool_msg = ToolMessage(content="Task completed", tool_call_id="tool_1")
     assert tool_msg.text == "Task completed"
-    assert tool_msg.text == "Task completed"
-    assert str(tool_msg.text) == str(tool_msg.text)
+    assert tool_msg.text() == "Task completed"
+    assert str(tool_msg.text) == str(tool_msg.text())
 
     complex_msg = HumanMessage(
         content=[{"type": "text", "text": "Hello "}, {"type": "text", "text": "world"}]
     )
     assert complex_msg.text == "Hello world"
-    assert complex_msg.text == "Hello world"
-    assert str(complex_msg.text) == str(complex_msg.text)
+    assert complex_msg.text() == "Hello world"
+    assert str(complex_msg.text) == str(complex_msg.text())
 
     mixed_msg = AIMessage(
         content=[
@@ -1432,10 +1439,19 @@ def test_text_accessor() -> None:
         ]
     )
     assert mixed_msg.text == "The answer is 42"
-    assert mixed_msg.text == "The answer is 42"
-    assert str(mixed_msg.text) == str(mixed_msg.text)
+    assert mixed_msg.text() == "The answer is 42"
+    assert str(mixed_msg.text) == str(mixed_msg.text())
 
     empty_msg = HumanMessage(content=[])
     assert empty_msg.text == ""
-    assert empty_msg.text == ""
-    assert str(empty_msg.text) == str(empty_msg.text)
+    assert empty_msg.text() == ""
+    assert str(empty_msg.text) == str(empty_msg.text())
+
+
+def test_text_accessor_deprecation_warning() -> None:
+    """Test that calling `.text()` as a method emits a deprecation warning."""
+    with pytest.warns(
+        LangChainDeprecationWarning,
+        match=r"Calling \.text\(\) as a method is deprecated",
+    ):
+        HumanMessage(content="Hello world").text()


### PR DESCRIPTION
Fixes #40225

---

`test_text_accessor` is documented as testing "that `message.text` property and `.text()`
method return the same value". It never calls `.text()`. For each message it asserts the same
literal twice and then adds `assert str(msg.text) == str(msg.text)`, which compares a pure
expression to itself and holds for whatever `.text` returns.

`TextAccessor.__call__` is the backward-compatibility shim that lets pre-1.0 code keep calling
`.text()` as a method. It emits a deprecation warning and is scheduled for removal in `2.0.0`,
so until then it is public behavior. Nothing verified it: `.text()` as a method call appears
exactly once in any test file under `libs/`, and that one occurrence is this test's own
docstring.

The coverage was written and then lost, rather than never attempted. Three variants of this
test exist across the v1 branches. The two that shipped alongside `TextAccessor` — #32441 in
the `v1` namespace and #32672 in the mainline message classes — both call `.text()` and
compare the result against `.text`. The variant that reached `master` in the `v1.0.0` release
squash is the one that never calls the method, and it is byte-identical to the test there
today.

This restores the assertions #32672 carried: for each of the seven messages, `.text()` is
called and its result compared against `.text`. A separate test covers the deprecation
warning, which no earlier version asserted, and `test_text_accessor` carries a
`filterwarnings` mark so the intentional calls do not add noise to the suite. The structure
of the existing test is otherwise unchanged.

Test-only — no package code changes and no user-visible behavior change.

## Red/green

Three independent mutations of `TextAccessor.__call__`, each run against the old test and the
new one:

| `__call__` mutated to | old | new |
|---|---|---|
| return `"TOTALLY BROKEN"`, emit no warning | passes | fails |
| return the correct value, emit no warning | passes | fails |
| still warn, return `"TOTALLY BROKEN"` | passes | fails |

Unmutated, both pass.

This contribution was prepared with the assistance of an AI agent.
