### PR TITLE
fix(langchain): inherit shell environments by execution policy

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/_execution.py
+++ b/libs/langchain_v1/langchain/agents/middleware/_execution.py
@@ -66,6 +66,9 @@ class BaseExecutionPolicy(abc.ABC):
     isolation using Docker.
     """
 
+    inherit_parent_environment: typing.ClassVar[bool] = True
+    """Whether an omitted environment inherits variables from the parent process."""
+
     command_timeout: float = 30.0
     startup_timeout: float = 30.0
     termination_timeout: float = 10.0
@@ -76,6 +79,21 @@ class BaseExecutionPolicy(abc.ABC):
         if self.max_output_lines <= 0:
             msg = "max_output_lines must be positive."
             raise ValueError(msg)
+
+    def prepare_environment(self, env: Mapping[str, str] | None) -> dict[str, str]:
+        """Resolve the environment passed to the shell process.
+
+        Args:
+            env: Explicit environment variables, or `None` to use the policy default.
+
+        Returns:
+            Explicit variables when provided, otherwise the parent environment for
+            policies that enable inheritance or an empty environment for policies that
+            disable it.
+        """
+        if env is not None:
+            return dict(env)
+        return os.environ.copy() if self.inherit_parent_environment else {}
 
     @abc.abstractmethod
     def spawn(
@@ -280,6 +298,8 @@ class DockerExecutionPolicy(BaseExecutionPolicy):
     default image is `python:3.12-alpine3.19`; supply a custom image if you need
     preinstalled tooling.
     """
+
+    inherit_parent_environment: typing.ClassVar[bool] = False
 
     binary: str = "docker"
     image: str = "python:3.12-alpine3.19"

--- a/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
@@ -580,8 +580,10 @@ class ShellToolMiddleware(AgentMiddleware[ShellToolState[ResponseT], ContextT, R
                 Defaults to an implementation-defined bash command.
             env: Optional environment variables to supply to the shell session.
 
-                Values are coerced to strings before command execution. If omitted, the
-                session inherits the parent process environment.
+                Values are coerced to strings and replace the inherited environment. If
+                omitted, host and Codex sandbox sessions inherit the parent process
+                environment, while Docker sessions do not forward host variables into the
+                container.
         """
         super().__init__()
         self._workspace_root = Path(workspace_root) if workspace_root else None
@@ -736,7 +738,7 @@ class ShellToolMiddleware(AgentMiddleware[ShellToolState[ResponseT], ContextT, R
             workspace_path,
             self._execution_policy,
             self._shell_command,
-            self._environment or {},
+            self._execution_policy.prepare_environment(self._environment),
         )
         try:
             session.start()

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py
@@ -334,6 +334,22 @@ def test_docker_policy_rejects_cpu_limit() -> None:
         DockerExecutionPolicy(cpu_time_seconds=1)
 
 
+def test_docker_policy_omitted_env_does_not_forward_host_environment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An omitted environment must not expose host variables to the container."""
+    monkeypatch.setenv("LANGCHAIN_SHELL_HOST_SECRET", "secret")
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/docker")
+    policy = DockerExecutionPolicy()
+
+    environment = policy.prepare_environment(None)
+    command = policy._build_command(tmp_path, environment, ("/bin/sh",))
+
+    assert environment == {}
+    assert "-e" not in command
+    assert not any("LANGCHAIN_SHELL_HOST_SECRET" in arg for arg in command)
+
+
 def test_docker_policy_validates_memory() -> None:
     with pytest.raises(ValueError, match="memory_bytes must be positive if provided"):
         DockerExecutionPolicy(memory_bytes=0)

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
@@ -236,6 +236,29 @@ def test_normalize_env_coercion(tmp_path: Path) -> None:
         middleware.after_agent(state, runtime)
 
 
+def test_omitted_env_inherits_parent_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that an omitted environment inherits variables from the parent process."""
+    monkeypatch.setenv("LANGCHAIN_SHELL_TEST_ENV", "inherited")
+    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace")
+    runtime = Runtime()
+    state = _empty_state()
+    try:
+        updates = middleware.before_agent(state, runtime)
+        if updates:
+            state.update(cast("ShellToolState", updates))
+        resources = middleware._get_or_create_resources(state)
+        result = middleware._run_shell_tool(
+            resources,
+            {"command": "printf '%s\\n' \"$LANGCHAIN_SHELL_TEST_ENV\""},
+            tool_call_id=None,
+        )
+        assert result.strip() == "inherited"
+    finally:
+        middleware.after_agent(state, runtime)
+
+
 def test_shell_tool_missing_command_string(tmp_path: Path) -> None:
     """Test that shell tool raises an error when command is not a string."""
     middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace")


### PR DESCRIPTION
Fixes #40252

---

`ShellToolMiddleware` users expect host and Codex sessions to inherit the parent process environment when `env` is omitted. This change moves environment preparation to the execution policy so host and Codex sessions inherit it, Docker remains isolated, and an explicit `env` continues to replace it.

Verified with 60 targeted unit tests plus Ruff lint and format checks.

## Release note

`ShellToolMiddleware` now inherits the parent process environment for host and Codex sandbox sessions when `env` is omitted, while Docker sessions remain isolated.

This contribution was prepared with assistance from an AI coding agent.