### PR TITLE
fix(langchain): cap retry delay at `max_delay` after jitter

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/_retry.py
+++ b/libs/langchain_v1/langchain/agents/middleware/_retry.py
@@ -128,7 +128,7 @@ def calculate_delay(
     if jitter and delay > 0:
         jitter_amount = delay * 0.25  # ±25% jitter
         delay += random.uniform(-jitter_amount, jitter_amount)  # noqa: S311
-        # Ensure delay is not negative after jitter
-        delay = max(0, delay)
+        # Cap again so positive jitter cannot push the delay past `max_delay`
+        delay = min(max(0, delay), max_delay)
 
     return delay

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_retry.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_retry.py
@@ -3,6 +3,7 @@
 import time
 from collections.abc import Callable
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from langchain_core.messages import HumanMessage, ToolCall, ToolMessage
@@ -698,6 +699,41 @@ def test_tool_retry_max_delay_cap() -> None:
     assert delay_0 == 1.0
     assert delay_1 == 2.0
     assert delay_2 == 2.0
+
+
+def test_tool_retry_max_delay_cap_with_jitter() -> None:
+    """Test calculate_delay keeps the capped delay at or below `max_delay` under jitter."""
+    # Patch jitter to always take the upper bound so positive jitter cannot be
+    # masked by the random draw.
+    with patch(
+        "langchain.agents.middleware._retry.random.uniform",
+        side_effect=lambda _lower, upper: upper,
+    ):
+        # Pre-jitter delay is capped to `max_delay`, so jitter can only push it over.
+        delay = calculate_delay(
+            0,
+            backoff_factor=0.0,  # Constant delay
+            initial_delay=10.0,
+            max_delay=10.0,
+            jitter=True,
+        )
+
+    assert delay == 10.0
+
+    # Backoff growth that does not itself reach the cap is also bounded by it.
+    with patch(
+        "langchain.agents.middleware._retry.random.uniform",
+        side_effect=lambda _lower, upper: upper,
+    ):
+        delay = calculate_delay(
+            10,
+            backoff_factor=1.5,
+            initial_delay=1.0,
+            max_delay=60.0,  # 1.5 ** 10 = 57.67
+            jitter=True,
+        )
+
+    assert delay == 60.0
 
 
 def test_tool_retry_jitter_variation() -> None:


### PR DESCRIPTION
Closes #40259

---

`calculate_delay` capped the delay at `max_delay` before applying ±25% jitter, then only clamped the lower bound with `max(0, delay)`. Positive jitter could therefore push the final delay as high as `max_delay * 1.25`.

Anyone raising `max_retries` past the shipped default of `2` hits this: with the documented defaults (`backoff_factor=2.0`, `initial_delay=1.0`, `max_delay=60.0`), `retry_number=6` yields an uncapped 64s, the first cap reduces it to 60s, and positive jitter then returns 75s — 15s past the configured maximum. The minimal case needs no backoff growth at all: `backoff_factor=0.0` (constant delay, an explicitly documented `ModelRetryMiddleware` configuration) with `initial_delay=max_delay=10.0` returns 12.5s on the first retry. Where the pre-jitter delay equals `max_delay`, roughly half of all calls exceed the limit.

`max_delay` is documented as the maximum delay between retries, so the returned value — jitter included — should stay at or below it.

The fix clamps once more after jitter, leaving the `max(0, ...)` lower bound intact. It is contained to the single point both `ModelRetryMiddleware` and `ToolRetryMiddleware` share.

Existing tests covered the cap only with `jitter=False`, and covered jitter only against a cap that was never reached, so the boundary went unexercised. `test_tool_retry_max_delay_cap_with_jitter` patches `random.uniform` to always take the upper bound, making positive jitter deterministic rather than probabilistic, and covers both shapes of the overshoot: a pre-jitter delay already at the cap, and backoff growth that stays under it.
