### PR TITLE
fix(openai): classify provider errors returned in a 200 response body

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -38,6 +38,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    NoReturn,
     TypeAlias,
     TypeVar,
     cast,
@@ -674,7 +675,61 @@ def _handle_openai_api_error(e: openai.APIError) -> None:
         raise OpenAITimeoutError(e.request) from e
     if isinstance(e, openai.APIConnectionError):
         raise OpenAIConnectionError(message=e.message, request=e.request) from e
+    if getattr(e, "status_code", None) is None:
+        # Some OpenAI-compatible gateways report a failure with HTTP 200 and the
+        # status the response should have carried inside the body. Nothing
+        # raised a typed error, so none of the branches above matched.
+        status = _status_from_body_error(getattr(e, "body", None))
+        if status is not None:
+            _raise_classified_body_error(e.body, url=str(getattr(e, "request", "")))
     raise
+
+
+_BODY_ERROR_TYPES: dict[int, type[openai.APIStatusError]] = {
+    400: openai.BadRequestError,
+    401: openai.AuthenticationError,
+    403: openai.PermissionDeniedError,
+    404: openai.NotFoundError,
+    422: openai.UnprocessableEntityError,
+    429: openai.RateLimitError,
+}
+
+
+def _status_from_body_error(error: Any) -> int | None:
+    """Read the HTTP status out of an error payload delivered inside a 200."""
+    if not isinstance(error, dict):
+        return None
+    code = error.get("code")
+    if isinstance(code, str) and code.isdigit():
+        return int(code)
+    return code if isinstance(code, int) else None
+
+
+def _raise_classified_body_error(error: Any, *, url: str) -> NoReturn:
+    """Raise the error a provider reported inside a successful response body.
+
+    A 200 carries no failing status object, so one is built from the status the
+    payload reports. Routing through ``_handle_openai_api_error`` keeps the
+    mapping from status to LangChain type in one place.
+    """
+    # The SDK pins httpx2 on newer `openai` majors and httpx on older ones.
+    try:
+        import httpx2 as httpx
+    except ImportError:  # pragma: no cover - depends on the installed openai major
+        import httpx  # type: ignore[no-redef]
+
+    status = _status_from_body_error(error)
+    message = (
+        error.get("message") if isinstance(error, dict) else None
+    ) or "The provider returned an error in a successful response body"
+    body = error if isinstance(error, dict) else {"message": str(error)}
+    response = httpx.Response(status or 500, request=httpx.Request("POST", url))
+    error_type = _BODY_ERROR_TYPES.get(status or 500, openai.InternalServerError)
+    sdk_error = error_type(message, response=response, body=body)
+    if isinstance(sdk_error, openai.BadRequestError):
+        _handle_openai_bad_request(sdk_error)
+    _handle_openai_api_error(sdk_error)
+    raise sdk_error  # pragma: no cover - handlers above always raise
 
 
 def _add_gateway_metadata(generation_info: dict[str, Any], raw_response: Any) -> None:
@@ -2001,7 +2056,9 @@ class BaseChatOpenAI(BaseChatModel):
         # typically followed by a null value for `choices`, which we raise for
         # separately below).
         if response_dict.get("error"):
-            raise ValueError(response_dict.get("error"))
+            _raise_classified_body_error(
+                response_dict["error"], url=str(self.openai_api_base or "")
+            )
 
         # Raise informative error messages for non-OpenAI chat completions APIs
         # that return malformed responses.
@@ -5020,7 +5077,10 @@ def _construct_lc_result_from_responses_api(
 ) -> ChatResult:
     """Construct `ChatResponse` from OpenAI Response API response."""
     if response.error:
-        raise ValueError(response.error)
+        _raise_classified_body_error(
+            {"message": getattr(response.error, "message", "") or str(response.error)},
+            url="",
+        )
 
     if output_version is None:
         # Sentinel value of None lets us know if output_version is set explicitly.

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -2256,7 +2256,7 @@ def test_structured_outputs_parser_valid_falsy_response() -> None:
 
 
 def test__construct_lc_result_from_responses_api_error_handling() -> None:
-    """Test that errors in the response are properly raised."""
+    """Errors in the response raise a classified provider error, not a ValueError."""
     response = Response(
         id="resp_123",
         created_at=1234567890,
@@ -2269,10 +2269,12 @@ def test__construct_lc_result_from_responses_api_error_handling() -> None:
         output=[],
     )
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(openai.InternalServerError) as excinfo:
         _construct_lc_result_from_responses_api(response)
 
     assert "Test error" in str(excinfo.value)
+    assert isinstance(excinfo.value, ModelAPIError)
+    assert excinfo.value.is_retryable is True
 
 
 def test__construct_lc_result_from_responses_api_basic_text_response() -> None:
@@ -5494,3 +5496,114 @@ def test_configuration_update_block_without_text() -> None:
         "type": "configuration_update",
         "reasoning": {"effort": "low"},
     }
