### PR TITLE
fix(langchain-classic): preserve chain input mappings

### DIFF
--- a/libs/langchain/langchain_classic/chains/mapreduce.py
+++ b/libs/langchain/langchain_classic/chains/mapreduce.py
@@ -101,6 +101,7 @@ class MapReduceChain(Chain):
         run_manager: CallbackManagerForChainRun | None = None,
     ) -> dict[str, str]:
         _run_manager = run_manager or CallbackManagerForChainRun.get_noop_manager()
+        inputs = inputs.copy()
         # Split the larger text into smaller chunks.
         doc_text = inputs.pop(self.input_key)
         texts = self.text_splitter.split_text(doc_text)

--- a/libs/langchain/langchain_classic/chains/openai_functions/openapi.py
+++ b/libs/langchain/langchain_classic/chains/openai_functions/openapi.py
@@ -243,8 +243,9 @@ class SimpleRequestChain(Chain):
     ) -> dict[str, Any]:
         """Run the logic of this chain and return the output."""
         _run_manager = run_manager or CallbackManagerForChainRun.get_noop_manager()
-        name = inputs[self.input_key].pop("name")
-        args = inputs[self.input_key].pop("arguments")
+        function_call = inputs[self.input_key].copy()
+        name = function_call.pop("name")
+        args = function_call.pop("arguments")
         _pretty_name = get_colored_text(name, "green")
         _pretty_args = get_colored_text(json.dumps(args, indent=2), "green")
         _text = f"Calling endpoint {_pretty_name} with arguments:\n" + _pretty_args

--- a/libs/langchain/langchain_classic/chains/qa_with_sources/base.py
+++ b/libs/langchain/langchain_classic/chains/qa_with_sources/base.py
@@ -242,7 +242,7 @@ class QAWithSourcesChain(BaseQAWithSourcesChain):
         run_manager: CallbackManagerForChainRun,
     ) -> list[Document]:
         """Get docs to run questioning over."""
-        return inputs.pop(self.input_docs_key)
+        return inputs[self.input_docs_key]
 
     @override
     async def _aget_docs(
@@ -252,7 +252,7 @@ class QAWithSourcesChain(BaseQAWithSourcesChain):
         run_manager: AsyncCallbackManagerForChainRun,
     ) -> list[Document]:
         """Get docs to run questioning over."""
-        return inputs.pop(self.input_docs_key)
+        return inputs[self.input_docs_key]
 
     @property
     def _chain_type(self) -> str:

--- a/libs/langchain/tests/unit_tests/chains/test_input_immutability.py
+++ b/libs/langchain/tests/unit_tests/chains/test_input_immutability.py
@@ -1,0 +1,85 @@
+"""Regression tests for chains that destructure caller-owned input mappings."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+from typing import Any
+
+from langchain_core.documents import Document
+from requests import Response
+
+from langchain_classic.chains.mapreduce import MapReduceChain
+from langchain_classic.chains.openai_functions.openapi import SimpleRequestChain
+from langchain_classic.chains.qa_with_sources.base import QAWithSourcesChain
+
+
+class _TextSplitter:
+    def split_text(self, text: str) -> list[str]:
+        return [text]
+
+
+class _CombineDocumentsChain:
+    input_key = "input_documents"
+
+    def run(self, inputs: dict[str, Any] | None = None, **_kwargs: Any) -> str:
+        return "combined" if inputs is not None else "answer\nSOURCES: source"
+
+    async def arun(self, **_kwargs: Any) -> str:
+        return "answer\nSOURCES: source"
+
+
+def test_map_reduce_call_does_not_mutate_inputs() -> None:
+    chain = SimpleNamespace(
+        input_key="input_text",
+        output_key="output_text",
+        text_splitter=_TextSplitter(),
+        combine_documents_chain=_CombineDocumentsChain(),
+    )
+    inputs = {"input_text": "hello", "metadata": "kept"}
+    original = deepcopy(inputs)
+
+    result = MapReduceChain._call(chain, inputs)
+
+    assert result == {"output_text": "combined"}
+    assert inputs == original
+
+
+def test_qa_with_sources_call_does_not_mutate_inputs() -> None:
+    chain = SimpleNamespace(input_docs_key="docs")
+    inputs = {"question": "question", "docs": [Document(page_content="context")]}
+    original = deepcopy(inputs)
+
+    docs = QAWithSourcesChain._get_docs(chain, inputs, run_manager=None)
+
+    assert docs == inputs["docs"]
+    assert inputs == original
+
+
+async def test_qa_with_sources_acall_does_not_mutate_inputs() -> None:
+    chain = SimpleNamespace(input_docs_key="docs")
+    inputs = {"question": "question", "docs": [Document(page_content="context")]}
+    original = deepcopy(inputs)
+
+    docs = await QAWithSourcesChain._aget_docs(chain, inputs, run_manager=None)
+
+    assert docs == inputs["docs"]
+    assert inputs == original
+
+
+def test_openapi_request_call_does_not_mutate_nested_input() -> None:
+    response = Response()
+    response.status_code = 200
+    response._content = b'{"ok": true}'
+    chain = SimpleRequestChain(request_method=lambda _name, _args: response)
+    inputs = {
+        "function": {
+            "name": "get_item",
+            "arguments": {"params": {"id": "1"}},
+        }
+    }
+    original = deepcopy(inputs)
+
+    chain._call(inputs)
+
+    assert inputs == original


### PR DESCRIPTION
Several classic chains destructured dictionaries with `pop`, including a nested OpenAPI function-call dictionary owned by the caller. Invoking these chains could therefore remove `input_text`, `docs`, `name`, or `arguments` from objects that application code reused after the call. `MapReduceChain` now works from a shallow top-level copy, `QAWithSourcesChain` reads documents without removing them, and `SimpleRequestChain` copies its nested function call before destructuring it.

The regression tests cover synchronous and asynchronous QA access as well as the map-reduce and OpenAPI cases.

## Release note

Classic map-reduce, QA-with-sources, and OpenAPI request chains no longer remove fields from caller-provided input dictionaries.

This contribution was prepared with assistance from an AI coding agent and was reviewed and tested against the current source tree.
