### PR TITLE
fix(langchain): prohibit tool name changes in edit decisions

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -90,7 +90,7 @@ class EditDecision(TypedDict):
     edited_action: Action
     """Edited action for the agent to perform.
 
-    Ex: for a tool call, a human reviewer can edit the tool name and args.
+    For a tool call, a human reviewer can edit the args but not the tool name.
     """
 
 
@@ -327,10 +327,16 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
             return tool_call, None
         if decision["type"] == "edit" and "edit" in allowed_decisions:
             edited_action = decision["edited_action"]
+            if edited_action["name"] != tool_call["name"]:
+                msg = (
+                    "Tool name cannot be changed in an edit decision. "
+                    f"Expected '{tool_call['name']}', got '{edited_action['name']}'."
+                )
+                raise ValueError(msg)
             return (
                 ToolCall(
                     type="tool_call",
-                    name=edited_action["name"],
+                    name=tool_call["name"],
                     args=edited_action["args"],
                     id=tool_call["id"],
                 ),

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
@@ -149,6 +149,44 @@ def test_human_in_the_loop_middleware_single_tool_edit() -> None:
         assert result["messages"][0].tool_calls[0]["id"] == "1"  # ID should be preserved
 
 
+def test_human_in_the_loop_middleware_edit_cannot_change_tool_name() -> None:
+    """Test that an edit decision cannot redirect a call to another tool."""
+    middleware = HumanInTheLoopMiddleware(interrupt_on={"tool_a": {"allowed_decisions": ["edit"]}})
+
+    ai_message = AIMessage(
+        content="I'll help you",
+        tool_calls=[{"name": "tool_a", "args": {"input": "test"}, "id": "1"}],
+    )
+    state = AgentState[Any](messages=[HumanMessage(content="Hello"), ai_message])
+
+    def mock_cross_tool_edit(_: Any) -> dict[str, Any]:
+        return {
+            "decisions": [
+                {
+                    "type": "edit",
+                    "edited_action": Action(
+                        name="tool_b",
+                        args={"input": "edited"},
+                    ),
+                }
+            ]
+        }
+
+    with (
+        patch(
+            "langchain.agents.middleware.human_in_the_loop.interrupt",
+            side_effect=mock_cross_tool_edit,
+        ),
+        pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Tool name cannot be changed in an edit decision. Expected 'tool_a', got 'tool_b'."
+            ),
+        ),
+    ):
+        middleware.after_model(state, Runtime())
+
+
 def test_human_in_the_loop_middleware_single_tool_rejection_reason() -> None:
     """Test a custom rejection reason retains its human-provided context."""
     middleware = HumanInTheLoopMiddleware(


### PR DESCRIPTION
Fixes #40166

---

`HumanInTheLoopMiddleware` users can now rely on tool-specific approval boundaries because edit decisions may modify arguments but cannot redirect an approved call to a different tool. This PR implements the "Prohibit changing the tool name in an edit decision" approach; I plan to implement the alternative policy re-evaluation approach separately.

## Release note

`HumanInTheLoopMiddleware` now raises a `ValueError` when an edit decision changes the tool name, preventing cross-tool edits from bypassing the target tool's `interrupt_on` policy.

Verified with the HITL middleware unit suite (31 passed) and Ruff lint and format checks.

This contribution was developed with assistance from an AI coding agent.