### PR TITLE
fix(langchain): retry after failed return_direct tool calls

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -2020,6 +2020,16 @@ def _make_tools_to_model_edge(
         client_side_tool_calls = [
             c for c in last_ai_message.tool_calls if c["name"] in tool_node.tools_by_name
         ]
+        return_direct_tool_call_ids = {
+            c["id"]
+            for c in client_side_tool_calls
+            if tool_node.tools_by_name[c["name"]].return_direct
+        }
+        if any(
+            message.tool_call_id in return_direct_tool_call_ids and message.status == "error"
+            for message in tool_messages
+        ):
+            return model_destination
         if client_side_tool_calls and all(
             tool_node.tools_by_name[c["name"]].return_direct for c in client_side_tool_calls
         ):

--- a/libs/langchain_v1/tests/unit_tests/agents/test_return_direct_graph.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_return_direct_graph.py
@@ -1,5 +1,6 @@
 """Tests for return_direct tool graph structure."""
 
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.tools import tool
 from syrupy.assertion import SnapshotAssertion
 
@@ -70,3 +71,40 @@ def test_agent_graph_with_mixed_tools(snapshot: SnapshotAssertion) -> None:
     # because at least one tool has return_direct=True
     mermaid_diagram = agent.get_graph().draw_mermaid()
     assert mermaid_diagram == snapshot
+
+
+def test_return_direct_tool_error_routes_back_to_model() -> None:
+    """Test that a failed return_direct tool gives the model a chance to recover."""
+
+    @tool(return_direct=True)
+    def failing_tool(input_string: str) -> str:
+        """A tool that always fails."""
+        msg = f"failed to process {input_string}"
+        raise ValueError(msg)
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [
+                    {
+                        "name": "failing_tool",
+                        "args": {"input_string": "hello"},
+                        "id": "call_1",
+                    }
+                ],
+                [],
+            ]
+        ),
+        tools=[failing_tool],
+        system_prompt="You are a helpful assistant.",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Run the tool.")]})
+
+    assert any(
+        isinstance(message, ToolMessage)
+        and message.tool_call_id == "call_1"
+        and message.status == "error"
+        for message in result["messages"]
+    )
+    assert isinstance(result["messages"][-1], AIMessage)


### PR DESCRIPTION
Fixes #36411

When a `return_direct=True` tool returns an error, route the conversation back to the model so it can recover instead of ending the agent run. Added a regression test for this behavior.

## Release note

Failed `return_direct` tools now give the model an opportunity to recover instead of terminating the agent run.

## Verification

`git diff --check` and Python syntax compilation passed. The targeted pytest could not run locally because `uv` and the test dependencies are unavailable.

## AI disclosure

This change was prepared with assistance from an AI coding agent and reviewed by the author.