### PR TITLE
fix(deepseek): preserve reasoning content in request payloads

### DIFF
--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -355,7 +355,20 @@ class ChatDeepSeek(BaseChatOpenAI):
         **kwargs: Any,
     ) -> dict:
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
-        for message in payload["messages"]:
+        input_messages = self._convert_input(input_).to_messages()
+        for input_message, message in zip(
+            input_messages, payload["messages"], strict=True
+        ):
+            if (
+                isinstance(input_message, AIMessage)
+                and (
+                    reasoning_content := input_message.additional_kwargs.get(
+                        "reasoning_content"
+                    )
+                )
+                is not None
+            ):
+                message["reasoning_content"] = reasoning_content
             if message["role"] == "tool" and isinstance(message["content"], list):
                 message["content"] = json.dumps(message["content"])
             elif message["role"] == "assistant" and isinstance(

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -259,6 +259,20 @@ class TestChatDeepSeekCustomUnit:
         payload = chat_model._get_request_payload([tool_message])
         assert payload["messages"][0]["content"] == "test string"
 
+    def test_get_request_payload_preserves_reasoning_content(self) -> None:
+        """Reasoning content should survive an assistant-message round trip."""
+        chat_model = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("api_key"))
+        message = AIMessage(
+            content="",
+            additional_kwargs={"reasoning_content": "analysis from the model"},
+        )
+
+        payload = chat_model._get_request_payload([message])
+
+        assert payload["messages"][0]["reasoning_content"] == (
+            "analysis from the model"
+        )
+
 
 class SampleTool(PydanticBaseModel):
     """Sample tool schema for testing."""


### PR DESCRIPTION
`ChatDeepSeek` stores provider reasoning output in `AIMessage.additional_kwargs`, but the inherited OpenAI serializer omits `reasoning_content` when that message is sent back to the model. `_get_request_payload` now restores the field for assistant messages, preserving DeepSeek's reasoning-message contract across tool-call turns.

The current DeepSeek service accepted both the incomplete and corrected payloads during live verification, so this change does not claim that a missing field currently produces an HTTP 400 response.

## Release note

`ChatDeepSeek` now preserves `reasoning_content` when assistant messages are serialized into follow-up requests.

This contribution was prepared with assistance from an AI coding agent and was reviewed and tested against the current source tree.
