### PR TITLE
fix(core): preserve empty Google GenAI image blocks

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/google_genai.py
+++ b/libs/core/langchain_core/messages/block_translators/google_genai.py
@@ -447,8 +447,6 @@ def _convert_to_v1_from_genai(message: AIMessage) -> list[types.ContentBlock]:
                 else:
                     # This likely won't be reached according to previous implementations
                     converted_blocks.append({"type": "non_standard", "value": item})
-                    msg = "Image URL not a data URI; appending as non-standard block."
-                    raise ValueError(msg)
             elif item_type == "function_call":
                 # Handle Google GenAI function calls
                 function_call_block: types.ToolCall = {

--- a/libs/core/tests/unit_tests/messages/block_translators/test_google_genai.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_google_genai.py
@@ -253,6 +253,17 @@ def test_content_blocks_preserve_index_for_images() -> None:
     assert [block.get("index") for block in blocks] == [0, 1]
 
 
+def test_empty_image_url_falls_back_to_non_standard_block() -> None:
+    """An empty image URL should preserve the source block instead of raising."""
+    item = {"type": "image_url", "image_url": {"url": ""}}
+    message = AIMessage(
+        content=[item],
+        response_metadata={"model_provider": "google_genai"},
+    )
+
+    assert message.content_blocks == [{"type": "non_standard", "value": item}]
+
+
 def test_content_blocks_preserve_index_for_parallel_tool_calls() -> None:
     """Tool calls rebuilt from `tool_calls` must recover their chunk index."""
     message = _genai_chunk(


### PR DESCRIPTION
Fixes #40351

---

Google GenAI users can now inspect messages containing an empty `image_url` because the translator returns the fallback `non_standard` block it constructs instead of raising immediately afterward. The new regression test confirms that the original source block is preserved.

## Release note

Google GenAI content-block conversion now preserves empty image URL blocks as non-standard content instead of raising a `ValueError`.

Verified in `libs/core` with the focused Google GenAI translator suite (12 passed), `make format`, and `make lint` (Ruff and mypy passed). Reverting only the production change makes the new regression test fail with the reported `ValueError`.

This contribution was prepared with AI-agent assistance and reviewed and verified by the author.
