### PR TITLE
fix: HTMLHeaderTextSplitter accepts non-heading tags in constructor

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -87,6 +87,19 @@ def _find_all_tags(
     return tag.find_all(name, recursive=recursive)
 
 
+def _get_header_level(tag: str) -> int:
+    """Return the numeric header level for a tag, with fallback for non-standard tags.
+
+    h1 -> 1, h2 -> 2, etc. Non-numeric tags (e.g. div, section) get level 9999
+    so they sort below every numbered heading, matching the existing fallback in
+    _generate_documents.
+    """
+    try:
+        return int(tag[1:])
+    except ValueError:
+        return 9999
+
+
 class HTMLHeaderTextSplitter:
     """Split HTML content into structured Documents based on specified headers.
 
@@ -173,7 +186,7 @@ class HTMLHeaderTextSplitter:
         """
         # Sort headers by their numeric level so that h1 < h2 < h3...
         self.headers_to_split_on = sorted(
-            headers_to_split_on, key=lambda x: int(x[0][1:])
+            headers_to_split_on, key=lambda x: _get_header_level(x[0])
         )
         self.header_mapping = dict(self.headers_to_split_on)
         self.header_tags = [tag for tag, _ in self.headers_to_split_on]
@@ -325,10 +338,7 @@ class HTMLHeaderTextSplitter:
                         yield doc
 
                 # Determine numeric level (h1->1, h2->2, etc.)
-                try:
-                    level = int(tag[1:])
-                except ValueError:
-                    level = 9999
+                level = _get_header_level(tag)
 
                 # Remove any active headers that are at or deeper than this new level
                 headers_to_remove = [

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -2819,6 +2819,44 @@ def html_header_splitter_splitter_factory() -> Callable[
             ],
             "Headers with no associated content",
         ),
+        (
+            # Test Case: Non-heading tags (e.g., div) should work as split points
+            [("h1", "Header 1"), ("div", "Div Content")],
+            """
+            <html>
+                <body>
+                    <h1>Introduction</h1>
+                    <p>Intro text.</p>
+                    <div>Div content here.</div>
+                    <h1>Conclusion</h1>
+                    <p>Final thoughts.</p>
+                </body>
+            </html>
+            """,
+            [
+                Document(
+                    page_content="Introduction", metadata={"Header 1": "Introduction"}
+                ),
+                Document(
+                    page_content="Intro text.",
+                    metadata={"Header 1": "Introduction"},
+                ),
+                Document(
+                    page_content="Div content here.",
+                    metadata={
+                        "Header 1": "Introduction",
+                        "Div Content": "Div content here.",
+                    },
+                ),
+                Document(
+                    page_content="Conclusion", metadata={"Header 1": "Conclusion"}
+                ),
+                Document(
+                    page_content="Final thoughts.", metadata={"Header 1": "Conclusion"}
+                ),
+            ],
+            "Non-heading tags as split points",
+        ),
     ],
 )
 @pytest.mark.requires("bs4")
@@ -2864,6 +2902,40 @@ def test_html_header_text_splitter(
             f"Test Case '{test_case}' Failed at Document {idx}: "
             f"Metadata mismatch.\nExpected: {expected.metadata}\nGot: {doc.metadata}"
         )
+
+
+@pytest.mark.requires("bs4")
+def test_html_header_splitter_non_heading_tags() -> None:
+    """Test that HTMLHeaderTextSplitter accepts non-heading tags like div.
+
+    Previously the constructor raised ValueError for any tag outside h1-h6
+    because int(tag[1:]) fails on non-numeric suffixes.  The fix uses a shared
+    _get_header_level helper that falls back to level 9999, matching the
+    existing fallback in _generate_documents.
+    """
+    # Should not raise — this was the original bug
+    splitter = HTMLHeaderTextSplitter(
+        headers_to_split_on=[("h1", "Main Topic"), ("div", "Div Content")]
+    )
+    assert splitter.header_tags == ["h1", "div"]
+    # h1 (level 1) must sort before div (level 9999)
+    assert splitter.header_mapping["h1"] == "Main Topic"
+    assert splitter.header_mapping["div"] == "Div Content"
+
+    html = """
+    <html><body>
+      <h1>Intro</h1>
+      <p>Intro text</p>
+      <div>Div body</div>
+      <h1>Conclusion</h1>
+      <p>Final</p>
+    </body></html>
+    """
+    docs = splitter.split_text(html)
+    # The div should nest under the active h1, and a later h1 should close it
+    assert any("Div body" in d.page_content for d in docs)
+    assert any("Intro" in d.metadata.get("Main Topic", "") for d in docs)
+    assert any("Conclusion" in d.metadata.get("Main Topic", "") for d in docs)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Fix: HTMLHeaderTextSplitter crashes on non-heading tags

### Problem
`HTMLHeaderTextSplitter.__init__` sorted headers with `int(x[0][1:])`, which raised `ValueError: invalid literal for int()` for any tag outside `h1`-`h6` (e.g. `div`, `section`). The splitting engine in `_generate_documents` already supported these tags via a `level = 9999` fallback, but the constructor rejected them.

This was reported in issue #40341.

### Solution
Extracted the level calculation into a shared `_get_header_level` helper that returns 9999 for non-numeric tags, and used it in both:
- `__init__`: for sorting headers by level
- `_generate_documents`: for level assignment during splitting

### Tests
Added a parametrized test case and a dedicated test function verifying that non-heading tags work as split points without raising errors.

Fixes #40341