### PR TITLE
fix(langchain): re-evaluate HITL policy after tool name edits

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -404,6 +404,86 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
         )
         return when(req)
 
+    def _request_decisions(
+        self,
+        tool_calls: dict[int, ToolCall],
+        candidate_indices: list[int],
+        state: AgentState[Any],
+        runtime: Runtime[ContextT],
+    ) -> tuple[list[Decision], list[int]] | None:
+        """Request decisions for candidate tool calls that require review."""
+        action_requests: list[ActionRequest] = []
+        review_configs: list[ReviewConfig] = []
+        interrupt_indices: list[int] = []
+
+        for idx in candidate_indices:
+            tool_call = tool_calls[idx]
+            if (config := self.interrupt_on.get(tool_call["name"])) is None:
+                continue
+            if not self._should_interrupt(tool_call, config, state, runtime):
+                continue
+            action_request, review_config = self._create_action_and_config(
+                tool_call, config, state, runtime
+            )
+            action_requests.append(action_request)
+            review_configs.append(review_config)
+            interrupt_indices.append(idx)
+
+        if not action_requests:
+            return None
+
+        hitl_request = HITLRequest(
+            action_requests=action_requests,
+            review_configs=review_configs,
+        )
+        decisions = interrupt(hitl_request)["decisions"]
+        if (decisions_len := len(decisions)) != (interrupt_count := len(interrupt_indices)):
+            msg = (
+                f"Number of human decisions ({decisions_len}) does not match "
+                f"number of hanging tool calls ({interrupt_count})."
+            )
+            raise ValueError(msg)
+        return decisions, interrupt_indices
+
+    def _review_renamed_tool_calls(
+        self,
+        tool_calls: dict[int, ToolCall],
+        renamed_indices: list[int],
+        state: AgentState[Any],
+        runtime: Runtime[ContextT],
+    ) -> list[ToolMessage]:
+        """Review edited calls against each new target tool's interrupt policy."""
+        artificial_tool_messages: list[ToolMessage] = []
+
+        while renamed_indices:
+            review = self._request_decisions(tool_calls, renamed_indices, state, runtime)
+            if review is None:
+                break
+            decisions, interrupt_indices = review
+            next_renamed_indices: list[int] = []
+
+            for idx, decision in zip(interrupt_indices, decisions, strict=True):
+                tool_call = tool_calls[idx]
+                config = self.interrupt_on[tool_call["name"]]
+                revised_tool_call, tool_message = self._process_decision(
+                    decision, tool_call, config
+                )
+                if revised_tool_call is None:
+                    del tool_calls[idx]
+                else:
+                    tool_calls[idx] = revised_tool_call
+                    if (
+                        decision["type"] == "edit"
+                        and revised_tool_call["name"] != tool_call["name"]
+                    ):
+                        next_renamed_indices.append(idx)
+                if tool_message is not None:
+                    artificial_tool_messages.append(tool_message)
+
+            renamed_indices = next_renamed_indices
+
+        return artificial_tool_messages
+
     def after_model(
         self, state: AgentState[Any], runtime: Runtime[ContextT]
     ) -> dict[str, Any] | None:
@@ -428,68 +508,46 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
         if not last_ai_msg or not last_ai_msg.tool_calls:
             return None
 
