### PR TITLE
fix(deepseek): preserve reasoning_content in request payload

### DIFF
--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -342,20 +342,28 @@ class ChatDeepSeek(BaseChatOpenAI):
         **kwargs: Any,
     ) -> dict:
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
-        for message in payload["messages"]:
+        messages = self._convert_input(input_).to_messages()
+        for i, message in enumerate(payload["messages"]):
             if message["role"] == "tool" and isinstance(message["content"], list):
                 message["content"] = json.dumps(message["content"])
-            elif message["role"] == "assistant" and isinstance(
-                message["content"], list
-            ):
-                # DeepSeek API expects assistant content to be a string, not a list.
-                # Extract text blocks and join them, or use empty string if none exist.
-                text_parts = [
-                    block.get("text", "")
-                    for block in message["content"]
-                    if isinstance(block, dict) and block.get("type") == "text"
-                ]
-                message["content"] = "".join(text_parts) if text_parts else ""
+            elif message["role"] == "assistant":
+                if isinstance(message["content"], list):
+                    # DeepSeek API expects assistant content to be a string, not a list.
+                    # Extract text blocks and join them,
+                    # or use empty string if none exist.
+                    text_parts = [
+                        block.get("text", "")
+                        for block in message["content"]
+                        if isinstance(block, dict) and block.get("type") == "text"
+                    ]
+                    message["content"] = "".join(text_parts) if text_parts else ""
+                # DeepSeek requires reasoning_content from previous turns to be passed
+                # back in multi-round conversations,
+                # but _convert_message_to_dict drops it.
+                if i < len(messages) and isinstance(messages[i], AIMessage):
+                    reasoning = messages[i].additional_kwargs.get("reasoning_content")
+                    if reasoning is not None:
+                        message["reasoning_content"] = reasoning
 
         # Azure-hosted DeepSeek does not support the dict/object form of
         # tool_choice (e.g. {"type": "function", "function": {"name": "..."}}).

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Literal
 from unittest.mock import MagicMock
 
-from langchain_core.messages import AIMessage, AIMessageChunk, ToolMessage
+from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
 from langchain_tests.unit_tests import ChatModelUnitTests
 from openai import BaseModel
 from openai.types import CompletionUsage
@@ -254,6 +254,65 @@ class TestChatDeepSeekCustomUnit:
         tool_message = ToolMessage(content="test string", tool_call_id="test_id")
         payload = chat_model._get_request_payload([tool_message])
         assert payload["messages"][0]["content"] == "test string"
+
+    def test_get_request_payload_preserves_reasoning_content(self) -> None:
+        """reasoning_content from AIMessage is passed through to the payload."""
+        chat_model = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("api_key"))
+        messages = [
+            HumanMessage(content="Hello!"),
+            AIMessage(
+                content="Hi!",
+                additional_kwargs={"reasoning_content": "thinking..."},
+            ),
+        ]
+        payload = chat_model._get_request_payload(messages)
+        assert payload["messages"][1]["reasoning_content"] == "thinking..."
+
+    def test_get_request_payload_reasoning_content_with_list_content(self) -> None:
+        """reasoning_content survives assistant content-list normalization."""
+        chat_model = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("api_key"))
+        messages = [
+            HumanMessage(content="Hello!"),
+            AIMessage(
+                content=[{"type": "text", "text": "Hi!"}],
+                additional_kwargs={"reasoning_content": "thinking..."},
+            ),
+        ]
+        payload = chat_model._get_request_payload(messages)
+        assert payload["messages"][1]["content"] == "Hi!"
+        assert payload["messages"][1]["reasoning_content"] == "thinking..."
+
+    def test_get_request_payload_without_reasoning_content(self) -> None:
+        """Assistant messages without reasoning_content don't get the key."""
+        chat_model = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("api_key"))
+        messages = [
+            HumanMessage(content="Hello!"),
+            AIMessage(content="Just a normal reply."),
+        ]
+        payload = chat_model._get_request_payload(messages)
+        assert "reasoning_content" not in payload["messages"][1]
+
+    def test_get_request_payload_reasoning_content_multi_round(self) -> None:
+        """reasoning_content stays aligned across mixed-role multi-round history."""
+        chat_model = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("api_key"))
+        messages = [
+            HumanMessage(content="Q1"),
+            AIMessage(
+                content="A1",
+                additional_kwargs={"reasoning_content": "r1"},
+            ),
+            ToolMessage(content="tool result", tool_call_id="call_1"),
+            AIMessage(content="A2"),
+            AIMessage(
+                content="A3",
+                additional_kwargs={"reasoning_content": "r3"},
+            ),
+        ]
+        payload = chat_model._get_request_payload(messages)
+        assert payload["messages"][1]["reasoning_content"] == "r1"
+        assert "reasoning_content" not in payload["messages"][2]
+        assert "reasoning_content" not in payload["messages"][3]
+        assert payload["messages"][4]["reasoning_content"] == "r3"
 
 
 class SampleTool(PydanticBaseModel):


### PR DESCRIPTION
Fixes #40219

In multi-round tool-calling conversations with `ChatDeepSeek`, `_get_request_payload` silently drops the `reasoning_content` field from prior assistant messages, which violates DeepSeek's thinking-mode tool-calling protocol (https://api-docs.deepseek.com/guides/thinking_mode/) and leads to 400 errors. The fix retrieves the original messages — which still carry `reasoning_content` — via `_convert_input` inside `_get_request_payload` and re-attaches the field to the corresponding assistant dicts in the payload.
## Release note

`ChatDeepSeek` now preserves `reasoning_content` from previous assistant messages (when the model produced reasoning) in follow-up requests, fixing the intermittent 400 errors caused by the missing field.

## How did you verify

Added four regression tests in `tests/unit_tests/test_chat_models.py`: `reasoning_content` is preserved when the model produced reasoning; `reasoning_content` is preserved when message content is in list form; no `reasoning_content` key is added to history messages when the model produced no reasoning; and fields stay correctly aligned in mixed-role multi-round conversations. The new tests fail on master without the fix and pass with it. Full unit suite passes locally (41 passed, 1 skipped), and ruff format/lint are clean.

Assisted by an AI coding tool during development and testing.