### PR TITLE
fix(langchain): avoid blocking during async shell cleanup

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
@@ -699,7 +699,7 @@ class ShellToolMiddleware(AgentMiddleware[ShellToolState[ResponseT], ContextT, R
         self, state: ShellToolState[ResponseT], runtime: Runtime[ContextT]
     ) -> None:
         """Async run shutdown commands and release resources when an agent completes."""
-        return self.after_agent(state, runtime)
+        await run_in_executor(None, self.after_agent, state, runtime)
 
     def _get_or_create_resources(self, state: ShellToolState[ResponseT]) -> _SessionResources:
         """Get existing resources from state or create new ones if they don't exist.

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
@@ -5,6 +5,7 @@ import logging
 import os
 import signal
 import tempfile
+import threading
 import time
 from pathlib import Path
 from typing import Any, cast
@@ -458,6 +459,25 @@ async def test_async_methods_delegate_to_sync(tmp_path: Path) -> None:
         await middleware.aafter_agent(state, Runtime())
     finally:
         pass
+
+
+async def test_aafter_agent_offloads_cleanup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that async cleanup does not run on the event loop thread."""
+    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace")
+    event_loop_thread_id = threading.get_ident()
+    cleanup_thread_ids: list[int] = []
+
+    def record_cleanup(_state: ShellToolState, _runtime: Runtime) -> None:
+        cleanup_thread_ids.append(threading.get_ident())
+
+    monkeypatch.setattr(middleware, "after_agent", record_cleanup)
+
+    await middleware.aafter_agent(_empty_state(), Runtime())
+
+    assert cleanup_thread_ids
+    assert cleanup_thread_ids[0] != event_loop_thread_id
 
 
 def test_shell_middleware_resumable_after_interrupt(tmp_path: Path) -> None:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import gc
 import logging
 import os
@@ -461,23 +462,26 @@ async def test_async_methods_delegate_to_sync(tmp_path: Path) -> None:
         pass
 
 
-async def test_aafter_agent_offloads_cleanup(
+async def test_aafter_agent_does_not_block_event_loop(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test that async cleanup does not run on the event loop thread."""
+    """Test that async cleanup does not block other event loop tasks."""
     middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace")
-    event_loop_thread_id = threading.get_ident()
-    cleanup_thread_ids: list[int] = []
+    event_loop = asyncio.get_running_loop()
+    cleanup_started = asyncio.Event()
+    release_cleanup = threading.Event()
 
     def record_cleanup(_state: ShellToolState, _runtime: Runtime) -> None:
-        cleanup_thread_ids.append(threading.get_ident())
+        event_loop.call_soon_threadsafe(cleanup_started.set)
+        assert release_cleanup.wait(timeout=1)
 
     monkeypatch.setattr(middleware, "after_agent", record_cleanup)
 
-    await middleware.aafter_agent(_empty_state(), Runtime())
+    cleanup_task = asyncio.create_task(middleware.aafter_agent(_empty_state(), Runtime()))
+    await cleanup_started.wait()
 
-    assert cleanup_thread_ids
-    assert cleanup_thread_ids[0] != event_loop_thread_id
+    release_cleanup.set()
+    await cleanup_task
 
 
 def test_shell_middleware_resumable_after_interrupt(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #40256

---

`ShellToolMiddleware` users running agents asynchronously could have the event loop blocked while shutdown commands and process cleanup completed. This delegates `aafter_agent()` cleanup through `run_in_executor()`, matching `abefore_agent()` and keeping other async tasks responsive.

A deterministic regression test verifies that the event loop can schedule work while cleanup is blocked. The 37 related unit tests and Ruff lint and format checks pass.

## Release note

`ShellToolMiddleware` no longer blocks the asyncio event loop while running shutdown commands and releasing shell resources.

This contribution was prepared with assistance from an AI coding agent.