### PR TITLE
fix(langchain): cap retry delay after applying jitter

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/_retry.py
+++ b/libs/langchain_v1/langchain/agents/middleware/_retry.py
@@ -128,7 +128,7 @@ def calculate_delay(
     if jitter and delay > 0:
         jitter_amount = delay * 0.25  # ±25% jitter
         delay += random.uniform(-jitter_amount, jitter_amount)  # noqa: S311
-        # Ensure delay is not negative after jitter
-        delay = max(0, delay)
+        # Keep jitter within the configured delay bounds
+        delay = min(max(0, delay), max_delay)
 
     return delay

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
@@ -598,6 +598,26 @@ def test_model_retry_max_delay_cap() -> None:
     assert delay_2 == 2.0
 
 
+def test_model_retry_max_delay_cap_with_jitter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test calculate_delay caps positive jitter at max_delay."""
+    monkeypatch.setattr(
+        "langchain.agents.middleware._retry.random.uniform",
+        lambda _lower, upper: upper,
+    )
+
+    delay = calculate_delay(
+        10,
+        backoff_factor=2.0,
+        initial_delay=1.0,
+        max_delay=5.0,
+        jitter=True,
+    )
+
+    assert delay == 5.0
+
+
 def test_model_retry_jitter_variation() -> None:
     """Test calculate_delay adds jitter to delays."""
     # Generate multiple delays and ensure they vary


### PR DESCRIPTION
Fixes #40259

---

Retry jitter was applied after capping exponential backoff, allowing final delays to exceed `max_delay` for both model and tool retry middleware. This change clamps the jittered value to the configured bounds and adds deterministic regression coverage for upper-bound jitter.

## Release note

`ModelRetryMiddleware` and `ToolRetryMiddleware` now keep jittered retry delays at or below the configured `max_delay`.

Verified with both middleware unit test files (65 tests) and targeted Ruff checks.

This contribution was prepared with assistance from an AI coding agent.