### PR TITLE
perf(core): defer tracer imports in runnables to call time

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -84,18 +84,6 @@ from langchain_core.runnables.utils import (
     is_async_generator,
 )
 from langchain_core.tracers._streaming import _StreamingCallbackHandler
-from langchain_core.tracers.event_stream import (
-    _astream_events_implementation_v1,
-    _astream_events_implementation_v2,
-)
-from langchain_core.tracers.log_stream import (
-    LogStreamCallbackHandler,
-    _astream_log_implementation,
-)
-from langchain_core.tracers.root_listeners import (
-    AsyncRootListenersTracer,
-    RootListenersTracer,
-)
 from langchain_core.utils.aiter import aclosing, atee
 from langchain_core.utils.iter import safetee
 from langchain_core.utils.pydantic import (
@@ -1309,6 +1297,12 @@ class Runnable(ABC, Generic[Input, Output]):
             A `RunLogPatch` or `RunLog` object.
 
         """
+        # Deferred to avoid importing langsmith at module level (~132ms).
+        from langchain_core.tracers.log_stream import (  # noqa: PLC0415
+            LogStreamCallbackHandler,
+            _astream_log_implementation,
+        )
+
         warn_deprecated(
             since="1.3.3",
             message=("astream_log is deprecated. Use astream instead."),
@@ -1626,6 +1620,12 @@ class Runnable(ABC, Generic[Input, Output]):
         exclude_tags: Sequence[str] | None = None,
         **kwargs: Any,
     ) -> AsyncIterator[StreamEvent]:
+        # Deferred to avoid importing langsmith at module level (~132ms).
+        from langchain_core.tracers.event_stream import (  # noqa: PLC0415
+            _astream_events_implementation_v1,
+            _astream_events_implementation_v2,
+        )
+
         if version == "v2":
             event_stream = _astream_events_implementation_v2(
                 self,
@@ -1963,6 +1963,11 @@ class Runnable(ABC, Generic[Input, Output]):
             chain.invoke(2)
             ```
         """
+        # Deferred to avoid importing langsmith at module level (~132ms).
+        from langchain_core.tracers.root_listeners import (  # noqa: PLC0415
+            RootListenersTracer,
+        )
+
         return RunnableBinding(
             bound=self,
             config_factories=[
@@ -2060,6 +2065,11 @@ class Runnable(ABC, Generic[Input, Output]):
             # on end callback ends at 2025-03-01T07:05:30.884831+00:00
             ```
         """
+        # Deferred to avoid importing langsmith at module level (~132ms).
+        from langchain_core.tracers.root_listeners import (  # noqa: PLC0415
+            AsyncRootListenersTracer,
+        )
+
         return RunnableBinding(
             bound=self,
             config_factories=[
@@ -6495,6 +6505,10 @@ class RunnableBinding(RunnableBindingBase[Input, Output]):  # type: ignore[no-re
         Returns:
             A new `Runnable` with the listeners bound.
         """
+        # Deferred to avoid importing langsmith at module level (~132ms).
+        from langchain_core.tracers.root_listeners import (  # noqa: PLC0415
+            RootListenersTracer,
+        )
 
         def listener_config_factory(config: RunnableConfig) -> RunnableConfig:
             return {

--- a/libs/core/tests/unit_tests/test_imports.py
+++ b/libs/core/tests/unit_tests/test_imports.py
@@ -59,3 +59,39 @@ def test_importable_all_via_subprocess() -> None:
             if code != 0:
                 msg = f"Failed to import {module_name}."
                 raise ValueError(msg)
+
+
+def test_runnables_does_not_import_langsmith() -> None:
+    """Importing `langchain_core.runnables` must not pull in the `langsmith` SDK.
+
+    The tracer modules reach `langsmith` through `tracers.schemas`, so importing
+    them at module level loads the SDK for every program, including those that
+    never trace. Run in a subprocess so the result cannot be affected by imports
+    performed by other tests.
+
+    `Runnable` is bound rather than importing the package alone, because
+    `langchain_core.runnables` resolves its exports lazily and would not load
+    `runnables.base` otherwise.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; from langchain_core.runnables import Runnable; "
+                "sys.exit(2 if 'langsmith' in sys.modules else 0)"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 2:
+        msg = (
+            "`langsmith` was imported as a side effect of importing "
+            "`langchain_core.runnables`"
+        )
+        raise AssertionError(msg)
+    if result.returncode != 0:
+        msg = f"Subprocess failed unexpectedly:\n{result.stderr}"
+        raise AssertionError(msg)


### PR DESCRIPTION
Closes #40236

---

Anyone importing from `langchain_core.runnables`, which is nearly every LangChain program, also loads the full `langsmith` SDK even when they never trace. `Runnable` pulls the tracer modules in at module level, and those reach `langsmith` through the tracer schemas, so the SDK's model construction is paid on every cold start.

This defers the `event_stream`, `log_stream` and `root_listeners` imports into the five methods that use them: `astream_log`, `_astream_events_v1_v2`, `Runnable.with_listeners`, `Runnable.with_alisteners` and `RunnableBinding.with_listeners`. `_StreamingCallbackHandler` stays at module level because it imports nothing expensive, so moving it saves nothing.

Same approach as #35298, which did this for the callback manager and runnable config. These particular imports were only moved to module level by #32351 as part of the `PLC0415` rollout, not for any behavioural reason. The tradeoff is that the first `astream_events` or `astream_log` call in a process pays the import on the event loop thread; both were already async generators, so their bodies were already deferred to first iteration, and #35298 set that precedent.

I also added a test asserting `langsmith` is absent from `sys.modules` after importing `Runnable`. Nothing covered that before, and the obvious version of the test passes even without the fix, because `langchain_core.runnables` resolves its exports lazily and so never loads the module under test. The same win holds for `BaseChatModel`, `tool` and `ChatPromptTemplate`, though the test only pins `Runnable`.

`ruff`, `ruff format`, `mypy` and `lint_imports.sh` are clean, and the `runnables`, `astream_events` and `test_imports` suites pass. My Windows machine has pre-existing `pytest_socket` failures identical on `master` and on this branch, so CI is the authority for the full suite.

I noticed `sr/deferred-imports` has a similar change. Is that still active? If so I'm happy to defer to it. This version adds a regression test that neither that branch nor #35298 has, and skips the `TYPE_CHECKING` block, since no deferred name is used in an annotation.

## Release note

Importing `langchain_core.runnables` no longer loads the `langsmith` SDK, reducing cold-start import time for applications that do not use tracing.

---

Drafted with AI-agent assistance; every change was run and verified locally.
