### PR TITLE
fix(deepseek): translate `JSONDecodeError` on the async path too

### DIFF
--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import AsyncIterator, Callable, Iterator, Sequence
 from json import JSONDecodeError
 from typing import Any, Literal, TypeAlias, cast
 from urllib.parse import urlparse
 
 import openai
 from langchain_core.callbacks import (
+    AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
 )
 from langchain_core.language_models import (
@@ -483,6 +484,32 @@ class ChatDeepSeek(BaseChatOpenAI):
                 e.pos,
             ) from e
 
+    async def _astream(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: AsyncCallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[ChatGenerationChunk]:
+        try:
+            async for chunk in super()._astream(
+                messages,
+                stop=stop,
+                run_manager=run_manager,
+                **kwargs,
+            ):
+                yield chunk
+        except JSONDecodeError as e:
+            msg = (
+                "DeepSeek API returned an invalid response. "
+                "Please check the API status and try again."
+            )
+            raise JSONDecodeError(
+                msg,
+                e.doc,
+                e.pos,
+            ) from e
+
     def _generate(
         self,
         messages: list[BaseMessage],
@@ -492,6 +519,31 @@ class ChatDeepSeek(BaseChatOpenAI):
     ) -> ChatResult:
         try:
             return super()._generate(
+                messages,
+                stop=stop,
+                run_manager=run_manager,
+                **kwargs,
+            )
+        except JSONDecodeError as e:
+            msg = (
+                "DeepSeek API returned an invalid response. "
+                "Please check the API status and try again."
+            )
+            raise JSONDecodeError(
+                msg,
+                e.doc,
+                e.pos,
+            ) from e
+
+    async def _agenerate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: AsyncCallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        try:
+            return await super()._agenerate(
                 messages,
                 stop=stop,
                 run_manager=run_manager,

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from json import JSONDecodeError
 from typing import Any, Literal
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from langchain_core.messages import AIMessage, AIMessageChunk, ToolMessage
 from langchain_tests.unit_tests import ChatModelUnitTests
 from openai import BaseModel
@@ -704,6 +706,99 @@ class TestChatDeepSeekPromptCacheUsage:
         message = generation_chunk.message
         assert isinstance(message, AIMessageChunk)
         assert message.usage_metadata is None
+
+
+INVALID_RESPONSE_MSG = (
+    "DeepSeek API returned an invalid response. "
+    "Please check the API status and try again."
+)
+
+
+def _empty_body_error() -> JSONDecodeError:
+    """Build the error the SDK raises when a response body is empty.
+
+    `json.loads("")` raises exactly `JSONDecodeError("Expecting value", "", 0)`,
+    which is what escapes the `openai` client when DeepSeek answers with a
+    truncated or empty body.
+    """
+    return JSONDecodeError("Expecting value", "", 0)
+
+
+class TestChatDeepSeekInvalidResponse:
+    """Tests that an unparseable response body reads the same from every entry point.
+
+    `ChatDeepSeek` overrides `_stream` and `_generate` for the sole purpose of
+    re-raising the SDK's `JSONDecodeError` with a message that names DeepSeek
+    instead of the opaque "Expecting value" (#29758, closing #29626). The async
+    twins have to do the same, or `ainvoke`/`astream` — the halves every
+    LangGraph deployment and every async service uses — leak the raw message.
+    """
+
+    @staticmethod
+    def _get_model() -> ChatDeepSeek:
+        """Build a model whose clients always fail to parse the response.
+
+        `_generate`/`_agenerate` always request through
+        `with_raw_response.create`, while `_stream`/`_astream` call `create`
+        directly, so both attributes have to fail for all four entry points to
+        be covered.
+        """
+        model = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("api_key"))
+
+        sync_client = MagicMock()
+        sync_client.create = MagicMock(side_effect=_empty_body_error())
+        sync_client.with_raw_response.create = MagicMock(
+            side_effect=_empty_body_error(),
+        )
+        async_client = MagicMock()
+        async_client.create = AsyncMock(side_effect=_empty_body_error())
+        async_client.with_raw_response.create = AsyncMock(
+            side_effect=_empty_body_error(),
+        )
+
+        model.client = sync_client
+        model.async_client = async_client
+        return model
+
+    def test_invoke_names_deepseek(self) -> None:
+        """Test that `invoke` reports which API returned the bad response."""
+        with pytest.raises(JSONDecodeError) as exc_info:
+            self._get_model().invoke("test")
+
+        assert exc_info.value.msg == INVALID_RESPONSE_MSG
+
+    def test_stream_names_deepseek(self) -> None:
+        """Test that `stream` reports which API returned the bad response."""
+        with pytest.raises(JSONDecodeError) as exc_info:
+            list(self._get_model().stream("test"))
+
+        assert exc_info.value.msg == INVALID_RESPONSE_MSG
+
+    async def test_ainvoke_names_deepseek(self) -> None:
+        """Test that `ainvoke` reports it too, not just its sync twin."""
+        with pytest.raises(JSONDecodeError) as exc_info:
+            await self._get_model().ainvoke("test")
+
+        assert exc_info.value.msg == INVALID_RESPONSE_MSG
+
+    async def test_astream_names_deepseek(self) -> None:
+        """Test that `astream` reports it too, not just its sync twin."""
+        with pytest.raises(JSONDecodeError) as exc_info:
+            async for _ in self._get_model().astream("test"):
+                pass
+
+        assert exc_info.value.msg == INVALID_RESPONSE_MSG
+
+    async def test_original_error_is_preserved(self) -> None:
+        """Test that the re-raise keeps the position and chains the cause."""
+        with pytest.raises(JSONDecodeError) as exc_info:
+            await self._get_model().ainvoke("test")
+
+        assert exc_info.value.doc == ""
+        assert exc_info.value.pos == 0
+        cause = exc_info.value.__cause__
+        assert isinstance(cause, JSONDecodeError)
+        assert cause.msg == "Expecting value"
 
 
 def test_profile() -> None:


### PR DESCRIPTION
Closes #40281

---

`ChatDeepSeek` overrides `_stream` and `_generate` for one reason only: to catch the `openai` SDK's `JSONDecodeError` and re-raise it with a message that names DeepSeek, instead of the bare `Expecting value: line 1 column 1 (char 0)` a user gets when DeepSeek answers with a truncated or empty body. That is #29758, merged against #29626. The class defines no `_astream` and no `_agenerate`, so `BaseChatOpenAI`'s async halves ran unwrapped and the raw message escaped from `ainvoke` and `astream`. Any async caller takes that path — an ASGI service, or a LangGraph / `create_agent` application invoked with `ainvoke` / `astream` — and got an error naming neither DeepSeek nor `ChatDeepSeek`.

This mirrors the two existing overrides one for one, with each async twin placed next to its sync counterpart, which is how `ChatXAI` overrides both halves on this base class. No routing, payload or parsing logic changes; the only difference is which exception message reaches the caller on the async path, and the re-raise preserves `doc` and `pos` and chains the original error as `__cause__` exactly as the sync halves already do.

The five new tests cover all four entry points plus the preserved position. Three of them fail on the parent commit — `ainvoke` and `astream` each assert the DeepSeek message and get `Expecting value`, and the third finds no chained `JSONDecodeError` cause — and pass with the change; the two sync ones pin the behaviour #29758 introduced. Applying the implementation alone leaves every existing test at its previous status. The stub has to fail both `create` and `with_raw_response.create` because the two paths differ: `_generate`/`_agenerate` always request through `with_raw_response.create`, while `_stream`/`_astream` call `create` directly in the default configuration.

## Release note

`ChatDeepSeek` now reports `DeepSeek API returned an invalid response. Please check the API status and try again.` from `ainvoke` and `astream` as well, instead of leaking the underlying `JSONDecodeError("Expecting value")`. Previously only the synchronous `invoke` and `stream` translated it.

---

*This contribution was prepared with AI assistance.*
