### PR TITLE
fix(openai): use unique OAuth token temporary files

### DIFF
--- a/libs/partners/openai/langchain_openai/chatgpt_oauth.py
+++ b/libs/partners/openai/langchain_openai/chatgpt_oauth.py
@@ -36,6 +36,7 @@ import json
 import logging
 import os
 import secrets
+import tempfile
 import threading
 import time
 import urllib.parse
@@ -300,18 +301,22 @@ def _atomic_write_private_json(path: Path, data: dict[str, Any]) -> None:
     parent = path.parent
     parent.mkdir(parents=True, exist_ok=True)
     _chmod_warn(parent, 0o700)
-    tmp = path.with_suffix(path.suffix + ".tmp")
     payload = json.dumps(data, indent=2, sort_keys=True)
-    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-    fd = os.open(tmp, flags, 0o600)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    tmp = Path(tmp_name)
     try:
+        _chmod_warn(tmp, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(payload)
-    except Exception:
+        tmp.replace(path)
+    except BaseException:
         with contextlib.suppress(OSError):
             tmp.unlink()
         raise
-    tmp.replace(path)
     _chmod_warn(path, 0o600)
 
 

--- a/libs/partners/openai/tests/unit_tests/test_chatgpt_oauth.py
+++ b/libs/partners/openai/tests/unit_tests/test_chatgpt_oauth.py
@@ -1029,3 +1029,26 @@ def test_file_lock_logs_warning_when_fcntl_unavailable(
     ):
         pass
     assert any("fcntl is unavailable" in rec.message for rec in caplog.records)
+
+
+def test_atomic_writes_use_unique_temporary_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Concurrent writes must not contend for a fixed temporary filename."""
+    created_paths: list[Path] = []
+    real_mkstemp = oauth_module.tempfile.mkstemp
+
+    def recording_mkstemp(*args: Any, **kwargs: Any) -> tuple[int, str]:
+        fd, name = real_mkstemp(*args, **kwargs)
+        created_paths.append(Path(name))
+        return fd, name
+
+    monkeypatch.setattr(oauth_module.tempfile, "mkstemp", recording_mkstemp)
+    target = tmp_path / "auth.json"
+
+    oauth_module._atomic_write_private_json(target, {"version": 1})
+    oauth_module._atomic_write_private_json(target, {"version": 2})
+
+    assert len(set(created_paths)) == 2
+    assert json.loads(target.read_text(encoding="utf-8")) == {"version": 2}
+    assert not any(path.exists() for path in created_paths)


### PR DESCRIPTION
OAuth token writes used one fixed sibling `.tmp` path. When file locking is unavailable, especially on Windows, concurrent writers could close and replace the same temporary file, causing one writer to fail and potentially losing a refreshed token. Each atomic write now creates a private unique temporary file in the destination directory, replaces the token file, and removes the temporary file on every failure path.

## Release note

Concurrent ChatGPT OAuth token writes no longer contend for a shared temporary filename.

This contribution was prepared with assistance from an AI coding agent and was reviewed and tested against the current source tree.
