### PR TITLE
fix(core): match the JSON code fence tag case-insensitively in `parse_json_markdown`

### DIFF
--- a/libs/core/langchain_core/utils/json.py
+++ b/libs/core/langchain_core/utils/json.py
@@ -136,7 +136,9 @@ def parse_partial_json(s: str, *, strict: bool = False) -> Any:
     return json.loads(s, strict=strict)
 
 
-_json_markdown_re = re.compile(r"```(json)?(.*)", re.DOTALL)
+# Fenced-block language tags are case-insensitive in practice: models emit
+# "```JSON" or "```Json" as readily as "```json".
+_json_markdown_re = re.compile(r"```(json)?(.*)", re.DOTALL | re.IGNORECASE)
 
 
 def parse_json_markdown(

--- a/libs/core/tests/unit_tests/output_parsers/test_json.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_json.py
@@ -201,6 +201,13 @@ def test_parse_json_with_code_blocks() -> None:
     assert parsed == {"foo": "```bar```"}
 
 
+@pytest.mark.parametrize("tag", ["JSON", "Json", "jSoN"])
+def test_parse_json_with_uppercase_code_block_tag(tag: str) -> None:
+    """The language tag of the fence is matched case-insensitively."""
+    parsed = parse_json_markdown(f'```{tag}\n{{"foo": "bar"}}\n```')
+    assert parsed == {"foo": "bar"}
+
+
 def test_parse_json_with_part_code_blocks() -> None:
     parsed = parse_json_markdown(JSON_WITH_PART_MARKDOWN_CODE_BLOCK)
     assert parsed == {"valid_json": "hey ```print(hello world!)``` hey"}


### PR DESCRIPTION
Fixes #40297

---

Users of `JsonOutputParser` (and `parse_json_markdown` directly) get `OUTPUT_PARSING_FAILURE` when a model wraps its answer in a fence tagged `JSON` or `Json`, even though the same payload tagged `json` parses fine. The fence-tag regex now matches case-insensitively, so the tag spelling no longer decides whether the JSON is found.

## Release note

`parse_json_markdown` and `JsonOutputParser` now accept fenced code blocks whose language tag is spelled with any casing (`json`, `JSON`, `Json`).

Verified with a parametrized unit test that fails on `master` for all three spellings; `ruff format`, `ruff check` and `mypy` on the changed files and the `output_parsers/test_json.py` suite pass. Written with the help of an AI coding agent (Claude Code); reviewed by a human before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019m9gE9ZQnx3UeRYXggw7TN
