### PR TITLE
fix(core): keep indexing timestamps monotonic

### DIFF
--- a/libs/core/langchain_core/indexing/base.py
+++ b/libs/core/langchain_core/indexing/base.py
@@ -251,6 +251,7 @@ class InMemoryRecordManager(RecordManager):
         # of {'group_id': group_id, 'updated_at': timestamp}
         self.records: dict[str, _Record] = {}
         self.namespace = namespace
+        self._last_time: float | None = None
 
     def create_schema(self) -> None:
         """In-memory schema creation is simply ensuring the structure is initialized."""
@@ -260,7 +261,11 @@ class InMemoryRecordManager(RecordManager):
 
     @override
     def get_time(self) -> float:
-        return time.time()
+        current_time = time.time()
+        if self._last_time is not None:
+            current_time = max(current_time, self._last_time + 2e-6)
+        self._last_time = current_time
+        return current_time
 
     @override
     async def aget_time(self) -> float:
@@ -296,12 +301,16 @@ class InMemoryRecordManager(RecordManager):
         if group_ids and len(keys) != len(group_ids):
             msg = "Length of keys must match length of group_ids"
             raise ValueError(msg)
+        current_time = self.get_time()
         for index, key in enumerate(keys):
             group_id = group_ids[index] if group_ids else None
-            if time_at_least and time_at_least > self.get_time():
+            if time_at_least is not None and time_at_least > current_time:
                 msg = "time_at_least must be in the past"
                 raise ValueError(msg)
-            self.records[key] = {"group_id": group_id, "updated_at": self.get_time()}
+            updated_at = current_time
+            if time_at_least is not None:
+                updated_at = max(current_time, time_at_least) + 1e-6
+            self.records[key] = {"group_id": group_id, "updated_at": updated_at}
 
     async def aupdate(
         self,

--- a/libs/langchain/langchain_classic/indexes/_sql_record_manager.py
+++ b/libs/langchain/langchain_classic/indexes/_sql_record_manager.py
@@ -144,6 +144,7 @@ class SQLRecordManager(RecordManager):
         self.engine = _engine
         self.dialect = _engine.dialect.name
         self.session_factory = _session_factory
+        self._last_time: float | None = None
 
     def create_schema(self) -> None:
         """Create the database schema."""
@@ -215,6 +216,9 @@ class SQLRecordManager(RecordManager):
             if not isinstance(dt, float):
                 msg = f"Unexpected type for datetime: {type(dt)}"
                 raise AssertionError(msg)  # noqa: TRY004
+            if self._last_time is not None:
+                dt = max(dt, self._last_time + 2e-6)
+            self._last_time = dt
             return dt
 
     async def aget_time(self) -> float:
@@ -248,6 +252,9 @@ class SQLRecordManager(RecordManager):
             if not isinstance(dt, float):
                 msg = f"Unexpected type for datetime: {type(dt)}"
                 raise AssertionError(msg)  # noqa: TRY004
+            if self._last_time is not None:
+                dt = max(dt, self._last_time + 2e-6)
+            self._last_time = dt
             return dt
 
     def update(
@@ -277,10 +284,13 @@ class SQLRecordManager(RecordManager):
         # data loss due to incorrectly deleting records.
         update_time = self.get_time()
 
-        if time_at_least and update_time < time_at_least:
+        if time_at_least is not None and update_time < time_at_least:
             # Safeguard against time sync issues
             msg = f"Time sync issue: {update_time} < {time_at_least}"
             raise AssertionError(msg)
+
+        if time_at_least is not None:
+            update_time = max(update_time, time_at_least) + 1e-6
 
         records_to_upsert = [
             {
@@ -359,10 +369,13 @@ class SQLRecordManager(RecordManager):
         # data loss due to incorrectly deleting records.
         update_time = await self.aget_time()
 
-        if time_at_least and update_time < time_at_least:
+        if time_at_least is not None and update_time < time_at_least:
             # Safeguard against time sync issues
             msg = f"Time sync issue: {update_time} < {time_at_least}"
             raise AssertionError(msg)
+
+        if time_at_least is not None:
+            update_time = max(update_time, time_at_least) + 1e-6
 
         records_to_upsert = [
             {


### PR DESCRIPTION
Fixes #

This keeps record timestamps strictly monotonic during indexing so stale-record cleanup does not remove records that were freshly updated in the same run. The fix preserves the same boundary behavior in both the in-memory and SQL-backed record managers so cleanup stays consistent across implementations.

## Release note

Fix a bug in record indexing cleanup where newly refreshed records could be treated as stale when their timestamps landed on the same cleanup boundary. Cleanup now uses strictly monotonic timestamps so same-run updates are preserved while older stale records are still removed.

## How did you verify your code works?

- `uv run --group test pytest tests/unit_tests/indexing/test_indexing.py`

## Social handles (optional)

Twitter: @
LinkedIn: https://linkedin.com/in/