### PR TITLE
fix(text-splitters): allow non-heading tags in HTMLHeaderTextSplitter…

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -87,6 +87,19 @@ def _find_all_tags(
     return tag.find_all(name, recursive=recursive)
 
 
+def _header_level(tag: str) -> int:
+    """Map a header tag to its numeric level (`h1` -> 1, `h2` -> 2, ...).
+
+    Tags outside `h1`-`h6` (e.g. `div`) get a fallback level of `9999` so they
+    sort after every numbered heading, consistent with how the splitting engine
+    treats them.
+    """
+    try:
+        return int(tag[1:])
+    except ValueError:
+        return 9999
+
+
 class HTMLHeaderTextSplitter:
     """Split HTML content into structured Documents based on specified headers.
 
@@ -172,8 +185,10 @@ class HTMLHeaderTextSplitter:
                 fewer `Document` objects.
         """
         # Sort headers by their numeric level so that h1 < h2 < h3...
+        # Tags outside h1-h6 are allowed; they sort last, matching the
+        # fallback level the splitting engine assigns them.
         self.headers_to_split_on = sorted(
-            headers_to_split_on, key=lambda x: int(x[0][1:])
+            headers_to_split_on, key=lambda x: _header_level(x[0])
         )
         self.header_mapping = dict(self.headers_to_split_on)
         self.header_tags = [tag for tag, _ in self.headers_to_split_on]
@@ -325,10 +340,7 @@ class HTMLHeaderTextSplitter:
                         yield doc
 
                 # Determine numeric level (h1->1, h2->2, etc.)
-                try:
-                    level = int(tag[1:])
-                except ValueError:
-                    level = 9999
+                level = _header_level(tag)
 
                 # Remove any active headers that are at or deeper than this new level
                 headers_to_remove = [

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -3094,6 +3094,59 @@ def test_html_no_headers_with_multiple_splitters(
         )
 
 
+@pytest.mark.requires("bs4")
+def test_html_header_text_splitter_accepts_non_heading_tags() -> None:
+    """Constructing with a tag outside h1-h6 must not raise.
+
+    The splitting engine assigns such tags a fallback level, so the constructor
+    should accept them and sort them after every numbered heading.
+    """
+    splitter = HTMLHeaderTextSplitter(
+        headers_to_split_on=[("div", "Section"), ("h1", "Header 1")]
+    )
+    assert splitter.headers_to_split_on == [
+        ("h1", "Header 1"),
+        ("div", "Section"),
+    ]
+
+
+@pytest.mark.requires("bs4")
+def test_html_header_text_splitter_splits_on_non_heading_tag() -> None:
+    """A non-heading tag with direct text acts as a split boundary."""
+    splitter = HTMLHeaderTextSplitter(
+        headers_to_split_on=[("h1", "Header 1"), ("div", "Section")]
+    )
+    html = (
+        "<html><body><h1>Intro</h1><div>Section A</div><p>Some text.</p></body></html>"
+    )
+    docs = splitter.split_text(html)
+    assert [(doc.page_content, doc.metadata) for doc in docs] == [
+        ("Intro", {"Header 1": "Intro"}),
+        ("Section A", {"Header 1": "Intro", "Section": "Section A"}),
+        ("Some text.", {"Header 1": "Intro", "Section": "Section A"}),
+    ]
+
+
+@pytest.mark.requires("bs4")
+def test_html_header_text_splitter_non_heading_tag_closed_by_numbered_header() -> None:
+    """A following numbered header closes an active non-heading section."""
+    splitter = HTMLHeaderTextSplitter(
+        headers_to_split_on=[("h1", "Header 1"), ("div", "Section")]
+    )
+    html = (
+        "<html><body><h1>First</h1><div>A</div><p>one</p>"
+        "<h1>Second</h1><p>two</p></body></html>"
+    )
+    docs = splitter.split_text(html)
+    assert [(doc.page_content, doc.metadata) for doc in docs] == [
+        ("First", {"Header 1": "First"}),
+        ("A", {"Header 1": "First", "Section": "A"}),
+        ("one", {"Header 1": "First", "Section": "A"}),
+        ("Second", {"Header 1": "Second"}),
+        ("two", {"Header 1": "Second"}),
+    ]
+
+
 def test_split_text_on_tokens() -> None:
     """Test splitting by tokens per chunk."""
     text = "foo bar baz 123"


### PR DESCRIPTION
## Description

`HTMLHeaderTextSplitter` crashed at construction for any tag outside `h1`-`h6`, even though its splitting engine deliberately supports them:

```python
HTMLHeaderTextSplitter(headers_to_split_on=[("h1", "Header 1"), ("div", "Div")])
# ValueError: invalid literal for int() with base 10: 'iv'
```

The class disagreed with itself: `_generate_documents` assigns non-numeric tags a fallback level of `9999` so a container tag nests under an active `h1` (and is closed by a following `h1`), but `__init__` sorted `headers_to_split_on` with a bare `int(x[0][1:])` and no fallback, raising before any splitting could happen.

This PR extracts the conversion into a shared `_header_level` helper used by both call sites. Non-numeric tags now sort after every numbered heading, matching the level the engine already assigns them. Behavior for `h1`-`h6` is unchanged.

Fixes #40341

## Test plan

- Added `test_html_header_text_splitter_accepts_non_heading_tags`: constructing with `("div", "Div")` no longer raises, and the list is sorted with the non-heading tag last. Fails on `master` with `ValueError`.
- Added `test_html_header_text_splitter_splits_on_non_heading_tag`: a `div` with direct text acts as a boundary and lands in the metadata alongside an active `h1`.
- Added `test_html_header_text_splitter_non_heading_tag_closed_by_numbered_header`: a following `h1` closes the active `div` section, matching the level-`9999` semantics.
- Full unit suite: `pytest tests/unit_tests` -> 152 passed, 10 skipped.
- `ruff check`, `ruff format`, and `ty check` pass on the touched files.