### PR TITLE
fix(text-splitters): apply max_length to sentencizer pipeline

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/spacy.py
+++ b/libs/text-splitters/langchain_text_splitters/spacy.py
@@ -65,5 +65,5 @@ def _make_spacy_pipeline_for_splitting(
         sentencizer.add_pipe("sentencizer")
     else:
         sentencizer = cast("Language", spacy.load(pipeline, exclude=["ner", "tagger"]))
-        sentencizer.max_length = max_length
+    sentencizer.max_length = max_length
     return sentencizer

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -7,7 +7,9 @@ import random
 import re
 import string
 import textwrap
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
+from unittest.mock import Mock
 
 import pytest
 from langchain_core._api import suppress_langchain_beta_warning
@@ -171,6 +173,71 @@ def test_lazy_getattr_raises_for_unknown() -> None:
 
     with pytest.raises(AttributeError, match="no_such_thing"):
         _ = lts.no_such_thing  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize(
+    ("pipeline", "expected_max_length"),
+    [
+        ("sentencizer", 2_000_000),
+        ("en_core_web_sm", 2_000_000),
+    ],
+)
+def test_spacy_splitter_honors_custom_max_length(
+    pipeline: str,
+    expected_max_length: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`SpacyTextSplitter` applies `max_length` to every pipeline variant.
+
+    Regression test for the sentencizer fast path, where `max_length` used to be
+    ignored because the assignment only ran in the model-backed branch.
+    """
+    from langchain_text_splitters.spacy import (  # noqa: PLC0415
+        _make_spacy_pipeline_for_splitting,
+    )
+
+    nlp = Mock()
+    loaded = Mock()
+    nlp.max_length = 1_000_000
+    loaded.max_length = 1_000_000
+
+    def _fake_import(module: str) -> Any:  # noqa: ANN401
+        if module == "spacy":
+            spacy = SimpleNamespace()
+            spacy.load = Mock(return_value=loaded)
+            return spacy
+        if module == "spacy.lang.en":
+            return SimpleNamespace(English=lambda: nlp)
+        raise AssertionError(module)
+
+    monkeypatch.setattr("langchain_text_splitters.spacy.import_module", _fake_import)
+
+    tokenizer = _make_spacy_pipeline_for_splitting(
+        pipeline, max_length=expected_max_length
+    )
+    assert tokenizer.max_length == expected_max_length
+
+
+def test_spacy_splitter_default_max_length(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default `max_length` of 1_000_000 is preserved by default."""
+    from langchain_text_splitters.spacy import (  # noqa: PLC0415
+        _make_spacy_pipeline_for_splitting,
+    )
+
+    nlp = Mock()
+    nlp.max_length = 1_000_000
+
+    def _fake_import(module: str) -> Any:  # noqa: ANN401
+        if module == "spacy":
+            return SimpleNamespace()
+        if module == "spacy.lang.en":
+            return SimpleNamespace(English=lambda: nlp)
+        raise AssertionError(module)
+
+    monkeypatch.setattr("langchain_text_splitters.spacy.import_module", _fake_import)
+
+    tokenizer = _make_spacy_pipeline_for_splitting("sentencizer")
+    assert tokenizer.max_length == 1_000_000
 
 
 def test_lightweight_splitters_remain_eagerly_accessible() -> None:


### PR DESCRIPTION
Closes #40279

---

`SpacyTextSplitter` accepted a `max_length` argument but ignored it when `pipeline="sentencizer"`, silently keeping spaCy's default limit of 1,000,000 characters. Users raising the limit to process long documents still got the old default; lower custom limits were ignored too. The bug was in `_make_spacy_pipeline_for_splitting`, where the `sentencizer.max_length = max_length` assignment ran only in the model-backed `else` branch.

The assignment now runs after either pipeline variant is constructed, so the sentencizer fast path honors `max_length` exactly like the model-backed path. No new parameters or dependencies were added.

## Release note

- `SpacyTextSplitter(pipeline="sentencizer", max_length=...)` now applies the configured `max_length` instead of silently keeping spaCy's default limit.

## Testing

Added regression tests covering a custom `max_length` for both the sentencizer and model-backed pipelines, plus the preserved default. The tests use mocks, so the unit-test environment does not require a spaCy install. Verified a mutation of the fix (assignment moved back inside the `else` branch) fails the new sentencizer test, confirming the test genuinely catches the regression. The full `text-splitters` unit test file passes locally (152 passed, 4 skipped).

---

This contribution was prepared with AI assistance and reviewed by a human.