### PR TITLE
fix(langchain-classic): correct sqlite3 install guidance in SQLiteEntityStore error message

### DIFF
--- a/libs/langchain/langchain_classic/memory/entity.py
+++ b/libs/langchain/langchain_classic/memory/entity.py
@@ -374,7 +374,12 @@ class SQLiteEntityStore(BaseEntityStore):
         except ImportError as e:
             msg = (
                 "Could not import sqlite3 python package. "
-                "Please install it with `pip install sqlite3`."
+                "sqlite3 is part of the Python standard library, not a package "
+                "installable via pip. If it is missing, your Python installation "
+                "was likely built without SQLite support — check your Python or "
+                "operating system distributor's instructions for enabling the "
+                "sqlite3 extension (e.g., recompiling Python with SQLite support, "
+                "or installing your OS's sqlite3/libsqlite3 development package)."
             )
             raise ImportError(msg) from e
 


### PR DESCRIPTION
Fixes #40247

## Summary
`SQLiteEntityStore` raised an `ImportError` suggesting `pip install sqlite3`
when the `sqlite3` module is missing. `sqlite3` is part of the Python
standard library and is not installable via pip — PyPI also blocks new
projects whose names collide with stdlib modules, so the suggested
command could never succeed.

This PR updates the error message to correctly explain that sqlite3 is
a standard library module and points users toward their Python or OS
distributor for enabling SQLite support.

## Testing
Verified locally by simulating a missing sqlite3 import and confirming
the new message prints as expected.