### PR TITLE
fix(openai): add GPT-6 Astra reasoning efforts

### DIFF
--- a/libs/partners/openai/langchain_openai/data/_profiles.py
+++ b/libs/partners/openai/langchain_openai/data/_profiles.py
@@ -1196,6 +1196,13 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_tool_message": True,
         "tool_choice": True,
         "tool_call_streaming": True,
+        "reasoning_effort_levels": [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max",
+        ],
     },
     "gpt-image-1": {
         "name": "gpt-image-1",

--- a/libs/partners/openai/langchain_openai/data/profile_augmentations.toml
+++ b/libs/partners/openai/langchain_openai/data/profile_augmentations.toml
@@ -114,3 +114,6 @@ reasoning_effort_default = "medium"
 [overrides."gpt-5.6-terra"]
 reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh", "max"]
 reasoning_effort_default = "medium"
+
+[overrides."gpt-6-astra"]
+reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -206,6 +206,20 @@ def test_gpt_5_3_chat_latest_profile_has_no_reasoning_effort() -> None:
     assert "reasoning_effort_levels" not in model.profile
 
 
+def test_gpt_6_astra_reasoning_effort_levels() -> None:
+    model = ChatOpenAI(model="gpt-6-astra")
+
+    assert model.profile
+    assert model.profile["reasoning_effort_levels"] == [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    ]
+    assert "reasoning_effort_default" not in model.profile
+
+
 def test_function_message_dict_to_function_message() -> None:
     content = json.dumps({"result": "Example #1"})
     name = "test_function"


### PR DESCRIPTION
- Augment the generated GPT-6 Astra profile with its verified `low`, `medium`, `high`, `xhigh`, and `max` reasoning-effort levels.
- Leave the default unset because OpenAI does not publish one.
- Add regression coverage for the exact supported set.

Made by [Open SWE](https://openswe.vercel.app/agents/1328c41a-5a5c-5c6d-83d1-a01646bea9c2) · openai:gpt-5.6-sol (high)