### PR TITLE
fix(anthropic): preserve string blocks in system message cache middleware

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/prompt_caching.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/prompt_caching.py
@@ -235,7 +235,7 @@ def _tag_system_message(
             return system_message
         new_content = list(content)
         last = new_content[-1]
-        base = last if isinstance(last, dict) else {}
+        base = last if isinstance(last, dict) else {"type": "text", "text": last}
         new_content[-1] = {**base, "cache_control": cache_control}
     else:
         return system_message

--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_prompt_caching.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_prompt_caching.py
@@ -423,6 +423,20 @@ class TestSystemMessageCaching:
         assert "cache_control" not in blocks[1]
         assert blocks[2]["cache_control"] == {"type": "ephemeral", "ttl": "5m"}
 
+    def test_tags_trailing_string_in_list_as_text_block(self) -> None:
+        msg = SystemMessage(
+            content=[
+                {"type": "text", "text": "Block 1"},
+                "Trailing string",
+            ]
+        )
+        blocks = self._get_content_blocks(self._run(self._make_request(msg)))
+        assert len(blocks) == 2
+        assert blocks[0] == {"type": "text", "text": "Block 1"}
+        assert blocks[1]["type"] == "text"
+        assert blocks[1]["text"] == "Trailing string"
+        assert blocks[1]["cache_control"] == {"type": "ephemeral", "ttl": "5m"}
+
     def test_does_not_mutate_original_system_message(self) -> None:
         original_content: list[str | dict[str, str]] = [
             {"type": "text", "text": "Block 1"},


### PR DESCRIPTION
# Fix `AnthropicPromptCachingMiddleware` dropping trailing string blocks in SystemMessage

### Description
This PR fixes a bug in `AnthropicPromptCachingMiddleware` where it silently drops the text of a system message if the last content block is a string instead of a dictionary. 

**Root Cause:**
In `_tag_system_message`, a non-dict trailing block falls back to an empty dict:
```python
last = new_content[-1]
base = last if isinstance(last, dict) else {}
new_content[-1] = {**base, "cache_control": cache_control}
```
For a trailing string block (e.g., `["You are a helpful assistant"]`), `base` evaluates to `{}`, causing the string's text to be completely lost when `cache_control` is appended. 

**Fix:**
This PR updates the fallback logic to properly promote trailing strings into standard Anthropic text blocks (`{"type": "text", "text": last}`) before applying `cache_control`, mirroring how plain string contents are handled earlier in the function.

I have also added a comprehensive unit test in `TestSystemMessageCaching` to verify that trailing string blocks in list-form SystemMessages are no longer discarded.

### Issue 
Fixes #40311

### Submission checklist
- [x] This is a bug, not a usage question.
- [x] I added a clear and descriptive title that summarizes this issue.
- [x] I have read and followed the [Contributing Guidelines](https://github.com/langchain-ai/langchain/blob/master/CONTRIBUTING.md).
- [x] I used the GitHub search to find a similar question and didn't find it.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation (if applicable).
