### PR TITLE
fix(core): stop `get_function_nonlocals` from leaking bound-method owners

### DIFF
--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -407,7 +407,6 @@ def get_lambda_source(func: Callable[..., Any]) -> str | None:
     return visitor.source if visitor.count == 1 else name
 
 
-@lru_cache(maxsize=256)
 def get_function_nonlocals(func: Callable[..., Any]) -> list[Any]:
     """Get the nonlocal variables accessed by a function.
 
@@ -417,6 +416,25 @@ def get_function_nonlocals(func: Callable[..., Any]) -> list[Any]:
     Returns:
         The nonlocal variables accessed by the function.
     """
+    # Only plain functions (`def`/`lambda`, including `async def`) are safe to
+    # memoize across calls: the cache key (the function object itself) is held
+    # strongly for as long as it stays in the LRU cache, so caching anything
+    # else that carries a reference to other state -- bound methods (whose key
+    # keeps `__self__` alive via `__self__`/`__func__`), callable class
+    # instances, `functools.partial`, etc. -- would keep that state alive for
+    # up to `maxsize` cache entries after the caller drops its own reference.
+    # See https://github.com/langchain-ai/langchain/issues/30667
+    if inspect.isfunction(func):
+        return _get_function_nonlocals_cached(func)
+    return _get_function_nonlocals(func)
+
+
+@lru_cache(maxsize=256)
+def _get_function_nonlocals_cached(func: Callable[..., Any]) -> list[Any]:
+    return _get_function_nonlocals(func)
+
+
+def _get_function_nonlocals(func: Callable[..., Any]) -> list[Any]:
     try:
         code = inspect.getsource(func)
         tree = ast.parse(textwrap.dedent(code))

--- a/libs/core/tests/unit_tests/runnables/test_utils.py
+++ b/libs/core/tests/unit_tests/runnables/test_utils.py
@@ -1,9 +1,13 @@
+import functools
+import gc
+import weakref
 from collections.abc import Callable
 from typing import Any
 
 import pytest
 
 from langchain_core.runnables.base import RunnableLambda
+from langchain_core.runnables.passthrough import RunnablePassthrough
 from langchain_core.runnables.utils import (
     AddableDict,
     get_function_nonlocals,
@@ -74,6 +78,113 @@ def test_nonlocals() -> None:
     assert RunnableLambda(my_func3).deps == [agent]
     assert RunnableLambda(my_func4).deps == [global_agent]
     assert RunnableLambda(func).deps == [nl]
+
+
+def test_get_function_nonlocals_bound_method_does_not_leak() -> None:
+    """A bound method must not keep its owning instance alive forever.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/30667:
+    `get_function_nonlocals` used to be wrapped directly in `@lru_cache`, whose
+    internal dict holds a strong reference to whatever is passed as the cache
+    key. For a bound method, that key holds `__self__` alive via
+    `__self__`/`__func__`, so the owning object (and anything it references)
+    was kept alive for as long as it stayed in the 256-entry LRU cache -- even
+    after every other reference to it was dropped.
+    """
+
+    class Owner:
+        def __init__(self) -> None:
+            self.payload = list(range(1000))
+
+        def call(self, value: dict[str, Any]) -> dict[str, Any]:
+            return value
+
+    owner = Owner()
+    ref = weakref.ref(owner)
+
+    get_function_nonlocals(owner.call)
+    del owner
+    gc.collect()
+
+    assert ref() is None
+
+
+def test_get_function_nonlocals_bound_method_no_leak_via_config_specs() -> None:
+    """Same as above, but through the realistic `RunnableLambda` trigger path.
+
+    `get_function_nonlocals` is only reached through `RunnableLambda.deps`,
+    which is consumed by `config_specs` and `get_graph` -- not by a plain
+    `invoke`. Composite runnables (sequences, parallels, routers, ...) touch
+    `config_specs` on their steps, so this is the realistic way the leak
+    surfaces, e.g. when a chain containing a bound-method `RunnableLambda` is
+    introspected or rendered.
+    """
+
+    class Owner:
+        def __init__(self) -> None:
+            self.payload = list(range(1000))
+
+        def call(self, value: dict[str, Any]) -> dict[str, Any]:
+            return value
+
+    owner = Owner()
+    ref = weakref.ref(owner)
+
+    chain = RunnableLambda(owner.call) | RunnablePassthrough()
+    chain.invoke({})
+    assert chain.config_specs == []
+
+    del owner
+    del chain
+    gc.collect()
+
+    assert ref() is None
+
+
+def test_get_function_nonlocals_callable_instance_does_not_leak() -> None:
+    """A callable class instance passed directly must not leak either.
+
+    The same strong-reference-as-cache-key problem applies to any callable
+    that isn't a plain function -- not just bound methods.
+    """
+
+    class CallableOwner:
+        def __init__(self) -> None:
+            self.payload = list(range(1000))
+
+        def __call__(self, value: dict[str, Any]) -> dict[str, Any]:
+            return value
+
+    instance = CallableOwner()
+    ref = weakref.ref(instance)
+
+    get_function_nonlocals(instance)
+    del instance
+    gc.collect()
+
+    assert ref() is None
+
+
+def test_get_function_nonlocals_partial_does_not_leak() -> None:
+    """A `functools.partial` capturing a heavy argument must not leak it."""
+
+    class Heavy:
+        def __init__(self) -> None:
+            self.payload = list(range(1000))
+
+    def process(_heavy: Heavy, value: dict[str, Any]) -> dict[str, Any]:
+        return value
+
+    heavy = Heavy()
+    ref = weakref.ref(heavy)
+    partial_func = functools.partial(process, heavy)
+
+    get_function_nonlocals(partial_func)
+    del heavy
+    del partial_func
+    gc.collect()
+
+    assert ref() is None
 
 
 def test_addable_dict_add_incompatible_types_raises() -> None:


### PR DESCRIPTION
Fixes #30667

---

`RunnableLambda.deps` (and therefore `config_specs` and `get_graph`) calls `get_function_nonlocals` to find any `Runnable`s referenced by the wrapped callable. That function was wrapped directly in `@lru_cache(maxsize=256)`, and the cache key is the callable itself — held strongly for as long as it stays in the cache.

For a bound method, that key keeps `__self__` alive through `__self__`/`__func__`. The same problem applies to any other callable that carries state of its own: a callable class instance, or a `functools.partial` with bound arguments. Since `RunnableLambda` accepts all of these as `func`, building a `RunnableLambda` from an instance method — a very common pattern — and later touching `.config_specs` or `.get_graph()`, either directly or indirectly through a parent chain that aggregates its steps' `config_specs`, would pin that instance (and everything it references) in memory for up to 256 cache entries, well after every other reference to it was dropped.

The fix only memoizes plain functions and lambdas, which don't carry a `__self__` and are safe to keep around indefinitely. Bound methods, callable instances, and partials are computed directly instead, with no caching — caching them was never actually effective anyway, since a bound method is a fresh object on every attribute access, so an identity/equality-based cache essentially never hit for them and was only ever adding the leak.

Related to #35296, which addresses the bound-method case specifically; this covers the same root cause more generally (callable instances and `functools.partial` leak the same way, not just bound methods).

## Release note

Fixed a memory leak where a `RunnableLambda` built from a bound method, callable instance, or `functools.partial` — most commonly a class's own method used as a chain step — could keep the underlying object alive indefinitely once its `config_specs` or `get_graph` had been accessed.