### PR TITLE
fix(core): keep quote state in CommaSeparatedListOutputParser streaming

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -40,6 +40,82 @@ def droplastn(
             yield buffer.popleft()
 
 
+def _decode_csv_field(field: str) -> str:
+    """Decode a single raw CSV field using the same dialect as `parse`.
+
+    Args:
+        field: The raw text of one CSV field, without its trailing separator.
+
+    Returns:
+        The decoded field value.
+    """
+    try:
+        reader = csv.reader(
+            StringIO(field), quotechar='"', delimiter=",", skipinitialspace=True
+        )
+        row = next(reader, None)
+    except csv.Error:
+        return field.strip()
+    if not row:
+        return ""
+    return row[0]
+
+
+def _split_complete_csv_fields(text: str) -> tuple[list[str], int]:
+    """Split completed CSV fields out of a raw, possibly partial CSV stream.
+
+    Scans `text` with quote awareness and returns the decoded fields that are
+    already terminated by a separator (a `,` or a record boundary outside
+    quotes), together with the index in `text` where the raw remainder (the
+    trailing field, which may still be incomplete) starts. Keeping the
+    remainder raw preserves quote state across streaming chunks, unlike
+    buffering the already-decoded last field.
+
+    Args:
+        text: The raw CSV text accumulated so far.
+
+    Returns:
+        A tuple of the decoded complete fields and the start index of the raw
+        remainder (`len(text)` when every field is complete).
+    """
+    fields: list[str] = []
+    start = 0
+    i = 0
+    n = len(text)
+    in_quotes = False
+    while i < n:
+        char = text[i]
+        if in_quotes:
+            if char == '"':
+                if i + 1 < n and text[i + 1] == '"':
+                    # Escaped quote inside a quoted field.
+                    i += 2
+                    continue
+                in_quotes = False
+            i += 1
+        elif char == '"':
+            in_quotes = True
+            i += 1
+        elif char == ",":
+            fields.append(_decode_csv_field(text[start:i]))
+            start = i + 1
+            i += 1
+        elif char in ("\r", "\n"):
+            if char == "\r" and i + 1 == n:
+                # A trailing `\r` may be the first half of a `\r\n` pair that
+                # arrives with the next chunk; do not split on it yet.
+                break
+            fields.append(_decode_csv_field(text[start:i]))
+            start = i + 1
+            if char == "\r" and i + 1 < n and text[i + 1] == "\n":
+                i += 2
+            else:
+                i += 1
+        else:
+            i += 1
+    return fields, start
+
+
 class ListOutputParser(BaseTransformOutputParser[list[str]]):
     """Parse the output of a model to a list."""
 
@@ -179,6 +255,56 @@ class CommaSeparatedListOutputParser(ListOutputParser):
         except csv.Error:
             # Keep old logic for backup
             return [part.strip() for part in text.split(",")]
+
+    @override
+    def _transform(self, input: Iterator[str | BaseMessage]) -> Iterator[list[str]]:
+        buffer = ""
+        for chunk in input:
+            if isinstance(chunk, BaseMessage):
+                # Extract text
+                chunk_content = chunk.content
+                if not isinstance(chunk_content, str):
+                    continue
+                buffer += chunk_content
+            else:
+                # Add current chunk to buffer
+                buffer += chunk
+            # Yield only fields already terminated by a separator, keeping the
+            # raw remainder (quote state intact) as the next buffer
+            fields, done_idx = _split_complete_csv_fields(buffer)
+            if done_idx:
+                for field in fields:
+                    yield [field]
+                buffer = buffer[done_idx:]
+        # Yield the last part
+        for part in self.parse(buffer):
+            yield [part]
+
+    @override
+    async def _atransform(
+        self, input: AsyncIterator[str | BaseMessage]
+    ) -> AsyncIterator[list[str]]:
+        buffer = ""
+        async for chunk in input:
+            if isinstance(chunk, BaseMessage):
+                # Extract text
+                chunk_content = chunk.content
+                if not isinstance(chunk_content, str):
+                    continue
+                buffer += chunk_content
+            else:
+                # Add current chunk to buffer
+                buffer += chunk
+            # Yield only fields already terminated by a separator, keeping the
+            # raw remainder (quote state intact) as the next buffer
+            fields, done_idx = _split_complete_csv_fields(buffer)
+            if done_idx:
+                for field in fields:
+                    yield [field]
+                buffer = buffer[done_idx:]
+        # Yield the last part
+        for part in self.parse(buffer):
+            yield [part]
 
     @property
     def _type(self) -> str:

--- a/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
@@ -1,6 +1,8 @@
 from collections.abc import AsyncIterator, Iterable
 from typing import TypeVar
 
+import pytest
+
 from langchain_core.output_parsers.list import (
     CommaSeparatedListOutputParser,
     MarkdownListOutputParser,
@@ -87,6 +89,66 @@ def test_multiple_items_with_comma() -> None:
         parser.transform(" " + t if i > 0 else t for i, t in enumerate(text.split(" ")))
     ) == [[a] for a in expected]
     assert list(parser.transform(iter([text]))) == [[a] for a in expected]
+
+
+def test_streaming_quoted_field_split_across_chunks() -> None:
+    """A quoted field containing a comma must stream as one field.
+
+    Streaming chunked CSV text must produce the same fields as parsing the
+    concatenated text, even when a chunk boundary falls inside a quoted field.
+    """
+    parser = CommaSeparatedListOutputParser()
+    chunks = ['alpha, "beta,', ' gamma", delta']
+    text = "".join(chunks)
+    expected = ["alpha", "beta, gamma", "delta"]
+
+    assert parser.parse(text) == expected
+    assert list(parser.transform(iter(chunks))) == [[a] for a in expected]
+
+
+def test_streaming_quoted_field_with_escaped_quotes() -> None:
+    """Doubled quotes inside a quoted field survive chunk boundaries."""
+    parser = CommaSeparatedListOutputParser()
+    chunks = ['a, "say ""hi""', ' now", b']
+    text = "".join(chunks)
+    expected = ["a", 'say "hi" now', "b"]
+
+    assert parser.parse(text) == expected
+    assert list(parser.transform(iter(chunks))) == [[a] for a in expected]
+
+
+def test_streaming_matches_parse_on_newlines() -> None:
+    """Record boundaries in streamed text must match non-streaming parsing."""
+    parser = CommaSeparatedListOutputParser()
+    chunks = ["foo,\nbar", "\nbaz"]
+    text = "".join(chunks)
+
+    expected = parser.parse(text)
+    assert expected == ["foo", "", "bar", "baz"]
+    assert add(parser.transform(iter(chunks))) == expected
+
+
+def test_streaming_yields_complete_fields_incrementally() -> None:
+    """Complete fields are yielded as soon as their separator arrives."""
+    parser = CommaSeparatedListOutputParser()
+    output = parser.transform(iter(["alpha,", '"beta,', ' gamma",', " delta"]))
+
+    assert next(output) == ["alpha"]
+    assert next(output) == ["beta, gamma"]
+    assert next(output) == ["delta"]
+    with pytest.raises(StopIteration):
+        next(output)
+
+
+async def test_streaming_quoted_field_split_across_chunks_async() -> None:
+    """The async streaming path must match the sync path for quoted fields."""
+    parser = CommaSeparatedListOutputParser()
+    chunks = ['alpha, "beta,', ' gamma", delta']
+    expected = ["alpha", "beta, gamma", "delta"]
+
+    assert [a async for a in parser.atransform(aiter_from_iter(chunks))] == [
+        [a] for a in expected
+    ]
 
 
 def test_numbered_list() -> None:


### PR DESCRIPTION
## Description

`CommaSeparatedListOutputParser` streamed quoted CSV fields incorrectly whenever a chunk boundary fell inside a quoted field:

```python
parser = CommaSeparatedListOutputParser()
chunks = ['alpha, "beta,', ' gamma", delta']

parser.invoke("".join(chunks))              # ['alpha', 'beta, gamma', 'delta']
list(parser.transform(iter(chunks)))        # [['alpha'], ['beta'], ['gamma"'], ['delta']]
```

The generic `ListOutputParser` streaming fallback parses the partial buffer, emits all but its last field, and stores `parts[-1]` as the next buffer. That value is already CSV-decoded and has lost its opening quote, so subsequent chunks are re-split on the wrong boundaries. The async `atransform` path had the same problem.

This PR overrides streaming in `CommaSeparatedListOutputParser` with a quote-aware scan that yields only fields already terminated by a separator (`,` or a record boundary outside quotes) and buffers the raw remainder verbatim, preserving quote state across chunks. Field decoding uses the same `csv` dialect as `parse` (`quotechar='"'`, `skipinitialspace=True`), so streaming and non-streaming produce identical fields. A trailing `\r` is not treated as a separator until its next chunk arrives, so `\r\n` is never double-counted. Public signatures and dependencies are unchanged; the base-class fallback for `parse_iter`-based subclasses is untouched.

Fixes #40360

## Test plan

- `test_streaming_quoted_field_split_across_chunks`: the issue's repro - streaming now yields `[['alpha'], ['beta, gamma'], ['delta']]`, matching `invoke`.
- `test_streaming_quoted_field_with_escaped_quotes`: doubled quotes (`""`) survive chunk boundaries.
- `test_streaming_matches_parse_on_newlines`: record boundaries stream identically to `parse`.
- `test_streaming_yields_complete_fields_incrementally`: fields are emitted as soon as their separator arrives, before stream end.
- `test_streaming_quoted_field_split_across_chunks_async`: the async path matches the sync path.
- Existing parser tests pass unchanged: `pytest tests/unit_tests/output_parsers` -> 135 passed.
- `ruff check`, `ruff format`, and `mypy` pass on the touched files.