### PR TITLE
fix(core): append string content when merging into an empty list

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -400,8 +400,10 @@ def merge_content(
         # If second content is an empty string, treat as a no-op
         elif content == "":
             pass
-        # Otherwise, add the second content as a new element of the list
-        elif merged:
+        # Otherwise, add the second content as a new element of the list.
+        # This also covers merged == [] (falsy), where the string must
+        # still be appended rather than silently dropped.
+        else:
             merged.append(content)
     return merged
 

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -1099,6 +1099,16 @@ def test_tool_message_str() -> None:
             [[{"index": 0, "text": "bar"}]],
             [{"text": "foo"}, {"index": 0, "text": "bar"}],
         ),
+        # Regression cases for a non-empty string merged into an empty list:
+        # `elif merged:` used to be falsy for `[]`, silently dropping the
+        # string instead of appending it.
+        ([], ["bar"], ["bar"]),
+        ([], ["bar", "baz"], ["barbaz"]),
+        (
+            [{"text": "foo"}],
+            ["bar"],
+            [{"text": "foo"}, "bar"],
+        ),
     ],
 )
 def test_merge_content(


### PR DESCRIPTION
## What changed

`merge_content` in `libs/core/langchain_core/messages/base.py` used `elif merged:` as its
final fallback branch. `[]` is falsy, so when the accumulated content was an empty list and
the next chunk was a non-empty string, the branch was skipped and the string was silently
dropped:

```python
>>> from langchain_core.messages import AIMessageChunk
>>> (AIMessageChunk(content=[]) + AIMessageChunk(content="bar")).content
[]          # expected ["bar"]
```

Only a non-empty string can reach that branch at all (list content is handled earlier by
the `isinstance(content, list)` branch, and an empty string is a no-op via
`elif content == "":`), so it should always be appended regardless of whether `merged` is
currently empty. Replaced the guard with a plain `else`.

## Why

This is silent data loss on the message-chunk `+` path (and anything built on it, such as
`merge_message_runs`), and it triggers whenever a chunk's accumulated content starts as an
empty list, which happens when streaming from providers that use list content blocks.

I filed this as #40224. That issue was auto-closed shortly after filing by
`langchain-oss-automated-triage[bot]` because it has no "issue type" set (a requirement for
issues submitted via the API/CLI rather than the web form) - it was not closed as invalid,
duplicate, or already-fixed. I don't have write access to the repo to set an issue type or
reopen it myself, so I'm opening this PR against the closed issue number; a maintainer can
reopen #40224 or link it however is preferred.

A fix for the same root cause was previously submitted as #38798 (also closed, unmerged,
for lacking a linked issue - a bit of a catch-22 with the bot above). I did not reuse that
branch; this is written independently but lands on the same one-line fix, which is the
natural fix given the bug.

## How to test

Added 3 cases to the existing `test_merge_content` parametrize table in
`libs/core/tests/unit_tests/test_messages.py`:

- `([], ["bar"], ["bar"])`
- `([], ["bar", "baz"], ["barbaz"])`
- `([{"text": "foo"}], ["bar"], [{"text": "foo"}, "bar"])`

The first two fail on current `master` (`assert [] == ["bar"]` / `["barbaz"]`); I verified
this by reverting just the source change locally and re-running the suite. All three pass
after the fix. Full `libs/core/tests/unit_tests/test_messages.py` (59 tests) passes, and
`ruff check` / `ruff format --check` are clean on both changed files.

Fixes #40224
