### PR TITLE
fix(text-splitters): apply max_length to SpacyTextSplitter sentencizer pipeline

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/spacy.py
+++ b/libs/text-splitters/langchain_text_splitters/spacy.py
@@ -65,5 +65,5 @@ def _make_spacy_pipeline_for_splitting(
         sentencizer.add_pipe("sentencizer")
     else:
         sentencizer = cast("Language", spacy.load(pipeline, exclude=["ner", "tagger"]))
-        sentencizer.max_length = max_length
+    sentencizer.max_length = max_length
     return sentencizer


### PR DESCRIPTION
Fixes #40279. This correctly unindents the `max_length` assignment so that it is applied when `pipeline="sentencizer"` as well.