### PR TITLE
fix(core): preserve quoted CSV fields across streaming chunks in CommaSeparatedListOutputParser (#40360)

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -184,6 +184,96 @@ class CommaSeparatedListOutputParser(ListOutputParser):
     def _type(self) -> str:
         return "comma-separated-list"
 
+    @override
+    def _transform(self, input: Iterator[str | BaseMessage]) -> Iterator[list[str]]:
+        buffer = ""
+        for chunk in input:
+            if isinstance(chunk, BaseMessage):
+                # Extract text
+                chunk_content = chunk.content
+                if not isinstance(chunk_content, str):
+                    continue
+                buffer += chunk_content
+            else:
+                # Add current chunk to buffer
+                buffer += chunk
+
+            # Find delimiter commas that are outside quotes
+            last_delim_idx = -1
+            in_quotes = False
+            i = 0
+            n = len(buffer)
+            while i < n:
+                char = buffer[i]
+                if char == '"':
+                    if in_quotes:
+                        if i + 1 < n and buffer[i + 1] == '"':
+                            i += 1
+                        else:
+                            in_quotes = False
+                    else:
+                        in_quotes = True
+                elif char == ',' and not in_quotes:
+                    last_delim_idx = i
+                i += 1
+
+            if last_delim_idx != -1:
+                complete_chunk = buffer[:last_delim_idx]
+                buffer = buffer[last_delim_idx + 1 :]
+                for part in self.parse(complete_chunk):
+                    yield [part]
+
+        # Yield any remaining part in buffer
+        if buffer:
+            for part in self.parse(buffer):
+                yield [part]
+
+    @override
+    async def _atransform(
+        self, input: AsyncIterator[str | BaseMessage]
+    ) -> AsyncIterator[list[str]]:
+        buffer = ""
+        async for chunk in input:
+            if isinstance(chunk, BaseMessage):
+                # Extract text
+                chunk_content = chunk.content
+                if not isinstance(chunk_content, str):
+                    continue
+                buffer += chunk_content
+            else:
+                # Add current chunk to buffer
+                buffer += chunk
+
+            # Find delimiter commas that are outside quotes
+            last_delim_idx = -1
+            in_quotes = False
+            i = 0
+            n = len(buffer)
+            while i < n:
+                char = buffer[i]
+                if char == '"':
+                    if in_quotes:
+                        if i + 1 < n and buffer[i + 1] == '"':
+                            i += 1
+                        else:
+                            in_quotes = False
+                    else:
+                        in_quotes = True
+                elif char == ',' and not in_quotes:
+                    last_delim_idx = i
+                i += 1
+
+            if last_delim_idx != -1:
+                complete_chunk = buffer[:last_delim_idx]
+                buffer = buffer[last_delim_idx + 1 :]
+                for part in self.parse(complete_chunk):
+                    yield [part]
+
+        # Yield any remaining part in buffer
+        if buffer:
+            for part in self.parse(buffer):
+                yield [part]
+
 
 class NumberedListOutputParser(ListOutputParser):
     """Parse a numbered list."""

--- a/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
@@ -89,6 +89,20 @@ def test_multiple_items_with_comma() -> None:
     assert list(parser.transform(iter([text]))) == [[a] for a in expected]
 
 
+def test_streaming_quoted_fields_across_chunks() -> None:
+    parser = CommaSeparatedListOutputParser()
+    chunks = ['item0, "foo, ', 'foo2", "bar, baz", qux']
+    expected = ["item0", "foo, foo2", "bar, baz", "qux"]
+    assert list(parser.transform(iter(chunks))) == [[a] for a in expected]
+
+
+def test_streaming_escaped_quotes_across_chunks() -> None:
+    parser = CommaSeparatedListOutputParser()
+    chunks = ['"foo""bar, ', 'baz", qux']
+    expected = ['foo"bar, baz', "qux"]
+    assert list(parser.transform(iter(chunks))) == [[a] for a in expected]
+
+
 def test_numbered_list() -> None:
     parser = NumberedListOutputParser()
     text1 = (
@@ -224,6 +238,44 @@ async def test_multiple_items_async() -> None:
         )
     ] == [[a] for a in expected]
     assert [a async for a in parser.atransform(aiter_from_iter([text]))] == [
+        [a] for a in expected
+    ]
+
+
+async def test_multiple_items_with_comma_async() -> None:
+    parser = CommaSeparatedListOutputParser()
+    text = '"foo, foo2",bar,baz'
+    expected = ["foo, foo2", "bar", "baz"]
+
+    assert await parser.aparse(text) == expected
+    assert await aadd(parser.atransform(aiter_from_iter(t for t in text))) == expected
+    assert [a async for a in parser.atransform(aiter_from_iter(t for t in text))] == [
+        [a] for a in expected
+    ]
+    assert [
+        a
+        async for a in parser.atransform(
+            aiter_from_iter(t for t in text.splitlines(keepends=True))
+        )
+    ] == [[a] for a in expected]
+    assert [
+        a
+        async for a in parser.atransform(
+            aiter_from_iter(
+                " " + t if i > 0 else t for i, t in enumerate(text.split(" "))
+            )
+        )
+    ] == [[a] for a in expected]
+    assert [a async for a in parser.atransform(aiter_from_iter([text]))] == [
+        [a] for a in expected
+    ]
+
+
+async def test_streaming_quoted_fields_across_chunks_async() -> None:
+    parser = CommaSeparatedListOutputParser()
+    chunks = ['item0, "foo, ', 'foo2", "bar, baz", qux']
+    expected = ["item0", "foo, foo2", "bar, baz", "qux"]
+    assert [a async for a in parser.atransform(aiter_from_iter(chunks))] == [
         [a] for a in expected
     ]
 


### PR DESCRIPTION
### Summary
Fixes #40360.

When streaming tokens with `CommaSeparatedListOutputParser`, previously `ListOutputParser._transform` / `_atransform` fell back to calling `self.parse(buffer)` and setting `buffer = parts[-1]`. If a streaming chunk boundary split across an unclosed quoted CSV field containing commas (e.g. `item0, "foo, ` followed by `foo2", bar`), `self.parse` decoded the trailing field into raw text (stripping the opening quote) and assigned it to the buffer. The subsequent chunk then failed to parse as a single quoted field and was prematurely split at the comma.

### Changes
- Implemented `_transform` and `_atransform` in `CommaSeparatedListOutputParser` with quote-aware streaming delimiter boundary tracking.
- Slices and parses only complete delimited fields, leaving unclosed/trailing raw text in the buffer with quotes intact across streaming chunks.
- Added comprehensive unit tests for sync and async streaming of quoted CSV fields and escaped quotes across chunk boundaries.