-        # Create action requests and review configs for tools that need approval
-        action_requests: list[ActionRequest] = []
-        review_configs: list[ReviewConfig] = []
-        interrupt_indices: list[int] = []
-
-        for idx, tool_call in enumerate(last_ai_msg.tool_calls):
-            if (config := self.interrupt_on.get(tool_call["name"])) is not None:
-                if not self._should_interrupt(tool_call, config, state, runtime):
-                    continue
-                action_request, review_config = self._create_action_and_config(
-                    tool_call, config, state, runtime
-                )
-                action_requests.append(action_request)
-                review_configs.append(review_config)
-                interrupt_indices.append(idx)
-
-        # If no interrupts needed, return early
-        if not action_requests:
-            return None
-
-        # Create single HITLRequest with all actions and configs
-        hitl_request = HITLRequest(
-            action_requests=action_requests,
-            review_configs=review_configs,
+        revised_tool_calls = dict(enumerate(last_ai_msg.tool_calls))
+        review = self._request_decisions(
+            revised_tool_calls, list(revised_tool_calls), state, runtime
         )
-
-        # Send interrupt and get response
-        decisions = interrupt(hitl_request)["decisions"]
-
-        # Validate that the number of decisions matches the number of interrupt tool calls
-        if (decisions_len := len(decisions)) != (interrupt_count := len(interrupt_indices)):
-            msg = (
-                f"Number of human decisions ({decisions_len}) does not match "
-                f"number of hanging tool calls ({interrupt_count})."
-            )
-            raise ValueError(msg)
+        if review is None:
+            return None
+        decisions, interrupt_indices = review
+        decisions_by_index = dict(zip(interrupt_indices, decisions, strict=True))
 
         # Process decisions and rebuild tool calls in original order
-        revised_tool_calls: list[ToolCall] = []
         artificial_tool_messages: list[ToolMessage] = []
-        decision_idx = 0
+        renamed_indices: list[int] = []
 
         for idx, tool_call in enumerate(last_ai_msg.tool_calls):
-            if idx in interrupt_indices:
+            if idx in decisions_by_index:
                 # This was an interrupt tool call - process the decision
                 config = self.interrupt_on[tool_call["name"]]
-                decision = decisions[decision_idx]
-                decision_idx += 1
+                decision = decisions_by_index[idx]
 
                 revised_tool_call, tool_message = self._process_decision(
                     decision, tool_call, config
                 )
                 if revised_tool_call is not None:
-                    revised_tool_calls.append(revised_tool_call)
-                if tool_message:
+                    revised_tool_calls[idx] = revised_tool_call
+                    if (
+                        decision["type"] == "edit"
+                        and revised_tool_call["name"] != tool_call["name"]
+                    ):
+                        renamed_indices.append(idx)
+                else:
+                    del revised_tool_calls[idx]
+                if tool_message is not None:
                     artificial_tool_messages.append(tool_message)
-            else:
-                # This was auto-approved - keep original
-                revised_tool_calls.append(tool_call)
+
+        artificial_tool_messages.extend(
+            self._review_renamed_tool_calls(revised_tool_calls, renamed_indices, state, runtime)
+        )
 
         # Update the AI message to only include approved tool calls
-        last_ai_msg.tool_calls = revised_tool_calls
+        last_ai_msg.tool_calls = list(revised_tool_calls.values())
 
         return {"messages": [last_ai_msg, *artificial_tool_messages]}
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
@@ -149,6 +149,179 @@ def test_human_in_the_loop_middleware_single_tool_edit() -> None:
         assert result["messages"][0].tool_calls[0]["id"] == "1"  # ID should be preserved
 
 
+def test_human_in_the_loop_middleware_rechecks_edited_tool_policy() -> None:
+    """Test that a renamed tool call is reviewed under its target tool policy."""
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={
+            "tool_a": {"allowed_decisions": ["approve", "edit"]},
+            "tool_b": {"allowed_decisions": ["approve", "reject"]},
+        }
+    )
+    ai_message = AIMessage(
+        content="I'll help you",
+        tool_calls=[{"name": "tool_a", "args": {"value": 1}, "id": "1"}],
+    )
+    state = AgentState[Any](messages=[HumanMessage(content="Hello"), ai_message])
+    captured_requests: list[Any] = []
+
+    def mock_decisions(request: Any) -> dict[str, Any]:
+        captured_requests.append(request)
+        if len(captured_requests) == 1:
+            return {
+                "decisions": [
+                    {
+                        "type": "edit",
+                        "edited_action": Action(
+                            name="tool_b",
+                            args={"value": "edited"},
+                        ),
+                    }
+                ]
+            }
+        return {"decisions": [{"type": "approve"}]}
+
+    with patch(
+        "langchain.agents.middleware.human_in_the_loop.interrupt",
+        side_effect=mock_decisions,
+    ):
+        result = middleware.after_model(state, Runtime())
+
+    assert result is not None
+    assert len(captured_requests) == 2
+    assert captured_requests[1]["action_requests"] == [
+        {
+            "name": "tool_b",
+            "args": {"value": "edited"},
+            "description": (
+                "Tool execution requires approval\n\nTool: tool_b\nArgs: {'value': 'edited'}"
+            ),
+        }
+    ]
+    assert captured_requests[1]["review_configs"] == [
+        {
+            "action_name": "tool_b",
+            "allowed_decisions": ["approve", "reject"],
+        }
+    ]
+    assert result["messages"][0].tool_calls == [
+        ToolCall(type="tool_call", name="tool_b", args={"value": "edited"}, id="1")
+    ]
+
+
+def test_human_in_the_loop_middleware_rechecks_edited_tool_when_predicate() -> None:
+    """Test that an edited target tool's `when` predicate can skip review."""
+    captured_target_calls: list[ToolCall] = []
+
+    def target_requires_review(request: ToolCallRequest) -> bool:
+        captured_target_calls.append(request.tool_call)
+        return False
+
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={
+            "tool_a": {"allowed_decisions": ["edit"]},
+            "tool_b": InterruptOnConfig(
+                allowed_decisions=["approve", "reject"],
+                when=target_requires_review,
+            ),
+        }
+    )
+    ai_message = AIMessage(
+        content="I'll help you",
+        tool_calls=[{"name": "tool_a", "args": {"value": 1}, "id": "1"}],
+    )
+    state = AgentState[Any](messages=[HumanMessage(content="Hello"), ai_message])
+
+    with (
+        patch("langchain.agents.middleware.human_in_the_loop.get_config", return_value={}),
+        patch(
+            "langchain.agents.middleware.human_in_the_loop.interrupt",
+            return_value={
+                "decisions": [
+                    {
+                        "type": "edit",
+                        "edited_action": Action(
+                            name="tool_b",
+                            args={"value": "safe"},
+                        ),
+                    }
+                ]
+            },
+        ) as mock_interrupt,
+    ):
+        result = middleware.after_model(state, Runtime())
+
+    assert result is not None
+    assert mock_interrupt.call_count == 1
+    assert captured_target_calls == [
+        ToolCall(type="tool_call", name="tool_b", args={"value": "safe"}, id="1")
+    ]
+    assert result["messages"][0].tool_calls == captured_target_calls
+
+
+def test_human_in_the_loop_middleware_rechecks_edited_tool_when_true() -> None:
+    """Test that a target tool's true `when` predicate triggers another review."""
+    captured_target_calls: list[ToolCall] = []
+
+    def target_requires_review(request: ToolCallRequest) -> bool:
+        captured_target_calls.append(request.tool_call)
+        return True
+
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={
+            "tool_a": {"allowed_decisions": ["edit"]},
+            "tool_b": InterruptOnConfig(
+                allowed_decisions=["approve", "reject"],
+                when=target_requires_review,
+            ),
+        }
+    )
+    ai_message = AIMessage(
+        content="I'll help you",
+        tool_calls=[{"name": "tool_a", "args": {"value": 1}, "id": "1"}],
+    )
+    state = AgentState[Any](messages=[HumanMessage(content="Hello"), ai_message])
+
+    with (
+        patch("langchain.agents.middleware.human_in_the_loop.get_config", return_value={}),
+        patch(
+            "langchain.agents.middleware.human_in_the_loop.interrupt",
+            side_effect=[
+                {
+                    "decisions": [
+                        {
+                            "type": "edit",
+                            "edited_action": Action(
+                                name="tool_b",
+                                args={"value": "requires-review"},
+                            ),
+                        }
+                    ]
+                },
+                {"decisions": [{"type": "approve"}]},
+            ],
+        ) as mock_interrupt,
+    ):
+        result = middleware.after_model(state, Runtime())
+
+    edited_tool_call = ToolCall(
+        type="tool_call",
+        name="tool_b",
+        args={"value": "requires-review"},
+        id="1",
+    )
+    assert result is not None
+    assert mock_interrupt.call_count == 2
+    assert captured_target_calls == [edited_tool_call]
+    target_request = mock_interrupt.call_args_list[1].args[0]
+    assert target_request["action_requests"][0]["name"] == "tool_b"
+    assert target_request["action_requests"][0]["args"] == {"value": "requires-review"}
+    assert target_request["review_configs"][0] == {
+        "action_name": "tool_b",
+        "allowed_decisions": ["approve", "reject"],
+    }
+    assert result["messages"][0].tool_calls == [edited_tool_call]
+
+
 def test_human_in_the_loop_middleware_single_tool_rejection_reason() -> None:
     """Test a custom rejection reason retains its human-provided context."""
     middleware = HumanInTheLoopMiddleware(
@@ -282,6 +455,221 @@ def test_human_in_the_loop_middleware_rejected_call_not_executed_and_stays_paire
     assert calls == []
     # The message history must remain protocol-valid throughout, including the rejection turn.
     _assert_tool_messages_are_paired(final["messages"])
+
+
+def test_cross_tool_edit_requires_target_tool_approval() -> None:
+    """A cross-tool edit must interrupt again before the target tool executes."""
+    calls: list[tuple[str, object]] = []
+
+    @tool
+    def tool_a(value: int) -> str:
+        """Run tool A."""
+        calls.append(("tool_a", value))
+        return "A executed"
+
+    @tool
+    def tool_b(value: str) -> str:
+        """Run tool B."""
+        calls.append(("tool_b", value))
+        return "B executed"
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="tool_a", args={"value": 1}, id="1")],
+            [],
+        ]
+    )
+    agent = create_agent(
+        model=model,
+        tools=[tool_a, tool_b],
+        middleware=[
+            HumanInTheLoopMiddleware(
+                interrupt_on={
+                    "tool_a": {"allowed_decisions": ["approve", "edit"]},
+                    "tool_b": {"allowed_decisions": ["approve", "reject"]},
+                }
+            )
+        ],
+        checkpointer=InMemorySaver(),
+    )
+    config = {"configurable": {"thread_id": "cross-tool-edit-target-policy"}}
+
+    first = agent.invoke({"messages": [HumanMessage("Run tool A")]}, config)
+    assert "__interrupt__" in first
+
+    second = agent.invoke(
+        Command(
+            resume={
+                "decisions": [
+                    {
+                        "type": "edit",
+                        "edited_action": {
+                            "name": "tool_b",
+                            "args": {"value": "edited"},
+                        },
+                    }
+                ]
+            }
+        ),
+        config,
+    )
+    assert "__interrupt__" in second
+    assert calls == []
+
+    final = agent.invoke(
+        Command(resume={"decisions": [{"type": "approve"}]}),
+        config,
+    )
+    assert "__interrupt__" not in final
+    assert calls == [("tool_b", "edited")]
+
+
+def test_multiple_cross_tool_edits_recheck_each_target() -> None:
+    """Each target in a chain of cross-tool edits must be reviewed before execution."""
+    calls: list[tuple[str, str]] = []
+
+    @tool
+    def tool_a(value: str) -> str:
+        """Run tool A."""
+        calls.append(("tool_a", value))
+        return "A executed"
+
+    @tool
+    def tool_b(value: str) -> str:
+        """Run tool B."""
+        calls.append(("tool_b", value))
+        return "B executed"
+
+    @tool
+    def tool_c(value: str) -> str:
+        """Run tool C."""
+        calls.append(("tool_c", value))
+        return "C executed"
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="tool_a", args={"value": "original"}, id="1")],
+            [],
+        ]
+    )
+    agent = create_agent(
+        model=model,
+        tools=[tool_a, tool_b, tool_c],
+        middleware=[
+            HumanInTheLoopMiddleware(
+                interrupt_on={
+                    "tool_a": {"allowed_decisions": ["edit"]},
+                    "tool_b": {"allowed_decisions": ["edit"]},
+                    "tool_c": {"allowed_decisions": ["approve"]},
+                }
+            )
+        ],
+        checkpointer=InMemorySaver(),
+    )
+    config = {"configurable": {"thread_id": "multiple-cross-tool-edits"}}
+
+    first = agent.invoke({"messages": [HumanMessage("Run tool A")]}, config)
+    assert "__interrupt__" in first
+
+    second = agent.invoke(
+        Command(
+            resume={
+                "decisions": [
+                    {
+                        "type": "edit",
+                        "edited_action": {
+                            "name": "tool_b",
+                            "args": {"value": "edited-b"},
+                        },
+                    }
+                ]
+            }
+        ),
+        config,
+    )
+    assert second["__interrupt__"][0].value["action_requests"][0]["name"] == "tool_b"
+    assert calls == []
+
+    third = agent.invoke(
+        Command(
+            resume={
+                "decisions": [
+                    {
+                        "type": "edit",
+                        "edited_action": {
+                            "name": "tool_c",
+                            "args": {"value": "edited-c"},
+                        },
+                    }
+                ]
+            }
+        ),
+        config,
+    )
+    assert third["__interrupt__"][0].value["action_requests"][0]["name"] == "tool_c"
+    assert calls == []
+
+    final = agent.invoke(
+        Command(resume={"decisions": [{"type": "approve"}]}),
+        config,
+    )
+    assert "__interrupt__" not in final
+    assert calls == [("tool_c", "edited-c")]
+
+
+def test_cross_tool_edit_to_unconfigured_tool_is_auto_approved() -> None:
+    """A renamed call is auto-approved when the target has no HITL policy."""
+    calls: list[tuple[str, str]] = []
+
+    @tool
+    def tool_a(value: str) -> str:
+        """Run tool A."""
+        calls.append(("tool_a", value))
+        return "A executed"
+
+    @tool
+    def tool_b(value: str) -> str:
+        """Run tool B."""
+        calls.append(("tool_b", value))
+        return "B executed"
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="tool_a", args={"value": "original"}, id="1")],
+            [],
+        ]
+    )
+    agent = create_agent(
+        model=model,
+        tools=[tool_a, tool_b],
+        middleware=[
+            HumanInTheLoopMiddleware(interrupt_on={"tool_a": {"allowed_decisions": ["edit"]}})
+        ],
+        checkpointer=InMemorySaver(),
+    )
+    config = {"configurable": {"thread_id": "cross-tool-edit-unconfigured-target"}}
+
+    first = agent.invoke({"messages": [HumanMessage("Run tool A")]}, config)
+    assert "__interrupt__" in first
+
+    final = agent.invoke(
+        Command(
+            resume={
+                "decisions": [
+                    {
+                        "type": "edit",
+                        "edited_action": {
+                            "name": "tool_b",
+                            "args": {"value": "auto-approved"},
+                        },
+                    }
+                ]
+            }
+        ),
+        config,
+    )
+    assert "__interrupt__" not in final
+    assert calls == [("tool_b", "auto-approved")]
 
 
 def test_human_in_the_loop_middleware_single_tool_respond() -> None:


### PR DESCRIPTION
Fixes #40166

---

`HumanInTheLoopMiddleware` users can safely edit a reviewed call to a different tool because the edited target is now re-evaluated against its own `interrupt_on` policy and `when` predicate before execution. This PR implements the "Permit name changes, but re-evaluate the edited target tool's `interrupt_on` policy before execution" approach, preserving documented cross-tool edits while preventing target-policy bypasses; it is an alternative to #40265.

## Release note

Cross-tool HITL edits now apply the target tool's approval policy before execution.

Verified with all 36 HITL middleware unit tests, including chained A → B → C edits, unconfigured targets, and conditional target policies. Ruff and mypy checks also pass.

This contribution was developed with assistance from an AI coding agent.