### PR TITLE
fix(openai): set GPT-6 Astra reasoning default

### DIFF
--- a/libs/partners/openai/langchain_openai/data/_profiles.py
+++ b/libs/partners/openai/langchain_openai/data/_profiles.py
@@ -1203,6 +1203,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
             "xhigh",
             "max",
         ],
+        "reasoning_effort_default": "low",
     },
     "gpt-image-1": {
         "name": "gpt-image-1",

--- a/libs/partners/openai/langchain_openai/data/profile_augmentations.toml
+++ b/libs/partners/openai/langchain_openai/data/profile_augmentations.toml
@@ -117,3 +117,4 @@ reasoning_effort_default = "medium"
 
 [overrides."gpt-6-astra"]
 reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
+reasoning_effort_default = "low"

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -217,7 +217,7 @@ def test_gpt_6_astra_reasoning_effort_levels() -> None:
         "xhigh",
         "max",
     ]
-    assert "reasoning_effort_default" not in model.profile
+    assert model.profile["reasoning_effort_default"] == "low"
 
 
 def test_function_message_dict_to_function_message() -> None:


### PR DESCRIPTION
GPT-6 Astra users currently have no profile default, so consumers such as dcode cannot show an active effort until the user sets an override.

- Set `reasoning_effort_default` to `low`, matching OpenAI's Codex model catalog and Agents SDK default.
- Regenerate the OpenAI profile data and cover the default in the existing Astra profile test.

## Release note

`ChatOpenAI` profiles now identify `low` as GPT-6 Astra's default reasoning effort.

Made by [Open SWE](https://openswe.vercel.app/agents/e088ac20-f9c3-5fea-bb63-2d6964057543) · openai:gpt-5.6-sol (high)