### PR TITLE
release(openai): 1.6.2

### DIFF
--- a/libs/partners/openai/langchain_openai/_version.py
+++ b/libs/partners/openai/langchain_openai/_version.py
@@ -1,3 +1,3 @@
 """Version information for `langchain-openai`."""
 
-__version__ = "1.6.1"
+__version__ = "1.6.2"

--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 
-version = "1.6.1"
+version = "1.6.2"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.6.2,<2.0.0",

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -767,7 +767,7 @@ typing = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.6.1"
+version = "1.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
Bumps `langchain-openai` from 1.6.1 to 1.6.2 for the next patch release.

Made by [Open SWE](https://openswe.vercel.app/agents/af6da570-efce-5c2d-9fb5-637e5b7e32fe) · openai:gpt-5.6-sol (high)