### PR TITLE
fix(text-splitters): strip closing hashes in MarkdownHeaderTextSplitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/markdown.py
+++ b/libs/text-splitters/langchain_text_splitters/markdown.py
@@ -20,6 +20,11 @@ class MarkdownTextSplitter(RecursiveCharacterTextSplitter):
         super().__init__(separators=separators, **kwargs)
 
 
+# Closing `#` run is not heading text when preceded by whitespace
+# (or the whole text); `# C#` keeps its `#` per CommonMark.
+_CLOSING_HASHES_RE = re.compile(r"(?:^|\s+)#+\s*$")
+
+
 class MarkdownHeaderTextSplitter:
     """Splitting markdown files based on specified headers."""
 
@@ -221,8 +226,11 @@ class MarkdownHeaderTextSplitter:
                             header_text = stripped_line[len(sep) : -len(sep)].strip()
                         else:
                             # For standard headers like # Header, extract text
-                            # after the separator
-                            header_text = stripped_line[len(sep) :].strip()
+                            # after the separator, dropping optional closing
+                            # `#` sequence (e.g. `# Header ##`).
+                            header_text = _CLOSING_HASHES_RE.sub(
+                                "", stripped_line[len(sep) :].strip()
+                            ).rstrip()
 
                         header: HeaderType = {
                             "level": current_header_level,


### PR DESCRIPTION
Fixes #40298

CommonMark ATX headings allow an optional closing `#` sequence (e.g. `# Title ##`) which is not part of the heading text. `MarkdownHeaderTextSplitter` kept it in header metadata (`Title ##`), breaking filtering/grouping.

This strips a trailing `#` run only when preceded by whitespace (or the whole text), so `# C#` and `# Title#` are preserved.

Verified: repro from #40298 now yields `Title` / `Section`; full `libs/text-splitters/tests/unit_tests/test_text_splitters.py` (153 passed).