### PR TITLE
perf(core): defer runnables tracer imports

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -84,18 +84,6 @@ from langchain_core.runnables.utils import (
     is_async_generator,
 )
 from langchain_core.tracers._streaming import _StreamingCallbackHandler
-from langchain_core.tracers.event_stream import (
-    _astream_events_implementation_v1,
-    _astream_events_implementation_v2,
-)
-from langchain_core.tracers.log_stream import (
-    LogStreamCallbackHandler,
-    _astream_log_implementation,
-)
-from langchain_core.tracers.root_listeners import (
-    AsyncRootListenersTracer,
-    RootListenersTracer,
-)
 from langchain_core.utils.aiter import aclosing, atee
 from langchain_core.utils.iter import safetee
 from langchain_core.utils.pydantic import (
@@ -1309,6 +1297,11 @@ class Runnable(ABC, Generic[Input, Output]):
             A `RunLogPatch` or `RunLog` object.
 
         """
+        from langchain_core.tracers.log_stream import (  # noqa: PLC0415
+            LogStreamCallbackHandler,
+            _astream_log_implementation,
+        )
+
         warn_deprecated(
             since="1.3.3",
             message=("astream_log is deprecated. Use astream instead."),
@@ -1626,6 +1619,11 @@ class Runnable(ABC, Generic[Input, Output]):
         exclude_tags: Sequence[str] | None = None,
         **kwargs: Any,
     ) -> AsyncIterator[StreamEvent]:
+        from langchain_core.tracers.event_stream import (  # noqa: PLC0415
+            _astream_events_implementation_v1,
+            _astream_events_implementation_v2,
+        )
+
         if version == "v2":
             event_stream = _astream_events_implementation_v2(
                 self,
@@ -1963,6 +1961,10 @@ class Runnable(ABC, Generic[Input, Output]):
             chain.invoke(2)
             ```
         """
+        from langchain_core.tracers.root_listeners import (  # noqa: PLC0415
+            RootListenersTracer,
+        )
+
         return RunnableBinding(
             bound=self,
             config_factories=[
@@ -2060,6 +2062,10 @@ class Runnable(ABC, Generic[Input, Output]):
             # on end callback ends at 2025-03-01T07:05:30.884831+00:00
             ```
         """
+        from langchain_core.tracers.root_listeners import (  # noqa: PLC0415
+            AsyncRootListenersTracer,
+        )
+
         return RunnableBinding(
             bound=self,
             config_factories=[
@@ -6495,6 +6501,9 @@ class RunnableBinding(RunnableBindingBase[Input, Output]):  # type: ignore[no-re
         Returns:
             A new `Runnable` with the listeners bound.
         """
+        from langchain_core.tracers.root_listeners import (  # noqa: PLC0415
+            RootListenersTracer,
+        )
 
         def listener_config_factory(config: RunnableConfig) -> RunnableConfig:
             return {

--- a/libs/core/tests/unit_tests/test_imports.py
+++ b/libs/core/tests/unit_tests/test_imports.py
@@ -59,3 +59,18 @@ def test_importable_all_via_subprocess() -> None:
             if code != 0:
                 msg = f"Failed to import {module_name}."
                 raise ValueError(msg)
+
+
+def test_runnables_import_does_not_import_langsmith() -> None:
+    """Importing runnable primitives should not eagerly import the LangSmith SDK."""
+    code = (
+        "import sys\n"
+        "from langchain_core.runnables import Runnable\n"
+        "loaded = sorted(\n"
+        "    name for name in sys.modules\n"
+        "    if name == 'langsmith' or name.startswith('langsmith.')\n"
+        ")\n"
+        "assert not loaded, loaded[:10]\n"
+        "assert Runnable.__name__ == 'Runnable'\n"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)


### PR DESCRIPTION
## Summary
- defer `runnables/base.py` imports of tracer event/log/root-listener modules until the APIs that need them are called
- keep `_StreamingCallbackHandler` at module import time because it is lightweight and used on streaming paths
- add a subprocess regression test that importing `Runnable` does not load `langsmith` into `sys.modules`

Fixes #40236

## Testing
- `ruff check libs/core/langchain_core/runnables/base.py libs/core/tests/unit_tests/test_imports.py`
- `ruff format --check libs/core/langchain_core/runnables/base.py libs/core/tests/unit_tests/test_imports.py`
- `python -m py_compile libs/core/langchain_core/runnables/base.py libs/core/tests/unit_tests/test_imports.py`
- Not run: `UV_CACHE_DIR=/private/tmp/uv-cache-langchain uv run --no-default-groups --group test pytest tests/unit_tests/test_imports.py::test_runnables_import_does_not_import_langsmith` could not complete because PyPI DNS resolution failed while downloading `langsmith==0.11.1`.