### PR TITLE
fix(openai): bump `max_completion_tokens` in cache breakpoint integration test

### DIFF
--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -1258,7 +1258,7 @@ def test_explicit_prompt_cache_breakpoint_invoke() -> None:
     """
     chat = ChatOpenAI(
         model="gpt-5.6-sol",
-        max_completion_tokens=10,
+        max_completion_tokens=16,
         prompt_cache_options={"mode": "explicit"},
     )
     # A prefix long enough to exceed OpenAI's minimum cacheable prompt length.


### PR DESCRIPTION
Release failed with
> FAILED tests/integration_tests/chat_models/test_base.py::test_explicit_prompt_cache_breakpoint_invoke - langchain_openai.chat_models.base.OpenAIInvalidRequestError: Error code: 400 - {'error': {'message': "Invalid 'max_output_tokens': integer below minimum value. Expected a value >= 16, but got 10 instead.", 'type': 'invalid_request_error', 'param': 'max_output_tokens', 'code': 'integer_below_min_value'}}

Now passes locally.