### PR TITLE
fix(anthropic): preserve invalid tool use blocks

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/_compat.py
+++ b/libs/partners/anthropic/langchain_anthropic/_compat.py
@@ -141,7 +141,23 @@ def _convert_from_v1_to_anthropic(
             )
 
         elif block["type"] == "invalid_tool_call":
-            continue
+            tool_call_id = block.get("id")
+            tool_name = block.get("name")
+            if (
+                model_provider == "anthropic"
+                and isinstance(tool_call_id, str)
+                and tool_call_id
+                and isinstance(tool_name, str)
+                and tool_name
+            ):
+                new_content.append(
+                    {
+                        "type": "tool_use",
+                        "name": tool_name,
+                        "input": {},
+                        "id": tool_call_id,
+                    }
+                )
 
         elif block["type"] == "reasoning" and model_provider == "anthropic":
             new_block = {}

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3250,6 +3250,47 @@ def test_format_messages_preserves_nonempty_thinking_field() -> None:
     assert block["signature"] == "sig_xyz"
 
 
+def test_v1_invalid_tool_call_retains_tool_use_for_error_result() -> None:
+    """An error result must retain its Anthropic tool-use block on replay."""
+    tool_call_id = "toolu_invalid"
+    invalid_tool_call = {
+        "type": "invalid_tool_call",
+        "id": tool_call_id,
+        "name": "get_weather",
+        "args": '{"location":',
+        "error": "Failed to parse tool call arguments as JSON",
+    }
+    ai_message = AIMessage(
+        content=[invalid_tool_call],
+        invalid_tool_calls=[invalid_tool_call],
+        response_metadata={"model_provider": "anthropic", "output_version": "v1"},
+    )
+    tool_message = ToolMessage(
+        "Tool call arguments were malformed.",
+        tool_call_id=tool_call_id,
+        status="error",
+    )
+    llm = ChatAnthropic(model=MODEL_NAME)  # type: ignore[call-arg]
+
+    payload = llm._get_request_payload(
+        [HumanMessage("Check the weather"), ai_message, tool_message]
+    )
+
+    assert payload["messages"][1] == {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool_use",
+                "id": tool_call_id,
+                "name": "get_weather",
+                "input": {},
+            }
+        ],
+    }
+    assert payload["messages"][2]["content"][0]["tool_use_id"] == tool_call_id
+    assert payload["messages"][2]["content"][0]["is_error"] is True
+
+
 def test_strict_tool_use() -> None:
     model = ChatAnthropic(
         model=MODEL_NAME,  # type: ignore[call-arg]

--- a/libs/partners/anthropic/tests/unit_tests/test_compat.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_compat.py
@@ -5,8 +5,8 @@ from langchain_core.messages import content as types
 from langchain_anthropic._compat import _convert_from_v1_to_anthropic
 
 
-def test_convert_from_v1_filters_invalid_tool_calls() -> None:
-    """Test that invalid tool calls are not sent to Anthropic."""
+def test_convert_from_v1_restores_anthropic_invalid_tool_calls() -> None:
+    """Test that Anthropic invalid tool calls retain their tool-use identity."""
     content: list[types.ContentBlock] = [
         {"type": "text", "text": "Let me check."},
         {
@@ -30,8 +30,44 @@ def test_convert_from_v1_filters_invalid_tool_calls() -> None:
         {"type": "text", "text": "Let me check."},
         {
             "type": "tool_use",
+            "id": "toolu_invalid",
+            "name": "get_weather",
+            "input": {},
+        },
+        {
+            "type": "tool_use",
             "id": "toolu_valid",
             "name": "get_weather",
             "input": {"city": "San Francisco"},
         },
     ]
+
+
+def test_convert_from_v1_filters_non_anthropic_invalid_tool_calls() -> None:
+    """Test that invalid calls from other providers are not promoted."""
+    content: list[types.ContentBlock] = [
+        {
+            "type": "invalid_tool_call",
+            "id": "call_invalid",
+            "name": "get_weather",
+            "args": '{"city":',
+            "error": "Invalid JSON",
+        }
+    ]
+
+    assert _convert_from_v1_to_anthropic(content, [], "openai") == []
+
+
+def test_convert_from_v1_filters_unidentified_invalid_tool_calls() -> None:
+    """Test that incomplete blocks are not promoted into tool calls."""
+    content: list[types.ContentBlock] = [
+        {
+            "type": "invalid_tool_call",
+            "id": None,
+            "name": "get_weather",
+            "args": '{"city":',
+            "error": "Invalid JSON",
+        }
+    ]
+
+    assert _convert_from_v1_to_anthropic(content, [], "anthropic") == []


### PR DESCRIPTION
Anthropic users can receive a malformed streamed tool invocation whose v1 representation is an `invalid_tool_call`. Preserve its original ID and name as a `tool_use` block with empty input when replaying Anthropic messages, so a matching error `ToolMessage` does not become an orphaned `tool_result`; invalid calls from other providers remain filtered.

Focused compatibility and request-payload regression tests cover the preserved pairing, provider guard, and missing-identity case.

## Release note

Anthropic message replay now preserves malformed streamed tool invocations so matching error tool results are accepted by the API instead of failing with an unexpected `tool_use_id` error.

AI-agent assistance was used in this contribution.

Made by [Open SWE](https://openswe.vercel.app/agents/d63a4b17-0b57-5691-8362-8fe352cc1a51) · openai:gpt-5.6-sol (high)