### PR TITLE
fix(core): preserve empty Google GenAI image URLs

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/google_genai.py
+++ b/libs/core/langchain_core/messages/block_translators/google_genai.py
@@ -445,10 +445,7 @@ def _convert_to_v1_from_genai(message: AIMessage) -> list[types.ContentBlock]:
                                 }
                             )
                 else:
-                    # This likely won't be reached according to previous implementations
                     converted_blocks.append({"type": "non_standard", "value": item})
-                    msg = "Image URL not a data URI; appending as non-standard block."
-                    raise ValueError(msg)
             elif item_type == "function_call":
                 # Handle Google GenAI function calls
                 function_call_block: types.ToolCall = {

--- a/libs/core/tests/unit_tests/messages/block_translators/test_google_genai.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_google_genai.py
@@ -360,3 +360,14 @@ def test_grounding_citations_do_not_mutate_content() -> None:
 
     assert message.content == original_content
     assert "annotations" in blocks[0]
+
+
+def test_empty_image_url_is_preserved_as_non_standard() -> None:
+    """An empty image URL should remain available to downstream consumers."""
+    content = [{"type": "image_url", "image_url": {"url": ""}}]
+    message = AIMessage(
+        content=content,
+        response_metadata={"model_provider": "google_genai"},
+    )
+
+    assert message.content_blocks == [{"type": "non_standard", "value": content[0]}]


### PR DESCRIPTION
The Google GenAI block translator appended an empty image URL as a non-standard block and then immediately raised `ValueError`, making the fallback unreachable to callers. Empty URLs are now retained as non-standard content, consistent with other provider-specific blocks that cannot be normalized.

## Release note

Google GenAI message conversion now retains empty image URLs as non-standard content instead of raising after conversion.

This contribution was prepared with assistance from an AI coding agent and was reviewed and tested against the current source tree.