+
+
+_BODY_ERROR_CASES = [
+    (400, openai.BadRequestError, ModelInvalidRequestError, False),
+    (401, openai.AuthenticationError, ModelAuthenticationError, False),
+    (403, openai.PermissionDeniedError, ModelPermissionDeniedError, False),
+    (404, openai.NotFoundError, ModelNotFoundError, False),
+    (429, openai.RateLimitError, ModelRateLimitError, True),
+    (500, openai.InternalServerError, ModelAPIError, True),
+    (502, openai.InternalServerError, ModelAPIError, True),
+    ("429", openai.RateLimitError, ModelRateLimitError, True),  # sent as a string
+]
+
+
+def _completion_with_error(error: Any) -> dict:
+    """A 200 response body carrying an error instead of choices."""
+    return {
+        "id": "chatcmpl-1",
+        "object": "chat.completion",
+        "created": 1,
+        "model": OPENAI_TEST_MODEL,
+        "error": error,
+    }
+
+
+@pytest.mark.parametrize(
+    ("code", "sdk_error_type", "model_error_type", "is_retryable"), _BODY_ERROR_CASES
+)
+def test_body_error_classification_invoke(
+    code: int | str,
+    sdk_error_type: type[openai.APIStatusError],
+    model_error_type: type[ModelError],
+    *,
+    is_retryable: bool,
+) -> None:
+    """An error inside a 200 body raises the types the same error raised would."""
+    model = ChatOpenAI(api_key=SecretStr("test"))
+    body = _completion_with_error({"code": code, "message": "gateway said no"})
+
+    with patch.object(model.client, "with_raw_response") as mock_client:
+        mock_client.create.return_value.parse.return_value = body
+        with pytest.raises(sdk_error_type) as exc_info:
+            model.invoke("test")
+
+    assert isinstance(exc_info.value, model_error_type)
+    assert exc_info.value.is_retryable is is_retryable
+    assert exc_info.value.body == {"code": code, "message": "gateway said no"}
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        {"message": "no code at all"},
+        {"code": "not_a_status", "message": "x"},
+        "a bare string error",
+    ],
+)
+def test_body_error_without_usable_status_still_raises(error: Any) -> None:
+    """A body that says "error" never reads as success, however malformed."""
+    model = ChatOpenAI(api_key=SecretStr("test"))
+
+    with patch.object(model.client, "with_raw_response") as mock_client:
+        mock_client.create.return_value.parse.return_value = _completion_with_error(
+            error
+        )
+        with pytest.raises(ModelAPIError):
+            model.invoke("test")
+
+
+@pytest.mark.parametrize(
+    ("code", "sdk_error_type", "model_error_type", "is_retryable"), _BODY_ERROR_CASES
+)
+def test_api_error_with_status_in_body_is_classified(
+    code: int | str,
+    sdk_error_type: type[openai.APIStatusError],
+    model_error_type: type[ModelError],
+    *,
+    is_retryable: bool,
+) -> None:
+    """A streamed gateway fault arrives as APIError with the status in `body`."""
+    model = ChatOpenAI(api_key=SecretStr("test"))
+    api_error = openai.APIError(
+        "gateway said no",
+        request=httpx2.Request("POST", "http://gateway.test/v1/chat/completions"),
+        body={"code": code, "message": "gateway said no"},
+    )
+
+    with patch.object(model.client, "with_raw_response") as mock_client:
+        mock_client.create.side_effect = api_error
+        with pytest.raises(sdk_error_type) as exc_info:
+            model.invoke("test")
+
+    assert isinstance(exc_info.value, model_error_type)
+    assert exc_info.value.is_retryable is is_retryable
+
+
+def test_api_error_without_usable_body_status_is_reraised_unchanged() -> None:
+    """An APIError with no status in its body keeps today's behaviour."""
+    model = ChatOpenAI(api_key=SecretStr("test"))
+    api_error = openai.APIError(
+        "something else went wrong",
+        request=httpx2.Request("POST", "http://gateway.test/v1/chat/completions"),
+        body={"message": "no code here"},
+    )
+
+    with patch.object(model.client, "with_raw_response") as mock_client:
+        mock_client.create.side_effect = api_error
+        with pytest.raises(openai.APIError) as exc_info:
+            model.invoke("test")
+
+    assert exc_info.value is api_error


### PR DESCRIPTION
Fixes #40362.

OpenAI-compatible gateways may report a failure with HTTP 200 and the status the
response should have carried inside the body. Nothing raises a typed SDK error, so
the request never reaches the `except openai.APIError` blocks that
`_handle_openai_api_error` sits behind, and the caller gets a bare `ValueError` on
the non-streaming path. On the streaming path the SDK does raise, but the resulting
`APIError` carries the status in `body` rather than `status_code`, so it matches
none of the handler's `isinstance` branches and falls through unclassified.

This reads the status out of the payload, builds the SDK error it describes, and
routes it through the existing handlers, so the mapping from status to LangChain
type stays in one place. `_construct_lc_result_from_responses_api` gets the same
treatment; its existing test is updated from `ValueError` to the classified type.

## Release note

`ChatOpenAI` raises the standard model errors for provider failures reported inside
a successful response body, so `is_retryable` is available for gateway faults as it
already is for HTTP-status ones.
