### PR TITLE
fix(perplexity): preserve cost and search usage metadata

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -96,6 +96,14 @@ def _create_usage_metadata(token_usage: dict) -> UsageMetadata:
     output_tokens = token_usage.get("completion_tokens", 0)
     total_tokens = token_usage.get("total_tokens", input_tokens + output_tokens)
 
+    input_token_details: InputTokenDetails = {}
+    if (num_search_queries := token_usage.get("num_search_queries")) is not None:
+        # Search requests are billed separately from tokens and must remain
+        # visible to downstream cost calculators.
+        input_token_details["num_search_queries"] = (  # type: ignore[typeddict-unknown-key]
+            num_search_queries
+        )
+
     # Build output_token_details for Perplexity-specific fields
     output_token_details: OutputTokenDetails = {}
     if (reasoning := token_usage.get("reasoning_tokens")) is not None:
@@ -103,12 +111,15 @@ def _create_usage_metadata(token_usage: dict) -> UsageMetadata:
     if (citation_tokens := token_usage.get("citation_tokens")) is not None:
         output_token_details["citation_tokens"] = citation_tokens  # type: ignore[typeddict-unknown-key]
 
-    return UsageMetadata(
+    usage = UsageMetadata(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=total_tokens,
         output_token_details=output_token_details,
     )
+    if input_token_details:
+        usage["input_token_details"] = input_token_details
+    return usage
 
 
 _RESPONSES_ONLY_ARGS = frozenset(
@@ -339,6 +350,12 @@ def _get_attr(obj: Any, name: str, default: Any = None) -> Any:
     return getattr(obj, name, default)
 
 
+def _serialize_cost(cost: Any) -> Any:
+    """Return a JSON-compatible cost payload when the SDK provides a model."""
+    model_dump = getattr(cost, "model_dump", None)
+    return model_dump() if callable(model_dump) else cost
+
+
 def _convert_responses_usage(usage: Any) -> UsageMetadata | None:
     """Build `UsageMetadata` from a Responses API usage payload.
 
@@ -369,6 +386,11 @@ def _convert_responses_usage(usage: Any) -> UsageMetadata | None:
         cache_creation = _get_attr(details, "cache_creation_input_tokens", None)
         if cache_creation is not None:
             input_token_details["cache_creation"] = cache_creation
+
+    if (num_search_queries := _get_attr(usage, "num_search_queries", None)) is not None:
+        input_token_details["num_search_queries"] = (  # type: ignore[typeddict-unknown-key]
+            num_search_queries
+        )
 
     return UsageMetadata(
         input_tokens=input_tokens,
@@ -461,6 +483,9 @@ def _convert_responses_to_chat_result(response: Any) -> ChatResult:
         if value is not None:
             response_metadata[key] = value
     _set_model_name_alias(response_metadata)
+    cost = _get_attr(_get_attr(response, "usage", None), "cost", None)
+    if cost is not None:
+        response_metadata["cost"] = _serialize_cost(cost)
 
     message = AIMessage(
         content=content,
@@ -557,6 +582,9 @@ def _convert_responses_stream_event_to_chunk(
                 value = _get_attr(response, key, None)
                 if value:
                     additional_kwargs[key] = value
+            cost = _get_attr(_get_attr(response, "usage", None), "cost", None)
+            if cost is not None:
+                response_metadata["cost"] = _serialize_cost(cost)
         return ChatGenerationChunk(
             message=AIMessageChunk(
                 content="",
@@ -1219,6 +1247,7 @@ class ChatPerplexity(BaseChatModel):
         added_model_name: bool = False
         added_search_queries: bool = False
         added_search_context_size: bool = False
+        added_cost: bool = False
         for chunk in stream_resp:
             if not isinstance(chunk, dict):
                 chunk = chunk.model_dump()
@@ -1239,7 +1268,9 @@ class ChatPerplexity(BaseChatModel):
                 generation_info["model_name"] = model_name
                 added_model_name = True
             if total_usage := chunk.get("usage"):
-                if num_search_queries := total_usage.get("num_search_queries"):
+                if (
+                    num_search_queries := total_usage.get("num_search_queries")
+                ) is not None:
                     if not added_search_queries:
                         generation_info["num_search_queries"] = num_search_queries
                         added_search_queries = True
@@ -1247,6 +1278,9 @@ class ChatPerplexity(BaseChatModel):
                     if search_context_size := total_usage.get("search_context_size"):
                         generation_info["search_context_size"] = search_context_size
                         added_search_context_size = True
+                if (cost := total_usage.get("cost")) is not None and not added_cost:
+                    generation_info["cost"] = _serialize_cost(cost)
+                    added_cost = True
 
             choices = chunk.get("choices") or []
             if len(choices) == 0:
@@ -1336,6 +1370,7 @@ class ChatPerplexity(BaseChatModel):
         added_model_name: bool = False
         added_search_queries: bool = False
         added_search_context_size: bool = False
+        added_cost: bool = False
         async for chunk in stream_resp:
             if not isinstance(chunk, dict):
                 chunk = chunk.model_dump()
@@ -1355,7 +1390,9 @@ class ChatPerplexity(BaseChatModel):
                 generation_info["model_name"] = model_name
                 added_model_name = True
             if total_usage := chunk.get("usage"):
-                if num_search_queries := total_usage.get("num_search_queries"):
+                if (
+                    num_search_queries := total_usage.get("num_search_queries")
+                ) is not None:
                     if not added_search_queries:
                         generation_info["num_search_queries"] = num_search_queries
                         added_search_queries = True
@@ -1363,6 +1400,9 @@ class ChatPerplexity(BaseChatModel):
                     if search_context_size := total_usage.get("search_context_size"):
                         generation_info["search_context_size"] = search_context_size
                         added_search_context_size = True
+                if (cost := total_usage.get("cost")) is not None and not added_cost:
+                    generation_info["cost"] = _serialize_cost(cost)
+                    added_cost = True
 
             choices = chunk.get("choices") or []
             if len(choices) == 0:
@@ -1462,10 +1502,12 @@ class ChatPerplexity(BaseChatModel):
         response_metadata: dict[str, Any] = {
             "model_name": getattr(response, "model", self.model)
         }
-        if num_search_queries := usage_dict.get("num_search_queries"):
+        if (num_search_queries := usage_dict.get("num_search_queries")) is not None:
             response_metadata["num_search_queries"] = num_search_queries
         if search_context_size := usage_dict.get("search_context_size"):
             response_metadata["search_context_size"] = search_context_size
+        if (cost := usage_dict.get("cost")) is not None:
+            response_metadata["cost"] = _serialize_cost(cost)
 
         message = AIMessage(
             content=response.choices[0].message.content,
@@ -1531,10 +1573,12 @@ class ChatPerplexity(BaseChatModel):
         response_metadata: dict[str, Any] = {
             "model_name": getattr(response, "model", self.model)
         }
-        if num_search_queries := usage_dict.get("num_search_queries"):
+        if (num_search_queries := usage_dict.get("num_search_queries")) is not None:
             response_metadata["num_search_queries"] = num_search_queries
         if search_context_size := usage_dict.get("search_context_size"):
             response_metadata["search_context_size"] = search_context_size
+        if (cost := usage_dict.get("cost")) is not None:
+            response_metadata["cost"] = _serialize_cost(cost)
 
         message = AIMessage(
             content=response.choices[0].message.content,

--- a/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
@@ -200,6 +200,10 @@ def _usage_bearing_chunks() -> list[dict[str, Any]]:
                 "total_tokens": 13,
                 "num_search_queries": 2,
                 "search_context_size": "low",
+                "cost": {
+                    "total_cost": 0.042,
+                    "search_queries_cost": 0.02,
+                },
             },
         },
     ]
@@ -219,6 +223,10 @@ def test_perplexity_stream_emits_single_valued_usage_metadata_once() -> None:
     assert full.response_metadata["search_context_size"] == "low"
     assert full.response_metadata["num_search_queries"] == 2
     assert full.response_metadata["model_name"] == "sonar"
+    assert full.response_metadata["cost"] == {
+        "total_cost": 0.042,
+        "search_queries_cost": 0.02,
+    }
 
 
 @pytest.mark.asyncio
@@ -243,6 +251,10 @@ async def test_perplexity_astream_emits_single_valued_usage_metadata_once() -> N
     assert full.response_metadata["search_context_size"] == "low"
     assert full.response_metadata["num_search_queries"] == 2
     assert full.response_metadata["model_name"] == "sonar"
+    assert full.response_metadata["cost"] == {
+        "total_cost": 0.042,
+        "search_queries_cost": 0.02,
+    }
 
 
 def test_create_usage_metadata_basic() -> None:
@@ -251,6 +263,7 @@ def test_create_usage_metadata_basic() -> None:
         "prompt_tokens": 10,
         "completion_tokens": 20,
         "total_tokens": 30,
+        "num_search_queries": 0,
         "reasoning_tokens": 0,
         "citation_tokens": 0,
     }
@@ -262,6 +275,17 @@ def test_create_usage_metadata_basic() -> None:
     assert usage_metadata["total_tokens"] == 30
     assert usage_metadata["output_token_details"]["reasoning"] == 0
     assert usage_metadata["output_token_details"]["citation_tokens"] == 0  # type: ignore[typeddict-item]
+    assert (
+        usage_metadata["input_token_details"]["num_search_queries"] == 0  # type: ignore[typeddict-item]
+    )
+
+
+def test_create_usage_metadata_omits_missing_search_queries() -> None:
+    usage_metadata = _create_usage_metadata(
+        {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}
+    )
+
+    assert "input_token_details" not in usage_metadata
 
 
 def test_perplexity_invoke_includes_num_search_queries(mocker: MockerFixture) -> None:
@@ -275,6 +299,7 @@ def test_perplexity_invoke_includes_num_search_queries(mocker: MockerFixture) ->
         "total_tokens": 30,
         "num_search_queries": 3,
         "search_context_size": "high",
+        "cost": {"total_cost": 0.123, "search_queries_cost": 0.09},
     }
 
     mock_response = MagicMock()
@@ -306,6 +331,14 @@ def test_perplexity_invoke_includes_num_search_queries(mocker: MockerFixture) ->
     assert result.response_metadata["num_search_queries"] == 3
     assert result.response_metadata["search_context_size"] == "high"
     assert result.response_metadata["model_name"] == "test-model"
+    assert result.response_metadata["cost"] == {
+        "total_cost": 0.123,
+        "search_queries_cost": 0.09,
+    }
+    assert result.usage_metadata is not None
+    assert (
+        result.usage_metadata["input_token_details"]["num_search_queries"] == 3  # type: ignore[typeddict-item]
+    )
     patcher.assert_called_once()
 
 

--- a/libs/partners/perplexity/tests/unit_tests/test_chat_models_responses.py
+++ b/libs/partners/perplexity/tests/unit_tests/test_chat_models_responses.py
@@ -135,6 +135,77 @@ def test_invoke_routes_to_responses_when_builtin_tool_in_payload() -> None:
     chat_create.assert_not_called()
 
 
+def test_invoke_responses_preserves_cost_metadata() -> None:
+    llm = ChatPerplexity(model="sonar-pro", api_key="test", use_responses_api=True)
+    llm.client = MagicMock()
+    cost = {"total_cost": 0.123, "search_queries_cost": 0.09}
+    usage = _make_response_obj(
+        input_tokens=11,
+        output_tokens=22,
+        total_tokens=33,
+        num_search_queries=3,
+        cost=cost,
+    )
+    response = _make_response_obj(
+        id="resp_cost",
+        model="sonar-pro",
+        status="completed",
+        object="response",
+        output_text="hello",
+        output=[],
+        usage=usage,
+        citations=None,
+        images=None,
+        related_questions=None,
+        search_results=None,
+    )
+    llm.client.responses.create.return_value = response
+
+    result = llm.invoke("Find recent news", tools=[{"type": "web_search"}])
+
+    assert result.response_metadata["cost"] == cost
+    assert result.usage_metadata is not None
+    assert (
+        result.usage_metadata["input_token_details"]["num_search_queries"] == 3  # type: ignore[typeddict-item]
+    )
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_responses_preserves_cost_metadata() -> None:
+    llm = ChatPerplexity(model="sonar-pro", api_key="test", use_responses_api=True)
+    cost = {"total_cost": 0.456, "search_queries_cost": 0.12}
+    usage = _make_response_obj(
+        input_tokens=5,
+        output_tokens=7,
+        total_tokens=12,
+        num_search_queries=0,
+        cost=cost,
+    )
+    response = _make_response_obj(
+        id="resp_async_cost",
+        model="sonar-pro",
+        status="completed",
+        object="response",
+        output_text="async hello",
+        output=[],
+        usage=usage,
+        citations=None,
+        images=None,
+        related_questions=None,
+        search_results=None,
+    )
+    llm.async_client = MagicMock()
+    llm.async_client.responses.create = AsyncMock(return_value=response)
+
+    result = await llm.ainvoke("Find recent news", tools=[{"type": "web_search"}])
+
+    assert result.response_metadata["cost"] == cost
+    assert result.usage_metadata is not None
+    assert (
+        result.usage_metadata["input_token_details"]["num_search_queries"] == 0  # type: ignore[typeddict-item]
+    )
+
+
 def test_invoke_routes_to_responses_when_previous_response_id_bound() -> None:
     llm = ChatPerplexity(model="sonar-pro", api_key="test")
     llm.client = MagicMock()
@@ -461,7 +532,12 @@ def test_stream_yields_text_chunks_and_final_usage() -> None:
     llm = ChatPerplexity(model="sonar-pro", api_key="test", use_responses_api=True)
     llm.client = MagicMock()
 
-    usage = _make_response_obj(input_tokens=2, output_tokens=6, total_tokens=8)
+    usage = _make_response_obj(
+        input_tokens=2,
+        output_tokens=6,
+        total_tokens=8,
+        cost={"total_cost": 0.02, "search_queries_cost": 0.01},
+    )
     completed_response = _make_response_obj(
         id="resp_stream",
         model="sonar-pro",
@@ -492,13 +568,24 @@ def test_stream_yields_text_chunks_and_final_usage() -> None:
     assert final_usage is not None
     assert final_usage["input_tokens"] == 2
     assert final_usage["output_tokens"] == 6
+    cost_chunks = [c for c in chunks if "cost" in c.response_metadata]
+    assert cost_chunks
+    assert cost_chunks[-1].response_metadata["cost"] == {
+        "total_cost": 0.02,
+        "search_queries_cost": 0.01,
+    }
 
 
 @pytest.mark.asyncio
 async def test_astream_yields_text_chunks_and_final_usage() -> None:
     llm = ChatPerplexity(model="sonar-pro", api_key="test", use_responses_api=True)
 
-    usage = _make_response_obj(input_tokens=3, output_tokens=9, total_tokens=12)
+    usage = _make_response_obj(
+        input_tokens=3,
+        output_tokens=9,
+        total_tokens=12,
+        cost={"total_cost": 0.03, "search_queries_cost": 0.015},
+    )
     completed_response = _make_response_obj(
         id="resp_async",
         model="sonar-pro",
@@ -545,6 +632,12 @@ async def test_astream_yields_text_chunks_and_final_usage() -> None:
     assert final_usage is not None
     assert final_usage["input_tokens"] == 3
     assert final_usage["output_tokens"] == 9
+    cost_chunks = [c for c in collected if "cost" in c.response_metadata]
+    assert cost_chunks
+    assert cost_chunks[-1].response_metadata["cost"] == {
+        "total_cost": 0.03,
+        "search_queries_cost": 0.015,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -863,6 +956,18 @@ def test_convert_responses_usage_maps_cache_token_details() -> None:
     result = _convert_responses_usage(usage)
     assert result is not None
     assert result["input_token_details"] == {"cache_read": 800, "cache_creation": 150}
+
+
+def test_convert_responses_usage_maps_search_queries() -> None:
+    usage = _make_response_obj(
+        input_tokens=1000,
+        output_tokens=50,
+        total_tokens=1050,
+        num_search_queries=3,
+    )
+    result = _convert_responses_usage(usage)
+    assert result is not None
+    assert result["input_token_details"] == {"num_search_queries": 3}
 
 
 def test_convert_responses_usage_maps_cache_token_details_from_mapping() -> None:


### PR DESCRIPTION
Fixes #31647

`ChatPerplexity` now exposes Perplexity's `num_search_queries` in `usage_metadata` and preserves the SDK-provided cost breakdown in response metadata across synchronous, asynchronous, Responses API, and streaming paths. Missing cost data remains optional, including proxied reasoning-mode responses.

## Release note

Perplexity cost and search-query usage metadata are now available to downstream cost tracking integrations.

## Verification

- Perplexity unit tests: 100 passed
- `ruff check` and `ruff format --check` passed
- Python compilation check passed

This change was developed with assistance from AI tools and reviewed locally.