### PR TITLE
fix(langchain): offload `ContextEditingMiddleware` token counting off the event loop

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/context_editing.py
+++ b/libs/langchain_v1/langchain/agents/middleware/context_editing.py
@@ -21,6 +21,7 @@ from langchain_core.messages import (
     ToolMessage,
 )
 from langchain_core.messages.utils import count_tokens_approximately
+from langchain_core.runnables import run_in_executor
 from typing_extensions import Protocol
 
 from langchain.agents.middleware.types import (
@@ -247,6 +248,23 @@ class ContextEditingMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, 
 
         return count_tokens
 
+    def _apply_edits(
+        self,
+        request: ModelRequest[ContextT],
+        count_tokens: TokenCounter,
+    ) -> list[AnyMessage]:
+        """Deep-copy the messages and apply every configured edit.
+
+        A separate method so the async path can run it in the default thread
+        pool executor: the token counter can be a synchronous, blocking model
+        call (``get_num_tokens_from_messages``) and must not hold up the event
+        loop.
+        """
+        edited_messages = deepcopy(list(request.messages))
+        for edit in self.edits:
+            edit.apply(edited_messages, count_tokens=count_tokens)
+        return edited_messages
+
     def wrap_model_call(
         self,
         request: ModelRequest[ContextT],
@@ -293,9 +311,10 @@ class ContextEditingMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, 
 
         count_tokens = self._resolve_token_counter(request)
 
-        edited_messages = deepcopy(list(request.messages))
-        for edit in self.edits:
-            edit.apply(edited_messages, count_tokens=count_tokens)
+        # Run the (potentially blocking) model token-counting edits off the
+        # event loop so an async agent isn't stalled by a synchronous
+        # `get_num_tokens_from_messages` call.
+        edited_messages = await run_in_executor(None, self._apply_edits, request, count_tokens)
 
         return await handler(request.override(messages=edited_messages))
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_context_editing.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_context_editing.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
 from typing import TYPE_CHECKING, Any, cast
 
 from langchain_core.language_models.fake_chat_models import FakeChatModel
@@ -578,3 +580,70 @@ async def test_custom_token_counter_forces_clearing_async() -> None:
     cleared_tool = modified_request.messages[1]
     assert isinstance(cleared_tool, ToolMessage)
     assert cleared_tool.content == "[cleared]"
+
+
+class _BlockingTokenCountingModel(FakeChatModel):
+    """Fake model whose token counting deliberately blocks for a fixed time."""
+
+    @override
+    def get_num_tokens_from_messages(
+        self,
+        messages: list[BaseMessage],
+        tools: Sequence[Any] | None = None,
+    ) -> int:
+        time.sleep(0.2)  # Simulate a synchronous, blocking remote call.
+        return sum(len(str(message.content)) for message in messages)
+
+
+async def test_async_token_counting_does_not_block_event_loop() -> None:
+    """Model-based token counting in the async path must not stall the loop.
+
+    Regression test for a bug where a synchronous ``get_num_tokens_from_messages``
+    blocked the asyncio event loop. An unrelated heartbeat task should stay
+    responsive while the middleware applies its edits.
+    """
+    tool_call_id = "call-blocking"
+    ai_message = AIMessage(
+        content="",
+        tool_calls=[{"id": tool_call_id, "name": "search", "args": {}}],
+    )
+    tool_message = ToolMessage(content="x" * 200, tool_call_id=tool_call_id)
+
+    model = _BlockingTokenCountingModel()
+    conversation: list[AnyMessage] = [ai_message, tool_message]
+    state = cast("AgentState[Any]", {"messages": conversation})
+    request = ModelRequest(
+        model=model,
+        system_prompt=None,
+        messages=conversation,
+        tool_choice=None,
+        tools=[],
+        response_format=None,
+        state=state,
+        runtime=_fake_runtime(),
+        model_settings={},
+    )
+
+    middleware = ContextEditingMiddleware(
+        edits=[ClearToolUsesEdit(trigger=50, keep=0, placeholder="[cleared]")],
+        token_count_method="model",  # noqa: S106
+    )
+
+    async def mock_handler(_req: ModelRequest) -> ModelResponse:
+        return ModelResponse(result=[AIMessage(content="mock response")])
+
+    async def heartbeat(gap: list[float]) -> None:
+        started = time.perf_counter()
+        await asyncio.sleep(0.02)
+        gap.append(time.perf_counter() - started)
+
+    gaps: list[float] = []
+    heartbeat_task = asyncio.create_task(heartbeat(gaps))
+
+    # Drive the middleware and heartbeat concurrently.
+    await asyncio.gather(middleware.awrap_model_call(request, mock_handler), heartbeat_task)
+
+    assert gaps, "heartbeat task did not run"
+    # Blocking count sleeps 0.2s per call; the heartbeat (0.02s) must not be
+    # delayed anywhere near that duration if the loop stayed responsive.
+    assert gaps[0] < 0.1, f"event loop was blocked; heartbeat took {gaps[0]:.3f}s"


### PR DESCRIPTION
Fixes #40261

---

`ContextEditingMiddleware.awrap_model_call` invoked the configured token counter synchronously. With model-based counting (`get_num_tokens_from_messages`), that call is a blocking, potentially remote operation — it stalled the asyncio event loop and delayed every unrelated coroutine in the runtime, exactly as the repro in the issue shows.

The async path now runs the edit application (deep copy + token counting) in the default thread pool executor via `langchain_core.runnables.run_in_executor`, matching the pattern already used by `ShellToolMiddleware`. The synchronous `wrap_model_call` path is unchanged, and the model-agnostic behavior is preserved.

Adds a regression test with a fake model whose `get_num_tokens_from_messages` blocks for a fixed time; an unrelated heartbeat coroutine must stay responsive while the edits are applied. The test fails without this change.

Note: this contribution was prepared with the assistance of an AI coding agent.