### PR TITLE
fix(openrouter): classify errors reported in a 200 response body

### DIFF
--- a/libs/partners/openrouter/langchain_openrouter/chat_models.py
+++ b/libs/partners/openrouter/langchain_openrouter/chat_models.py
@@ -6,11 +6,20 @@ import json
 import warnings
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
 from operator import itemgetter
-from typing import Any, Literal, cast
+from typing import Any, Literal, NoReturn, cast
 
 from langchain_core.callbacks import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
+)
+from langchain_core.exceptions import (
+    ModelAPIError,
+    ModelAuthenticationError,
+    ModelError,
+    ModelInvalidRequestError,
+    ModelNotFoundError,
+    ModelPermissionDeniedError,
+    ModelRateLimitError,
 )
 from langchain_core.language_models import (
     LanguageModelInput,
@@ -101,6 +110,37 @@ def _create_stream_generation_info(
     if object_ := chunk_dict.get("object"):
         generation_info["object"] = object_
     return generation_info
+
+
+_ERROR_TYPES: dict[int, type[ModelError]] = {
+    400: ModelInvalidRequestError,
+    401: ModelAuthenticationError,
+    402: ModelPermissionDeniedError,
+    403: ModelPermissionDeniedError,
+    404: ModelNotFoundError,
+    422: ModelInvalidRequestError,
+    429: ModelRateLimitError,
+}
+
+
+def _raise_streaming_error(error: Any) -> NoReturn:
+    """Raise a standard model error for a fault OpenRouter reports in a 200 body.
+
+    ``error.code`` is the only signal of whether the failure is worth retrying,
+    so it is mapped to an exception type rather than formatted into the message.
+    """
+    code = error.get("code") if isinstance(error, dict) else None
+    if isinstance(code, str) and code.isdigit():
+        code = int(code)
+    error_type: type[ModelError] = ModelAPIError
+    if isinstance(code, int):
+        error_type = _ERROR_TYPES.get(code, ModelAPIError)
+    message = (error.get("message") if isinstance(error, dict) else None) or str(error)
+    msg = (
+        f"OpenRouter API returned an error during streaming: "
+        f"{message} (code: {code if code is not None else 'unknown'})"
+    )
+    raise error_type(msg)
 
 
 class ChatOpenRouter(BaseChatModel):
@@ -609,12 +649,7 @@ class ChatOpenRouter(BaseChatModel):
             chunk_dict = chunk.model_dump(by_alias=True)
             if not chunk_dict.get("choices"):
                 if error := chunk_dict.get("error"):
-                    msg = (
-                        f"OpenRouter API returned an error during streaming: "
-                        f"{error.get('message', str(error))} "
-                        f"(code: {error.get('code', 'unknown')})"
-                    )
-                    raise ValueError(msg)
+                    _raise_streaming_error(error)
                 # Usage-only chunk (no choices) — emit with usage_metadata
                 if usage := chunk_dict.get("usage"):
                     usage_metadata = _create_usage_metadata(usage)
@@ -701,12 +736,7 @@ class ChatOpenRouter(BaseChatModel):
             chunk_dict = chunk.model_dump(by_alias=True)
             if not chunk_dict.get("choices"):
                 if error := chunk_dict.get("error"):
-                    msg = (
-                        f"OpenRouter API returned an error during streaming: "
-                        f"{error.get('message', str(error))} "
-                        f"(code: {error.get('code', 'unknown')})"
-                    )
-                    raise ValueError(msg)
+                    _raise_streaming_error(error)
                 # Usage-only chunk (no choices) — emit with usage_metadata
                 if usage := chunk_dict.get("usage"):
                     usage_metadata = _create_usage_metadata(usage)

--- a/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
@@ -7,6 +7,15 @@ from typing import Any, Literal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain_core.exceptions import (
+    ModelAPIError,
+    ModelAuthenticationError,
+    ModelError,
+    ModelInvalidRequestError,
+    ModelNotFoundError,
+    ModelPermissionDeniedError,
+    ModelRateLimitError,
+)
 from langchain_core.load import dumpd, dumps, load
 from langchain_core.messages import (
     AIMessage,
@@ -3422,7 +3431,7 @@ class TestStreamingErrors:
     """Tests for error handling during streaming."""
 
     def test_stream_error_chunk_raises(self) -> None:
-        """Test that a streaming error chunk raises ValueError."""
+        """A streaming error chunk raises a classified model error."""
         model = _make_model()
         model.client = MagicMock()
         error_chunks: list[dict[str, Any]] = [
@@ -3431,7 +3440,7 @@ class TestStreamingErrors:
             },
         ]
         model.client.chat.send.return_value = _MockSyncStream(error_chunks)
-        with pytest.raises(ValueError, match="Rate limit exceeded"):
+        with pytest.raises(ModelRateLimitError, match="Rate limit exceeded"):
             list(model.stream("Hello"))
 
     def test_stream_error_chunk_without_message(self) -> None:
@@ -3444,7 +3453,7 @@ class TestStreamingErrors:
             },
         ]
         model.client.chat.send.return_value = _MockSyncStream(error_chunks)
