### PR TITLE
fix(langchain): clarify `runtime.tools` test contract

### DIFF
--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
@@ -1124,6 +1124,8 @@ def test_when_predicate_receives_correct_args() -> None:
     assert req.state is state
     assert isinstance(req.runtime, ToolRuntime)
     assert req.runtime.tool_call_id == "tc-1"
+    # Empty reflects the current implementation, not a stable contract; predicates
+    # in this path must not depend on `runtime.tools`.
     assert req.runtime.tools == []
     assert req.runtime.state is state
     assert req.runtime.context is runtime.context


### PR DESCRIPTION
Fixes #40139.

Follow-up to #40140.

Clarify next to the existing `runtime.tools == []` assertion that the empty list reflects only the current implementation and should not be treated as a stable predicate contract. This changes no runtime behavior or test semantics.

Verified with the focused `test_when_predicate_receives_correct_args` unit test (1 passed).

> This PR was developed with AI-agent assistance.