### PR TITLE
fix(core): allow format specs in `StrictFormatter` input validation

### DIFF
--- a/libs/core/langchain_core/utils/formatting.py
+++ b/libs/core/langchain_core/utils/formatting.py
@@ -65,14 +65,39 @@ class StrictFormatter(Formatter):
         Raises:
             KeyError: If the format string contains placeholders not present
                 in input_variables.
+            IndexError: If the format string contains positional placeholders.
 
         Example:
             >>> fmt = StrictFormatter()
             >>> fmt.validate_input_variables("Hello, {name}!", ["name"])  # OK
             >>> fmt.validate_input_variables("Hello, {name}!", ["other"])  # Raises
         """
-        dummy_inputs = dict.fromkeys(input_variables, "foo")
-        super().format(format_string, **dummy_inputs)
+        names = set(input_variables)
+        self._validate_format_string(format_string, names)
+
+    def _validate_format_string(self, format_string: str, names: set[str]) -> None:
+        """Check that every placeholder in a format string is a known variable.
+
+        Only variable *names* are checked — placeholders are never rendered,
+        so format specs (e.g. `{score:.1f}`) cannot fail validation.
+
+        Args:
+            format_string: A string containing replacement fields to validate.
+            names: Valid variable names.
+        """
+        for _, field_name, format_spec, _ in self.parse(format_string):
+            if field_name is not None:
+                if not field_name:
+                    msg = (
+                        "Positional arguments are not allowed, everything "
+                        "should be passed as keyword arguments."
+                    )
+                    raise IndexError(msg)
+                root = field_name.split(".")[0].split("[")[0]
+                if root not in names:
+                    raise KeyError(root)
+            if format_spec:
+                self._validate_format_string(format_spec, names)
 
 
 #: Default StrictFormatter instance for use throughout LangChain.

--- a/libs/core/tests/unit_tests/utils/test_formatting.py
+++ b/libs/core/tests/unit_tests/utils/test_formatting.py
@@ -108,6 +108,20 @@ class TestStrictFormatter:
         # Should not raise
         fmt.validate_input_variables("Hello, World!", [])
 
+    def test_validate_input_variables_with_format_spec(self) -> None:
+        """Test `validate_input_variables` accepts templates with format specs."""
+        fmt = StrictFormatter()
+        # Should not raise: the variable is provided, the spec only affects
+        # rendering and must not fail validation.
+        fmt.validate_input_variables("Score: {score:.1f}", ["score"])
+        fmt.validate_input_variables("Count: {n:d} ({p:%})", ["n", "p"])
+
+    def test_validate_input_variables_with_format_spec_missing(self) -> None:
+        """Test `validate_input_variables` still raises on missing variables."""
+        fmt = StrictFormatter()
+        with pytest.raises(KeyError):
+            fmt.validate_input_variables("Score: {score:.1f}", ["other"])
+
 
 class TestFormatterSingleton:
     """Tests for the formatter singleton instance."""


### PR DESCRIPTION
Fixes #40355

---

Prompt templates using numeric format specs (e.g. `"Score: {score:.1f}"`) could not be created with `validate_template=True`: validation rendered the template against dummy strings, so the check itself crashed with `Unknown format code 'f' for object of type 'str'`. It now checks placeholder names instead of rendering values, so valid templates pass and genuinely missing variables are still rejected.

## Release note

Fixed `PromptTemplate` validation rejecting templates that use format specifiers such as `{score:.1f}` when `validate_template=True`.

Ran the formatting and prompts unit suites plus `ruff check` / `ruff format --check` locally; `mypy` was not available in my env so leaving that to CI. AI-agent assisted.