### PR TITLE
fix(core): treat an empty stream as success in `RunnableWithFallbacks`

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -486,6 +486,11 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         )
         first_error = None
         last_error = None
+        # Distinguishes "the stream ended without producing anything" from "the
+        # stream raised". Without it, the `StopIteration` raised by an exhausted
+        # stream would be caught below as if the `Runnable` had failed.
+        sentinel = object()
+        first_chunk: Output | object = sentinel
         for runnable in self.runnables:
             try:
                 if self.exception_key and last_error is not None:
@@ -497,7 +502,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         input,
                         **kwargs,
                     )
-                    chunk: Output = context.run(next, stream)
+                    first_chunk = context.run(next, stream, sentinel)
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -511,6 +516,13 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
             run_manager.on_chain_error(first_error)
             raise first_error
 
+        if first_chunk is sentinel:
+            # The `Runnable` succeeded but yielded nothing, so propagate the empty
+            # stream rather than falling back or raising.
+            run_manager.on_chain_end(None)
+            return
+
+        chunk = cast("Output", first_chunk)
         yield chunk
         output: Output | None = chunk
         try:
@@ -550,6 +562,10 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         )
         first_error = None
         last_error = None
+        # See the note in `stream`: an exhausted stream raises `StopAsyncIteration`,
+        # which would otherwise be mistaken for a failed `Runnable`.
+        sentinel = object()
+        first_chunk: Output | object = sentinel
         for runnable in self.runnables:
             try:
                 if self.exception_key and last_error is not None:
@@ -561,7 +577,9 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         child_config,
                         **kwargs,
                     )
-                    chunk = await coro_with_context(anext(stream), context)
+                    first_chunk = await coro_with_context(
+                        anext(stream, sentinel), context
+                    )
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -575,6 +593,13 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
             await run_manager.on_chain_error(first_error)
             raise first_error
 
+        if first_chunk is sentinel:
+            # The `Runnable` succeeded but yielded nothing, so propagate the empty
+            # stream rather than falling back or raising.
+            await run_manager.on_chain_end(None)
+            return
+
+        chunk = cast("Output", first_chunk)
         yield chunk
         output: Output | None = chunk
         try:

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -326,6 +326,59 @@ async def test_fallbacks_astream() -> None:
         _ = [_ async for _ in runnable.astream({})]
 
 
+# Iterating an empty list (rather than returning early) keeps the helpers below
+# generator functions without introducing unreachable statements.
+_NO_CHUNKS: list[str] = []
+
+
+def _generate_empty(_: Iterator[Any]) -> Iterator[str]:
+    """Yield nothing, which is a valid result rather than a failure."""
+    yield from _NO_CHUNKS
+
+
+async def _agenerate_empty(_: AsyncIterator[Any]) -> AsyncIterator[str]:
+    """Async counterpart of `_generate_empty`."""
+    for chunk in _NO_CHUNKS:
+        yield chunk
+
+
+def test_fallbacks_stream_empty() -> None:
+    # A `Runnable` that yields nothing succeeded, so no fallback should be used.
+    runnable = RunnableGenerator(_generate_empty).with_fallbacks(
+        [RunnableGenerator(_generate)]
+    )
+    assert list(runnable.stream({})) == []
+
+    # Nothing anywhere to stream is still not an error.
+    runnable = RunnableGenerator(_generate_empty).with_fallbacks(
+        [RunnableGenerator(_generate_empty)]
+    )
+    assert list(runnable.stream({})) == []
+
+    # A genuine failure still falls back, even when the fallback yields nothing.
+    runnable = RunnableGenerator(_generate_immediate_error).with_fallbacks(
+        [RunnableGenerator(_generate_empty)]
+    )
+    assert list(runnable.stream({})) == []
+
+
+async def test_fallbacks_astream_empty() -> None:
+    runnable = RunnableGenerator(_agenerate_empty).with_fallbacks(
+        [RunnableGenerator(_agenerate)]
+    )
+    assert [c async for c in runnable.astream({})] == []
+
+    runnable = RunnableGenerator(_agenerate_empty).with_fallbacks(
+        [RunnableGenerator(_agenerate_empty)]
+    )
+    assert [c async for c in runnable.astream({})] == []
+
+    runnable = RunnableGenerator(_agenerate_immediate_error).with_fallbacks(
+        [RunnableGenerator(_agenerate_empty)]
+    )
+    assert [c async for c in runnable.astream({})] == []
+
+
 class FakeStructuredOutputModel(BaseChatModel):
     foo: int
 


### PR DESCRIPTION
Fixes #38892

---

`RunnableWithFallbacks` decides whether a runnable "worked" by peeking at its
first streamed chunk with a bare `next()` / `anext()`. A runnable that
legitimately streams nothing — a model returning empty content, a filter step
that drops every chunk, a moderation-blocked response — signals that with
`StopIteration` / `StopAsyncIteration`. Both are `Exception` subclasses, so the
default `exceptions_to_handle` swallowed them and treated a valid empty stream
as a failed runnable.

That gave users two surprises: a configured fallback quietly replaced the
primary's valid empty output, and once there was nothing left to fall back to
the re-raised `StopIteration` surfaced as
`RuntimeError: generator raised StopIteration` (PEP 479), which points nowhere
near the real cause.

Peeking with a sentinel default separates "the stream is empty" from "the
stream raised", so an empty stream is now propagated as an empty stream. Real
exceptions still trigger the fallbacks exactly as before, which the existing
`test_fallbacks_stream` / `test_fallbacks_astream` cases cover.

Thanks to @ErenAta16 for the report and the minimal repro. They mentioned in
the issue that they had a fix ready and were waiting for approval — happy to
close this in favour of theirs if that is preferred.

## Release note

`RunnableWithFallbacks.stream()` and `astream()` no longer treat a runnable
that yields zero chunks as a failure. The empty stream is passed through
instead of silently switching to a fallback or raising
`RuntimeError: generator raised StopIteration`.

Reviewers may want to look closely at the behavior change: anyone who was
(perhaps unknowingly) relying on an empty stream to trigger a fallback will now
see the empty stream instead.

Prepared with the help of an AI coding agent; the repro, the fix, and
`make lint` / `make test` for `libs/core` were run and verified locally.
