### PR TITLE
fix(core): preserve Anthropic non-standard block input

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/anthropic.py
+++ b/libs/core/langchain_core/messages/block_translators/anthropic.py
@@ -486,7 +486,7 @@ def _convert_to_v1_from_anthropic(message: AIMessage) -> list[types.ContentBlock
             else:
                 new_block: types.NonStandardContentBlock = {
                     "type": "non_standard",
-                    "value": block,
+                    "value": block.copy(),
                 }
                 if "index" in new_block["value"]:
                     new_block["index"] = new_block["value"].pop("index")

--- a/libs/core/tests/unit_tests/messages/block_translators/test_anthropic.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_anthropic.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Any
 
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
@@ -572,3 +573,23 @@ def test_convert_to_v1_from_anthropic_malformed_citations() -> None:
             ],
         },
     ]
+
+
+def test_non_standard_block_conversion_does_not_mutate_content() -> None:
+    """Converting an unknown block must preserve the source message."""
+    message = AIMessage(
+        [{"type": "future_block", "index": 3, "value": "test"}],
+        response_metadata={"model_provider": "anthropic"},
+    )
+    original_content = deepcopy(message.content)
+
+    expected = [
+        {
+            "type": "non_standard",
+            "value": {"type": "future_block", "value": "test"},
+            "index": 3,
+        }
+    ]
+    assert message.content_blocks == expected
+    assert message.content == original_content
+    assert message.content_blocks == expected


### PR DESCRIPTION
Anthropic content-block translation removed `index` from the original message dictionary while constructing a non-standard block. Reading `content_blocks` therefore mutated `AIMessage.content`, and later reads observed different source data. The translator now copies an unknown provider block before moving its index, making conversion repeatable while preserving the message.

## Release note

Anthropic non-standard content block conversion no longer mutates the original message content.

This contribution was prepared with assistance from an AI coding agent and was reviewed and tested against the current source tree.
