### PR TITLE
feat(anthropic): forward credentials and auth_token to the anthropic client

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -999,10 +999,11 @@ def _raise_if_authentication_error(e: TypeError) -> None:
         msg = (
             "Anthropic authentication failed: no API key or authorization "
             "credentials were provided. Set the ANTHROPIC_API_KEY environment "
-            "variable, pass api_key=... to ChatAnthropic, or provide "
-            'credentials via default_headers={"Authorization": ...}. If you '
-            "are routing through the LangSmith gateway, set LANGSMITH_GATEWAY "
-            "and LANGSMITH_GATEWAY_API_KEY."
+            "variable, pass api_key=..., auth_token=..., or credentials=... to "
+            "ChatAnthropic, or configure the anthropic SDK's own credential "
+            "resolution (a profile, or the workload identity federation "
+            "environment variables). If you are routing through the LangSmith "
+            "gateway, set LANGSMITH_GATEWAY and LANGSMITH_GATEWAY_API_KEY."
         )
         raise TypeError(msg) from e
 
@@ -1138,6 +1139,31 @@ class ChatAnthropic(BaseChatModel):
 
     If `LANGSMITH_GATEWAY` is enabled and the base URL points at the gateway,
     `LANGSMITH_GATEWAY_API_KEY` is used instead.
+    """
+
+    anthropic_auth_token: SecretStr | None = Field(default=None, alias="auth_token")
+    """Bearer token, forwarded to the anthropic client as `auth_token`.
+
+    For deployments that authenticate with an `Authorization: Bearer`
+    credential instead of an API key. Not read from the environment here: when
+    no explicit credential is configured on this model, the anthropic SDK's own
+    resolution reads `ANTHROPIC_AUTH_TOKEN` (see `credentials`).
+    """
+
+    credentials: Any | None = Field(default=None, exclude=True)
+    """An anthropic SDK credentials provider (`anthropic.lib.credentials`
+    `AccessTokenProvider`), forwarded verbatim to the client.
+
+    Enables authentication modes where no static API key exists, such as
+    workload identity federation, where the provider mints short-lived access
+    tokens on demand.
+
+    When none of `api_key`, `auth_token`, or `credentials` is set, client
+    construction defers to the anthropic SDK's own credential resolution:
+    `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` environment variables,
+    profiles, and workload identity federation environment variables. If a
+    static credential is supplied alongside a provider, the SDK logs a warning
+    and the static credential wins.
     """
 
     anthropic_proxy: str | None = Field(
@@ -1332,6 +1358,7 @@ class ChatAnthropic(BaseChatModel):
         """Return a mapping of secret keys to environment variables."""
         return {
             "anthropic_api_key": "ANTHROPIC_API_KEY",
+            "anthropic_auth_token": "ANTHROPIC_AUTH_TOKEN",
             "mcp_servers": "ANTHROPIC_MCP_SERVERS",
         }
 
@@ -1449,11 +1476,21 @@ class ChatAnthropic(BaseChatModel):
             default_headers.update(self.default_headers)
 
         client_params: dict[str, Any] = {
-            "api_key": self.anthropic_api_key.get_secret_value(),
             "base_url": self.anthropic_api_url,
             "max_retries": self.max_retries,
             "default_headers": default_headers,
         }
+        # Forward credentials only when set. An unset api_key must not reach
+        # the client as an empty string: the SDK treats any non-None credential
+        # argument as explicit, which disables its own resolution (environment
+        # variables, profiles, workload identity federation) and shadows a
+        # `credentials` provider.
+        if api_key := self.anthropic_api_key.get_secret_value():
+            client_params["api_key"] = api_key
+        if self.anthropic_auth_token is not None:
+            client_params["auth_token"] = self.anthropic_auth_token.get_secret_value()
+        if self.credentials is not None:
+            client_params["credentials"] = self.credentials
         # value <= 0 indicates the param should be ignored. None is a meaningful value
         # for Anthropic client and treated differently than not specifying the param at
         # all.

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -287,6 +287,65 @@ def test_user_agent_header_in_client_params() -> None:
     assert params["default_headers"]["User-Agent"].startswith("langchain-anthropic/")
 
 
+def test_unset_api_key_is_omitted_from_client_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unset key defers to the anthropic SDK's own credential resolution.
+
+    Passing ``api_key=""`` counts as an explicit credential to the SDK, which
+    disables its resolution chain (environment variables, profiles, workload
+    identity federation) and shadows a ``credentials`` provider.
+    """
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    llm = ChatAnthropic(model=MODEL_NAME)
+    params = llm._client_params
+    assert "api_key" not in params
+    assert "auth_token" not in params
+    assert "credentials" not in params
+
+
+def test_explicit_and_env_api_keys_are_forwarded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    llm = ChatAnthropic(model=MODEL_NAME, api_key="explicit-key")  # type: ignore[arg-type]
+    assert llm._client_params["api_key"] == "explicit-key"
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "env-key")
+    llm = ChatAnthropic(model=MODEL_NAME)
+    assert llm._client_params["api_key"] == "env-key"
+
+
+def test_auth_token_is_forwarded(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    llm = ChatAnthropic(model=MODEL_NAME, auth_token="bearer-token")  # type: ignore[call-arg]  # noqa: S106
+    params = llm._client_params
+    assert params["auth_token"] == "bearer-token"  # noqa: S105
+    assert "api_key" not in params
+    assert isinstance(llm.anthropic_auth_token, SecretStr)
+
+
+def test_credentials_provider_reaches_the_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    captured: dict[str, Any] = {}
+
+    class FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    provider = object()
+    llm = ChatAnthropic(model=MODEL_NAME, credentials=provider)
+    monkeypatch.setattr(anthropic, "Client", FakeClient)
+    _ = llm._client
+    assert captured["credentials"] is provider
+    assert "api_key" not in captured
+    assert "auth_token" not in captured
+
+
 @pytest.mark.parametrize("async_api", [True, False])
 def test_streaming_attribute_should_stream(async_api: bool) -> None:  # noqa: FBT001
     llm = ChatAnthropic(model=MODEL_NAME, streaming=True)


### PR DESCRIPTION
Fixes #40163

---

Keyless deployments (workload identity federation) work with the bare anthropic SDK but fail through `ChatAnthropic`: it only knows `api_key` and always passes it, even empty, which the SDK reads as an explicit credential and turns its own resolution chain off. The fix: pass-through fields for `credentials=` and `auth_token=`, and `api_key` sent only when set, so the SDK resolves credentials the same way it does when used directly.

## Release note

`ChatAnthropic` accepts `credentials=` (an anthropic SDK `AccessTokenProvider`, such as workload identity federation) and `auth_token=`, and no longer sends an empty `api_key` to the client. With no key configured, the SDK's own credential resolution (environment variables, profiles, workload identity federation) now applies, where `ChatAnthropic` previously failed at request time.

## How I verified

`make format`, `make lint`, and `make test` pass from `libs/partners/anthropic` (330 unit tests, ruff, mypy with the pydantic plugin). New unit tests cover: an unset key omitted from client params, explicit and env keys unchanged, `auth_token` forwarded, and a fake client asserting `credentials=` arrives with no `api_key` beside it.

## Social handles (optional)
Twitter: @lairelaflare
LinkedIn: https://www.linkedin.com/in/larry-osakwe/