-        with pytest.raises(ValueError, match="OpenRouter API returned an error"):
+        with pytest.raises(ModelError, match="OpenRouter API returned an error"):
             list(model.stream("Hello"))
 
     def test_stream_heartbeat_chunk_skipped(self) -> None:
@@ -3463,7 +3472,7 @@ class TestStreamingErrors:
         assert "Hello" in full_content
 
     async def test_astream_error_chunk_raises(self) -> None:
-        """Test that an async streaming error chunk raises ValueError."""
+        """An async streaming error chunk raises a classified model error."""
         model = _make_model()
         model.client = MagicMock()
         error_chunks: list[dict[str, Any]] = [
@@ -3474,7 +3483,7 @@ class TestStreamingErrors:
         model.client.chat.send_async = AsyncMock(
             return_value=_MockAsyncStream(error_chunks)
         )
-        with pytest.raises(ValueError, match="Rate limit exceeded"):
+        with pytest.raises(ModelRateLimitError, match="Rate limit exceeded"):
             chunks = [c async for c in model.astream("Hello")]  # noqa: F841
 
     async def test_astream_heartbeat_chunk_skipped(self) -> None:
@@ -3779,3 +3788,30 @@ def test_profile() -> None:
     """Test that the model has a profile."""
     model = _make_model()
     assert model.profile
+
+
+@pytest.mark.parametrize(
+    ("code", "error_type", "is_retryable"),
+    [
+        (400, ModelInvalidRequestError, False),
+        (401, ModelAuthenticationError, False),
+        (402, ModelPermissionDeniedError, False),
+        (404, ModelNotFoundError, False),
+        (429, ModelRateLimitError, True),
+        (502, ModelAPIError, True),
+    ],
+)
+def test_stream_error_chunk_is_classified_by_code(
+    code: int, error_type: type[ModelError], *, is_retryable: bool
+) -> None:
+    """The error code decides the exception type, and whether a retry may help."""
+    model = _make_model()
+    model.client = MagicMock()
+    model.client.chat.send.return_value = _MockSyncStream(
+        [{"error": {"code": code, "message": "gateway said no"}}]
+    )
+
+    with pytest.raises(error_type) as exc_info:
+        list(model.stream("Hello"))
+
+    assert exc_info.value.is_retryable is is_retryable


### PR DESCRIPTION
Fixes #40364.

OpenRouter reports a throttle or an upstream fault with HTTP 200 and the status in
`error.code`. Both streaming paths already detect this, then interpolate the code
into a message string and raise a bare `ValueError` — so the one field that says
whether a retry may help is only recoverable by parsing prose.

This maps the code to the standard model errors from #39538. The message keeps its
exact existing shape, so anything matching on the text still matches; only the type
changes. The existing tests asserting `ValueError` on these paths are updated.

## Release note

`ChatOpenRouter` raises the standard model errors for faults reported during
streaming, so `is_retryable` distinguishes a throttle from a credential failure.
