### PR TITLE
fix(text-splitters): drop the closing `#` sequence from `MarkdownHeaderTextSplitter` header metadata

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/markdown.py
+++ b/libs/text-splitters/langchain_text_splitters/markdown.py
@@ -20,6 +20,11 @@ class MarkdownTextSplitter(RecursiveCharacterTextSplitter):
         super().__init__(separators=separators, **kwargs)
 
 
+# A run of `#` at the end of an ATX heading is a closing sequence when it is
+# preceded by whitespace (or is the whole text); `# C#` keeps its `#`.
+_CLOSING_HASHES_RE = re.compile(r"(?:^|\s+)#+\s*$")
+
+
 class MarkdownHeaderTextSplitter:
     """Splitting markdown files based on specified headers."""
 
@@ -221,8 +226,12 @@ class MarkdownHeaderTextSplitter:
                             header_text = stripped_line[len(sep) : -len(sep)].strip()
                         else:
                             # For standard headers like # Header, extract text
-                            # after the separator
-                            header_text = stripped_line[len(sep) :].strip()
+                            # after the separator. An optional closing sequence
+                            # of `#` (e.g. `# Header ##`) is not part of the
+                            # heading text, so drop it like CommonMark does.
+                            header_text = _CLOSING_HASHES_RE.sub(
+                                "", stripped_line[len(sep) :].strip()
+                            ).rstrip()
 
                         header: HeaderType = {
                             "level": current_header_level,

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -4432,3 +4432,28 @@ def test_character_text_splitter_chunk_size_effect(
         keep_separator=False,
     )
     assert splitter.split_text(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("line", "expected_header"),
+    [
+        ("# Title ##", "Title"),
+        ("# Title #", "Title"),
+        ("# Title   ###   ", "Title"),
+        ("# C#", "C#"),
+        ("# Title#", "Title#"),
+        ("# ##", ""),
+    ],
+)
+def test_md_header_text_splitter_strips_closing_hashes(
+    line: str, expected_header: str
+) -> None:
+    """A closing sequence of `#` is not part of the heading text (CommonMark)."""
+    markdown_document = f"{line}\nBody text."
+    headers_to_split_on = [("#", "Header 1")]
+    markdown_splitter = MarkdownHeaderTextSplitter(headers_to_split_on)
+    output = markdown_splitter.split_text(markdown_document)
+
+    assert output == [
+        Document(page_content="Body text.", metadata={"Header 1": expected_header})
+    ]

--- a/libs/text-splitters/uv.lock
+++ b/libs/text-splitters/uv.lock
@@ -1279,7 +1279,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.6.1"
+version = "1.6.2"
 source = { editable = "../core" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Fixes #40298

---

Anyone splitting Markdown written in the `# Title ##` style ends up with header metadata such as `Title ##` on every chunk, which breaks filtering and grouping by header. `MarkdownHeaderTextSplitter` now drops the optional closing `#` sequence from the extracted header text, following CommonMark: a run of `#` is only treated as a closing sequence when it is preceded by whitespace (or is the whole text), so `# C#` still yields `C#`.

## Release note

`MarkdownHeaderTextSplitter` no longer includes an ATX heading's closing `#` sequence (e.g. `# Title ##`) in the header metadata.

Verified with parametrized unit tests (`# Title ##`, `# Title   ###   `, `# C#`, `# Title#`, `# ##`) that fail on `master`; `ruff format`, `ruff check`, `ty check` and the full `test_text_splitters.py` suite pass. Written with the help of an AI coding agent (Claude Code); reviewed by a human before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019m9gE9ZQnx3UeRYXggw7TN
