### PR TITLE
feat(core): support metadata-only updates in index()

### DIFF
--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -172,6 +172,44 @@ def _calculate_hash(
     raise ValueError(msg)
 
 
+def _get_document_hashes(
+    document: Document,
+    *,
+    key_encoder: Callable[[Document], str]
+    | Literal["sha1", "sha256", "sha512", "blake2b"],
+) -> tuple[str, str, str]:
+    """Calculate (content_hash, metadata_hash, combined_hash) of the document.
+
+    Args:
+        document: Document to hash.
+        key_encoder: Hashing algorithm to use for hashing the document.
+
+    Raises:
+        ValueError: If the metadata cannot be serialized using json.
+
+    Returns:
+        Tuple of (content_hash, metadata_hash, combined_hash).
+    """
+    metadata: dict[str, Any] = dict(document.metadata or {})
+
+    if callable(key_encoder):
+        hash_ = key_encoder(document)
+        return hash_, "", hash_
+
+    content_hash = _calculate_hash(document.page_content, algorithm=key_encoder)
+    try:
+        serialized_meta = json.dumps(metadata, sort_keys=True)
+    except Exception as e:
+        msg = (
+            f"Failed to hash metadata: {e}. "
+            f"Please use a dict that can be serialized using json."
+        )
+        raise ValueError(msg) from e
+    metadata_hash = _calculate_hash(serialized_meta, algorithm=key_encoder)
+    combined_hash = _calculate_hash(content_hash + metadata_hash, algorithm=key_encoder)
+    return content_hash, metadata_hash, combined_hash
+
+
 def _get_document_with_hash(
     document: Document,
     *,
@@ -203,28 +241,11 @@ def _get_document_with_hash(
     Returns:
         Document with a unique identifier based on the hash of the content and metadata.
     """
-    metadata: dict[str, Any] = dict(document.metadata or {})
-
-    if callable(key_encoder):
-        # If key_encoder is a callable, we use it to generate the hash.
-        hash_ = key_encoder(document)
-    else:
-        # The hashes are calculated separate for the content and the metadata.
-        content_hash = _calculate_hash(document.page_content, algorithm=key_encoder)
-        try:
-            serialized_meta = json.dumps(metadata, sort_keys=True)
-        except Exception as e:
-            msg = (
-                f"Failed to hash metadata: {e}. "
-                f"Please use a dict that can be serialized using json."
-            )
-            raise ValueError(msg) from e
-        metadata_hash = _calculate_hash(serialized_meta, algorithm=key_encoder)
-        hash_ = _calculate_hash(content_hash + metadata_hash, algorithm=key_encoder)
+    _, _, combined_hash = _get_document_hashes(document, key_encoder=key_encoder)
 
     return Document(
         # Assign a unique identifier based on the hash.
-        id=hash_,
+        id=combined_hash,
         page_content=document.page_content,
         metadata=document.metadata,
     )
@@ -306,6 +327,7 @@ def index(
     key_encoder: Literal["sha1", "sha256", "sha512", "blake2b"]
     | Callable[[Document], str] = "sha1",
     upsert_kwargs: dict[str, Any] | None = None,
+    metadata_update: bool = False,
 ) -> IndexingResult:
     """Index data from the loader into the vector store.
 
@@ -388,6 +410,11 @@ def index(
             For example, you can use this to specify a custom vector_field:
             upsert_kwargs={"vector_field": "embedding"}
             !!! version-added "Added in `langchain-core` 0.3.10"
+        metadata_update: If True, documents whose content is unchanged will have
+            their metadata updated in-place without re-embedding or re-upserting
+            vectors. Documents with unchanged content and metadata are skipped.
+            Defaults to False.
+            !!! version-added "Added in `langchain-core` 1.6.3"
 
     Returns:
         Indexing result which contains information about how many documents
@@ -440,8 +467,26 @@ def index(
             # implementation which just raises a NotImplementedError
             msg = "Vectorstore has not implemented the delete method"
             raise ValueError(msg)
+
+        if (
+            metadata_update
+            and type(destination).update_metadata == VectorStore.update_metadata
+        ):
+            msg = (
+                f"Vectorstore {destination} has not implemented "
+                "the update_metadata method required when metadata_update=True."
+            )
+            raise ValueError(msg)
     elif isinstance(destination, DocumentIndex):
-        pass
+        if (
+            metadata_update
+            and type(destination).update_metadata == DocumentIndex.update_metadata
+        ):
+            msg = (
+                f"DocumentIndex {destination} has not implemented "
+                "the update_metadata method required when metadata_update=True."
+            )
+            raise ValueError(msg)
     else:
         msg = (  # type: ignore[unreachable]
             f"Vectorstore should be either a VectorStore or a DocumentIndex. "
@@ -471,90 +516,236 @@ def index(
         # Track original batch size before deduplication
         original_batch_size = len(doc_batch)
 
-        hashed_docs = list(
-            _deduplicate_in_order(
-                [
-                    _get_document_with_hash(doc, key_encoder=key_encoder)
-                    for doc in doc_batch
-                ]
+        if not metadata_update:
+            hashed_docs = list(
+                _deduplicate_in_order(
+                    [
+                        _get_document_with_hash(doc, key_encoder=key_encoder)
+                        for doc in doc_batch
+                    ]
+                )
             )
-        )
-        # Count documents removed by within-batch deduplication
-        num_skipped += original_batch_size - len(hashed_docs)
+            # Count documents removed by within-batch deduplication
+            num_skipped += original_batch_size - len(hashed_docs)
 
-        source_ids: Sequence[str | None] = [
-            source_id_assigner(hashed_doc) for hashed_doc in hashed_docs
-        ]
+            source_ids: Sequence[str | None] = [
+                source_id_assigner(hashed_doc) for hashed_doc in hashed_docs
+            ]
 
-        if cleanup in {"incremental", "scoped_full"}:
-            # Source IDs are required.
-            for source_id, hashed_doc in zip(source_ids, hashed_docs, strict=False):
-                if source_id is None:
-                    msg = (
-                        f"Source IDs are required when cleanup mode is "
-                        f"incremental or scoped_full. "
-                        f"Document that starts with "
-                        f"content: {hashed_doc.page_content[:100]} "
-                        f"was not assigned as source id."
+            if cleanup in {"incremental", "scoped_full"}:
+                # Source IDs are required.
+                for source_id, hashed_doc in zip(source_ids, hashed_docs, strict=False):
+                    if source_id is None:
+                        msg = (
+                            f"Source IDs are required when cleanup mode is "
+                            f"incremental or scoped_full. "
+                            f"Document that starts with "
+                            f"content: {hashed_doc.page_content[:100]} "
+                            f"was not assigned as source id."
+                        )
+                        raise ValueError(msg)
+                    if cleanup == "scoped_full":
+                        scoped_full_cleanup_source_ids.add(source_id)
+                # Source IDs cannot be None after for loop above.
+                source_ids = cast("Sequence[str]", source_ids)
+
+            exists_batch = record_manager.exists(
+                cast("Sequence[str]", [doc.id for doc in hashed_docs])
+            )
+
+            # Filter out documents that already exist in the record store.
+            uids = []
+            docs_to_index = []
+            uids_to_refresh = []
+            seen_docs: set[str] = set()
+            for hashed_doc, doc_exists in zip(hashed_docs, exists_batch, strict=False):
+                hashed_id = cast("str", hashed_doc.id)
+                if doc_exists:
+                    if force_update:
+                        seen_docs.add(hashed_id)
+                    else:
+                        uids_to_refresh.append(hashed_id)
+                        continue
+                uids.append(hashed_id)
+                docs_to_index.append(hashed_doc)
+
+            # Update refresh timestamp
+            if uids_to_refresh:
+                record_manager.update(uids_to_refresh, time_at_least=index_start_dt)
+                num_skipped += len(uids_to_refresh)
+
+            # Be pessimistic and assume that all vector store write will fail.
+            # First write to vector store
+            if docs_to_index:
+                if isinstance(destination, VectorStore):
+                    destination.add_documents(
+                        docs_to_index,
+                        ids=uids,
+                        batch_size=batch_size,
+                        **(upsert_kwargs or {}),
                     )
-                    raise ValueError(msg)
-                if cleanup == "scoped_full":
-                    scoped_full_cleanup_source_ids.add(source_id)
-            # Source IDs cannot be None after for loop above.
-            source_ids = cast("Sequence[str]", source_ids)
+                elif isinstance(destination, DocumentIndex):
+                    destination.upsert(
+                        docs_to_index,
+                        **(upsert_kwargs or {}),
+                    )
 
-        exists_batch = record_manager.exists(
-            cast("Sequence[str]", [doc.id for doc in hashed_docs])
-        )
+                num_added += len(docs_to_index) - len(seen_docs)
+                num_updated += len(seen_docs)
 
-        # Filter out documents that already exist in the record store.
-        uids = []
-        docs_to_index = []
-        uids_to_refresh = []
-        seen_docs: set[str] = set()
-        for hashed_doc, doc_exists in zip(hashed_docs, exists_batch, strict=False):
-            hashed_id = cast("str", hashed_doc.id)
-            if doc_exists:
-                if force_update:
-                    seen_docs.add(hashed_id)
+            # And only then update the record store.
+            # Update ALL records, even if they already exist since we want to refresh
+            # their timestamp.
+            record_manager.update(
+                cast("Sequence[str]", [doc.id for doc in hashed_docs]),
+                group_ids=source_ids,
+                time_at_least=index_start_dt,
+            )
+        else:
+            # Prepare documents with stable IDs and compute metadata hashes
+            batch_docs: list[Document] = []
+            batch_meta_hashes: list[str] = []
+            for doc in doc_batch:
+                s_id = source_id_assigner(doc)
+                c_hash, m_hash, _ = _get_document_hashes(doc, key_encoder=key_encoder)
+                if doc.id is not None:
+                    doc_id = doc.id
+                elif s_id is not None:
+                    doc_id = _calculate_hash(f"{s_id}:{c_hash}", algorithm=key_encoder)
                 else:
-                    uids_to_refresh.append(hashed_id)
-                    continue
-            uids.append(hashed_id)
-            docs_to_index.append(hashed_doc)
+                    doc_id = c_hash
 
-        # Update refresh timestamp
-        if uids_to_refresh:
-            record_manager.update(uids_to_refresh, time_at_least=index_start_dt)
-            num_skipped += len(uids_to_refresh)
-
-        # Be pessimistic and assume that all vector store write will fail.
-        # First write to vector store
-        if docs_to_index:
-            if isinstance(destination, VectorStore):
-                destination.add_documents(
-                    docs_to_index,
-                    ids=uids,
-                    batch_size=batch_size,
-                    **(upsert_kwargs or {}),
+                batch_docs.append(
+                    Document(
+                        id=doc_id,
+                        page_content=doc.page_content,
+                        metadata=doc.metadata,
+                    )
                 )
-            elif isinstance(destination, DocumentIndex):
-                destination.upsert(
-                    docs_to_index,
-                    **(upsert_kwargs or {}),
+                batch_meta_hashes.append(m_hash)
+
+            # Deduplicate in order by doc.id, tracking metadata hash
+            seen_ids: set[str] = set()
+            hashed_docs = []
+            meta_hashes: dict[str, str] = {}
+            for doc, m_hash in zip(batch_docs, batch_meta_hashes, strict=False):
+                doc_id = cast("str", doc.id)
+                if doc_id not in seen_ids:
+                    seen_ids.add(doc_id)
+                    hashed_docs.append(doc)
+                    meta_hashes[doc_id] = m_hash
+
+            num_skipped += original_batch_size - len(hashed_docs)
+
+            source_ids = [source_id_assigner(doc) for doc in hashed_docs]
+
+            if cleanup in {"incremental", "scoped_full"}:
+                for source_id, hashed_doc in zip(source_ids, hashed_docs, strict=False):
+                    if source_id is None:
+                        msg = (
+                            f"Source IDs are required when cleanup mode is "
+                            f"incremental or scoped_full. "
+                            f"Document that starts with "
+                            f"content: {hashed_doc.page_content[:100]} "
+                            f"was not assigned as source id."
+                        )
+                        raise ValueError(msg)
+                    if cleanup == "scoped_full":
+                        scoped_full_cleanup_source_ids.add(source_id)
+                source_ids = cast("Sequence[str]", source_ids)
+
+            batch_ids = [cast("str", doc.id) for doc in hashed_docs]
+            exists_batch = record_manager.exists(batch_ids)
+
+            # Check which existing documents have matching metadata
+            existing_ids = [
+                doc_id
+                for doc_id, exists in zip(batch_ids, exists_batch, strict=False)
+                if exists
+            ]
+            existing_meta_hashes: dict[str, str | None] = (
+                dict(
+                    zip(
+                        existing_ids,
+                        record_manager.get_metadata_hashes(existing_ids),
+                        strict=False,
+                    )
                 )
+                if existing_ids and not force_update
+                else {}
+            )
 
-            num_added += len(docs_to_index) - len(seen_docs)
-            num_updated += len(seen_docs)
+            uids = []
+            docs_to_index = []
+            uids_to_refresh = []
+            uids_to_update_metadata: list[str] = []
+            metadatas_to_update: list[dict[str, Any]] = []
+            seen_docs = set()
 
-        # And only then update the record store.
-        # Update ALL records, even if they already exist since we want to refresh
-        # their timestamp.
-        record_manager.update(
-            cast("Sequence[str]", [doc.id for doc in hashed_docs]),
-            group_ids=source_ids,
-            time_at_least=index_start_dt,
-        )
+            for hashed_doc, doc_exists in zip(hashed_docs, exists_batch, strict=False):
+                hashed_id = cast("str", hashed_doc.id)
+                if doc_exists:
+                    if force_update:
+                        seen_docs.add(hashed_id)
+                    else:
+                        stored_m_hash = existing_meta_hashes.get(hashed_id)
+                        curr_m_hash = meta_hashes[hashed_id]
+                        if stored_m_hash is not None and stored_m_hash == curr_m_hash:
+                            uids_to_refresh.append(hashed_id)
+                            continue
+                        uids_to_update_metadata.append(hashed_id)
+                        metadatas_to_update.append(hashed_doc.metadata)
+                        continue
+                uids.append(hashed_id)
+                docs_to_index.append(hashed_doc)
+
+            # Update refresh timestamp
+            if uids_to_refresh:
+                record_manager.update(uids_to_refresh, time_at_least=index_start_dt)
+                num_skipped += len(uids_to_refresh)
+
+            # Perform in-place metadata updates without re-embedding
+            if uids_to_update_metadata:
+                destination.update_metadata(
+                    uids_to_update_metadata,
+                    metadatas_to_update,
+                )
+                meta_hashes_to_update = [
+                    meta_hashes[uid] for uid in uids_to_update_metadata
+                ]
+                record_manager.update(
+                    uids_to_update_metadata,
+                    time_at_least=index_start_dt,
+                    metadata_hashes=meta_hashes_to_update,
+                )
+                num_updated += len(uids_to_update_metadata)
+
+            # First write to vector store
+            if docs_to_index:
+                if isinstance(destination, VectorStore):
+                    destination.add_documents(
+                        docs_to_index,
+                        ids=uids,
+                        batch_size=batch_size,
+                        **(upsert_kwargs or {}),
+                    )
+                elif isinstance(destination, DocumentIndex):
+                    destination.upsert(
+                        docs_to_index,
+                        **(upsert_kwargs or {}),
+                    )
+
+                num_added += len(docs_to_index) - len(seen_docs)
+                num_updated += len(seen_docs)
+
+            # And only then update the record store.
+            batch_m_hashes = [meta_hashes[cast("str", d.id)] for d in hashed_docs]
+            record_manager.update(
+                cast("Sequence[str]", [doc.id for doc in hashed_docs]),
+                group_ids=source_ids,
+                time_at_least=index_start_dt,
+                metadata_hashes=batch_m_hashes,
+            )
 
         # If source IDs are provided, we can do the deletion incrementally!
         if cleanup == "incremental":
@@ -645,6 +836,7 @@ async def aindex(
     key_encoder: Literal["sha1", "sha256", "sha512", "blake2b"]
     | Callable[[Document], str] = "sha1",
     upsert_kwargs: dict[str, Any] | None = None,
+    metadata_update: bool = False,
 ) -> IndexingResult:
     """Async index data from the loader into the vector store.
 
@@ -727,6 +919,11 @@ async def aindex(
             For example, you can use this to specify a custom vector_field:
             upsert_kwargs={"vector_field": "embedding"}
             !!! version-added "Added in `langchain-core` 0.3.10"
+        metadata_update: If True, documents whose content is unchanged will have
+            their metadata updated in-place without re-embedding or re-upserting
+            vectors. Documents with unchanged content and metadata are skipped.
+            Defaults to False.
+            !!! version-added "Added in `langchain-core` 1.6.3"
 
     Returns:
         Indexing result which contains information about how many documents
@@ -765,7 +962,6 @@ async def aindex(
     # If it's a vectorstore, let's check if it has the required methods.
     if isinstance(destination, VectorStore):
         # Check that the Vectorstore has required methods implemented
-        # Check that the Vectorstore has required methods implemented
         methods = ["adelete", "aadd_documents"]
 
         for method in methods:
@@ -783,8 +979,30 @@ async def aindex(
             # methods implementation which just raises a NotImplementedError
             msg = "Vectorstore has not implemented the adelete or delete method"
             raise ValueError(msg)
+
+        if (
+            metadata_update
+            and type(destination).aupdate_metadata == VectorStore.aupdate_metadata
+            and type(destination).update_metadata == VectorStore.update_metadata
+        ):
+            msg = (
+                f"Vectorstore {destination} has not implemented "
+                "the aupdate_metadata or update_metadata method required "
+                "when metadata_update=True."
+            )
+            raise ValueError(msg)
     elif isinstance(destination, DocumentIndex):
-        pass
+        if (
+            metadata_update
+            and type(destination).aupdate_metadata == DocumentIndex.aupdate_metadata
+            and type(destination).update_metadata == DocumentIndex.update_metadata
+        ):
+            msg = (
+                f"DocumentIndex {destination} has not implemented "
+                "the aupdate_metadata or update_metadata method required "
+                "when metadata_update=True."
+            )
+            raise ValueError(msg)
     else:
         msg = (  # type: ignore[unreachable]
             f"Vectorstore should be either a VectorStore or a DocumentIndex. "
@@ -821,89 +1039,234 @@ async def aindex(
         # Track original batch size before deduplication
         original_batch_size = len(doc_batch)
 
-        hashed_docs = list(
-            _deduplicate_in_order(
-                [
-                    _get_document_with_hash(doc, key_encoder=key_encoder)
-                    for doc in doc_batch
-                ]
+        if not metadata_update:
+            hashed_docs = list(
+                _deduplicate_in_order(
+                    [
+                        _get_document_with_hash(doc, key_encoder=key_encoder)
+                        for doc in doc_batch
+                    ]
+                )
             )
-        )
-        # Count documents removed by within-batch deduplication
-        num_skipped += original_batch_size - len(hashed_docs)
+            # Count documents removed by within-batch deduplication
+            num_skipped += original_batch_size - len(hashed_docs)
 
-        source_ids: Sequence[str | None] = [
-            source_id_assigner(doc) for doc in hashed_docs
-        ]
+            source_ids: Sequence[str | None] = [
+                source_id_assigner(doc) for doc in hashed_docs
+            ]
 
-        if cleanup in {"incremental", "scoped_full"}:
-            # If the cleanup mode is incremental, source IDs are required.
-            for source_id, hashed_doc in zip(source_ids, hashed_docs, strict=False):
-                if source_id is None:
-                    msg = (
-                        f"Source IDs are required when cleanup mode is "
-                        f"incremental or scoped_full. "
-                        f"Document that starts with "
-                        f"content: {hashed_doc.page_content[:100]} "
-                        f"was not assigned as source id."
+            if cleanup in {"incremental", "scoped_full"}:
+                # If the cleanup mode is incremental, source IDs are required.
+                for source_id, hashed_doc in zip(source_ids, hashed_docs, strict=False):
+                    if source_id is None:
+                        msg = (
+                            f"Source IDs are required when cleanup mode is "
+                            f"incremental or scoped_full. "
+                            f"Document that starts with "
+                            f"content: {hashed_doc.page_content[:100]} "
+                            f"was not assigned as source id."
+                        )
+                        raise ValueError(msg)
+                    if cleanup == "scoped_full":
+                        scoped_full_cleanup_source_ids.add(source_id)
+                # Source IDs cannot be None after for loop above.
+                source_ids = cast("Sequence[str]", source_ids)
+
+            exists_batch = await record_manager.aexists(
+                cast("Sequence[str]", [doc.id for doc in hashed_docs])
+            )
+
+            # Filter out documents that already exist in the record store.
+            uids: list[str] = []
+            docs_to_index: list[Document] = []
+            uids_to_refresh = []
+            seen_docs: set[str] = set()
+            for hashed_doc, doc_exists in zip(hashed_docs, exists_batch, strict=False):
+                hashed_id = cast("str", hashed_doc.id)
+                if doc_exists:
+                    if force_update:
+                        seen_docs.add(hashed_id)
+                    else:
+                        uids_to_refresh.append(hashed_id)
+                        continue
+                uids.append(hashed_id)
+                docs_to_index.append(hashed_doc)
+
+            if uids_to_refresh:
+                # Must be updated to refresh timestamp.
+                await record_manager.aupdate(
+                    uids_to_refresh, time_at_least=index_start_dt
+                )
+                num_skipped += len(uids_to_refresh)
+
+            # Be pessimistic and assume that all vector store write will fail.
+            # First write to vector store
+            if docs_to_index:
+                if isinstance(destination, VectorStore):
+                    await destination.aadd_documents(
+                        docs_to_index,
+                        ids=uids,
+                        batch_size=batch_size,
+                        **(upsert_kwargs or {}),
                     )
-                    raise ValueError(msg)
-                if cleanup == "scoped_full":
-                    scoped_full_cleanup_source_ids.add(source_id)
-            # Source IDs cannot be None after for loop above.
-            source_ids = cast("Sequence[str]", source_ids)
+                elif isinstance(destination, DocumentIndex):
+                    await destination.aupsert(
+                        docs_to_index,
+                        **(upsert_kwargs or {}),
+                    )
+                num_added += len(docs_to_index) - len(seen_docs)
+                num_updated += len(seen_docs)
 
-        exists_batch = await record_manager.aexists(
-            cast("Sequence[str]", [doc.id for doc in hashed_docs])
-        )
-
-        # Filter out documents that already exist in the record store.
-        uids: list[str] = []
-        docs_to_index: list[Document] = []
-        uids_to_refresh = []
-        seen_docs: set[str] = set()
-        for hashed_doc, doc_exists in zip(hashed_docs, exists_batch, strict=False):
-            hashed_id = cast("str", hashed_doc.id)
-            if doc_exists:
-                if force_update:
-                    seen_docs.add(hashed_id)
+            # And only then update the record store.
+            # Update ALL records, even if they already exist since we want to refresh
+            # their timestamp.
+            await record_manager.aupdate(
+                cast("Sequence[str]", [doc.id for doc in hashed_docs]),
+                group_ids=source_ids,
+                time_at_least=index_start_dt,
+            )
+        else:
+            # Prepare documents with stable IDs and compute metadata hashes
+            batch_docs: list[Document] = []
+            batch_meta_hashes: list[str] = []
+            for doc in doc_batch:
+                s_id = source_id_assigner(doc)
+                c_hash, m_hash, _ = _get_document_hashes(doc, key_encoder=key_encoder)
+                if doc.id is not None:
+                    doc_id = doc.id
+                elif s_id is not None:
+                    doc_id = _calculate_hash(f"{s_id}:{c_hash}", algorithm=key_encoder)
                 else:
-                    uids_to_refresh.append(hashed_id)
-                    continue
-            uids.append(hashed_id)
-            docs_to_index.append(hashed_doc)
+                    doc_id = c_hash
 
-        if uids_to_refresh:
-            # Must be updated to refresh timestamp.
-            await record_manager.aupdate(uids_to_refresh, time_at_least=index_start_dt)
-            num_skipped += len(uids_to_refresh)
-
-        # Be pessimistic and assume that all vector store write will fail.
-        # First write to vector store
-        if docs_to_index:
-            if isinstance(destination, VectorStore):
-                await destination.aadd_documents(
-                    docs_to_index,
-                    ids=uids,
-                    batch_size=batch_size,
-                    **(upsert_kwargs or {}),
+                batch_docs.append(
+                    Document(
+                        id=doc_id,
+                        page_content=doc.page_content,
+                        metadata=doc.metadata,
+                    )
                 )
-            elif isinstance(destination, DocumentIndex):
-                await destination.aupsert(
-                    docs_to_index,
-                    **(upsert_kwargs or {}),
-                )
-            num_added += len(docs_to_index) - len(seen_docs)
-            num_updated += len(seen_docs)
+                batch_meta_hashes.append(m_hash)
 
-        # And only then update the record store.
-        # Update ALL records, even if they already exist since we want to refresh
-        # their timestamp.
-        await record_manager.aupdate(
-            cast("Sequence[str]", [doc.id for doc in hashed_docs]),
-            group_ids=source_ids,
-            time_at_least=index_start_dt,
-        )
+            # Deduplicate in order by doc.id, tracking metadata hash
+            seen_ids: set[str] = set()
+            hashed_docs = []
+            meta_hashes: dict[str, str] = {}
+            for doc, m_hash in zip(batch_docs, batch_meta_hashes, strict=False):
+                doc_id = cast("str", doc.id)
+                if doc_id not in seen_ids:
+                    seen_ids.add(doc_id)
+                    hashed_docs.append(doc)
+                    meta_hashes[doc_id] = m_hash
+
+            num_skipped += original_batch_size - len(hashed_docs)
+
+            source_ids = [source_id_assigner(doc) for doc in hashed_docs]
+
+            if cleanup in {"incremental", "scoped_full"}:
+                for source_id, hashed_doc in zip(source_ids, hashed_docs, strict=False):
+                    if source_id is None:
+                        msg = (
+                            f"Source IDs are required when cleanup mode is "
+                            f"incremental or scoped_full. "
+                            f"Document that starts with "
+                            f"content: {hashed_doc.page_content[:100]} "
+                            f"was not assigned as source id."
+                        )
+                        raise ValueError(msg)
+                    if cleanup == "scoped_full":
+                        scoped_full_cleanup_source_ids.add(source_id)
+                source_ids = cast("Sequence[str]", source_ids)
+
+            batch_ids = [cast("str", doc.id) for doc in hashed_docs]
+            exists_batch = await record_manager.aexists(batch_ids)
+
+            # Check which existing documents have matching metadata
+            existing_ids = [
+                doc_id
+                for doc_id, exists in zip(batch_ids, exists_batch, strict=False)
+                if exists
+            ]
+            existing_meta_hashes: dict[str, str | None] = (
+                dict(
+                    zip(
+                        existing_ids,
+                        await record_manager.aget_metadata_hashes(existing_ids),
+                        strict=False,
+                    )
+                )
+                if existing_ids and not force_update
+                else {}
+            )
+
+            uids = []
+            docs_to_index = []
+            uids_to_refresh = []
+            uids_to_update_metadata: list[str] = []
+            metadatas_to_update: list[dict[str, Any]] = []
+            seen_docs = set()
+
+            for hashed_doc, doc_exists in zip(hashed_docs, exists_batch, strict=False):
+                hashed_id = cast("str", hashed_doc.id)
+                if doc_exists:
+                    if force_update:
+                        seen_docs.add(hashed_id)
+                    else:
+                        stored_m_hash = existing_meta_hashes.get(hashed_id)
+                        curr_m_hash = meta_hashes[hashed_id]
+                        if stored_m_hash is not None and stored_m_hash == curr_m_hash:
+                            uids_to_refresh.append(hashed_id)
+                            continue
+                        uids_to_update_metadata.append(hashed_id)
+                        metadatas_to_update.append(hashed_doc.metadata)
+                        continue
+                uids.append(hashed_id)
+                docs_to_index.append(hashed_doc)
+
+            if uids_to_refresh:
+                await record_manager.aupdate(
+                    uids_to_refresh, time_at_least=index_start_dt
+                )
+                num_skipped += len(uids_to_refresh)
+
+            if uids_to_update_metadata:
+                await destination.aupdate_metadata(
+                    uids_to_update_metadata,
+                    metadatas_to_update,
+                )
+                meta_hashes_to_update = [
+                    meta_hashes[uid] for uid in uids_to_update_metadata
+                ]
+                await record_manager.aupdate(
+                    uids_to_update_metadata,
+                    time_at_least=index_start_dt,
+                    metadata_hashes=meta_hashes_to_update,
+                )
+                num_updated += len(uids_to_update_metadata)
+
+            if docs_to_index:
+                if isinstance(destination, VectorStore):
+                    await destination.aadd_documents(
+                        docs_to_index,
+                        ids=uids,
+                        batch_size=batch_size,
+                        **(upsert_kwargs or {}),
+                    )
+                elif isinstance(destination, DocumentIndex):
+                    await destination.aupsert(
+                        docs_to_index,
+                        **(upsert_kwargs or {}),
+                    )
+                num_added += len(docs_to_index) - len(seen_docs)
+                num_updated += len(seen_docs)
+
+            batch_m_hashes = [meta_hashes[cast("str", d.id)] for d in hashed_docs]
+            await record_manager.aupdate(
+                cast("Sequence[str]", [doc.id for doc in hashed_docs]),
+                group_ids=source_ids,
+                time_at_least=index_start_dt,
+                metadata_hashes=batch_m_hashes,
+            )
 
         # If source IDs are provided, we can do the deletion incrementally!
 

--- a/libs/core/langchain_core/indexing/base.py
+++ b/libs/core/langchain_core/indexing/base.py
@@ -102,6 +102,7 @@ class RecordManager(ABC):
         *,
         group_ids: Sequence[str | None] | None = None,
         time_at_least: float | None = None,
+        metadata_hashes: Sequence[str | None] | None = None,
     ) -> None:
         """Upsert records into the database.
 
@@ -118,9 +119,13 @@ class RecordManager(ABC):
 
                 This is meant to help prevent time-drift issues since
                 time may not be monotonically increasing!
+            metadata_hashes: Optional list of metadata hashes
+                corresponding to the keys.
 
         Raises:
             ValueError: If the length of keys doesn't match the length of group_ids.
+            ValueError: If the length of keys doesn't match the length of
+                metadata_hashes.
         """
 
     @abstractmethod
@@ -130,6 +135,7 @@ class RecordManager(ABC):
         *,
         group_ids: Sequence[str | None] | None = None,
         time_at_least: float | None = None,
+        metadata_hashes: Sequence[str | None] | None = None,
     ) -> None:
         """Asynchronously upsert records into the database.
 
@@ -146,10 +152,36 @@ class RecordManager(ABC):
 
                 This is meant to help prevent time-drift issues since
                 time may not be monotonically increasing!
+            metadata_hashes: Optional list of metadata hashes
+                corresponding to the keys.
 
         Raises:
             ValueError: If the length of keys doesn't match the length of group_ids.
+            ValueError: If the length of keys doesn't match the length of
+                metadata_hashes.
         """
+
+    def get_metadata_hashes(self, keys: Sequence[str]) -> list[str | None]:
+        """Get metadata hashes for the provided keys.
+
+        Args:
+            keys: A list of keys to check.
+
+        Returns:
+            A list of metadata hashes (or None if not found or unsupported).
+        """
+        return [None] * len(keys)
+
+    async def aget_metadata_hashes(self, keys: Sequence[str]) -> list[str | None]:
+        """Asynchronously get metadata hashes for the provided keys.
+
+        Args:
+            keys: A list of keys to check.
+
+        Returns:
+            A list of metadata hashes (or None if not found or unsupported).
+        """
+        return self.get_metadata_hashes(keys)
 
     @abstractmethod
     def exists(self, keys: Sequence[str]) -> list[bool]:
@@ -232,9 +264,10 @@ class RecordManager(ABC):
         """
 
 
-class _Record(TypedDict):
+class _Record(TypedDict, total=False):
     group_id: str | None
     updated_at: float
+    metadata_hash: str | None
 
 
 class InMemoryRecordManager(RecordManager):
@@ -248,9 +281,10 @@ class InMemoryRecordManager(RecordManager):
         """
         super().__init__(namespace)
         # Each key points to a dictionary
-        # of {'group_id': group_id, 'updated_at': timestamp}
+        # of {'group_id': group_id, 'updated_at': timestamp, 'metadata_hash': ...}
         self.records: dict[str, _Record] = {}
         self.namespace = namespace
+        self._last_time: float = 0.0
 
     def create_schema(self) -> None:
         """In-memory schema creation is simply ensuring the structure is initialized."""
@@ -260,7 +294,11 @@ class InMemoryRecordManager(RecordManager):
 
     @override
     def get_time(self) -> float:
-        return time.time()
+        current_time = time.time()
+        if current_time <= self._last_time:
+            current_time = self._last_time + 1e-6
+        self._last_time = current_time
+        return current_time
 
     @override
     async def aget_time(self) -> float:
@@ -272,6 +310,7 @@ class InMemoryRecordManager(RecordManager):
         *,
         group_ids: Sequence[str | None] | None = None,
         time_at_least: float | None = None,
+        metadata_hashes: Sequence[str | None] | None = None,
     ) -> None:
         """Upsert records into the database.
 
@@ -287,21 +326,40 @@ class InMemoryRecordManager(RecordManager):
                 raise an error.
                 This is meant to help prevent time-drift issues since
                 time may not be monotonically increasing!
+            metadata_hashes: Optional list of metadata hashes corresponding to the keys.
 
         Raises:
             ValueError: If the length of keys doesn't match the length of group
                 ids.
+            ValueError: If the length of keys doesn't match the length of metadata
+                hashes.
             ValueError: If time_at_least is in the future.
         """
         if group_ids and len(keys) != len(group_ids):
             msg = "Length of keys must match length of group_ids"
             raise ValueError(msg)
+        if metadata_hashes and len(keys) != len(metadata_hashes):
+            msg = "Length of keys must match length of metadata_hashes"
+            raise ValueError(msg)
         for index, key in enumerate(keys):
             group_id = group_ids[index] if group_ids else None
+            metadata_hash = metadata_hashes[index] if metadata_hashes else None
             if time_at_least and time_at_least > self.get_time():
                 msg = "time_at_least must be in the past"
                 raise ValueError(msg)
-            self.records[key] = {"group_id": group_id, "updated_at": self.get_time()}
+            existing = self.records.get(key)
+            record: _Record = {
+                "group_id": group_id
+                if group_id is not None
+                else (existing.get("group_id") if existing else None),
+                "updated_at": self.get_time(),
+                "metadata_hash": (
+                    metadata_hash
+                    if metadata_hash is not None
+                    else (existing.get("metadata_hash") if existing else None)
+                ),
+            }
+            self.records[key] = record
 
     async def aupdate(
         self,
@@ -309,6 +367,7 @@ class InMemoryRecordManager(RecordManager):
         *,
         group_ids: Sequence[str | None] | None = None,
         time_at_least: float | None = None,
+        metadata_hashes: Sequence[str | None] | None = None,
     ) -> None:
         """Async upsert records into the database.
 
@@ -324,8 +383,24 @@ class InMemoryRecordManager(RecordManager):
                 raise an error.
                 This is meant to help prevent time-drift issues since
                 time may not be monotonically increasing!
+            metadata_hashes: Optional list of metadata hashes corresponding to the keys.
         """
-        self.update(keys, group_ids=group_ids, time_at_least=time_at_least)
+        self.update(
+            keys,
+            group_ids=group_ids,
+            time_at_least=time_at_least,
+            metadata_hashes=metadata_hashes,
+        )
+
+    @override
+    def get_metadata_hashes(self, keys: Sequence[str]) -> list[str | None]:
+        """Get metadata hashes for the provided keys."""
+        return [self.records.get(key, {}).get("metadata_hash") for key in keys]
+
+    @override
+    async def aget_metadata_hashes(self, keys: Sequence[str]) -> list[str | None]:
+        """Async get metadata hashes for the provided keys."""
+        return self.get_metadata_hashes(keys)
 
     def exists(self, keys: Sequence[str]) -> list[bool]:
         """Check if the provided keys exist in the database.
@@ -558,6 +633,47 @@ class DocumentIndex(BaseRetriever):
             None,
             self.upsert,
             items,
+            **kwargs,
+        )
+
+    def update_metadata(
+        self,
+        ids: Sequence[str],
+        metadatas: Sequence[dict[str, Any]],
+        **kwargs: Any,
+    ) -> None:
+        """Update metadata for documents in the index without re-indexing.
+
+        Args:
+            ids: Sequence of document IDs to update.
+            metadatas: Sequence of metadata dicts corresponding to the IDs.
+            **kwargs: Additional keyword arguments.
+
+        Raises:
+            NotImplementedError: If the document index does not support
+                updating metadata.
+        """
+        msg = f"{self.__class__.__name__} does not support update_metadata."
+        raise NotImplementedError(msg)
+
+    async def aupdate_metadata(
+        self,
+        ids: Sequence[str],
+        metadatas: Sequence[dict[str, Any]],
+        **kwargs: Any,
+    ) -> None:
+        """Async update metadata for documents in the index without re-indexing.
+
+        Args:
+            ids: Sequence of document IDs to update.
+            metadatas: Sequence of metadata dicts corresponding to the IDs.
+            **kwargs: Additional keyword arguments.
+        """
+        return await run_in_executor(
+            None,
+            self.update_metadata,
+            ids,
+            metadatas,
             **kwargs,
         )
 

--- a/libs/core/langchain_core/indexing/in_memory.py
+++ b/libs/core/langchain_core/indexing/in_memory.py
@@ -58,6 +58,35 @@ class InMemoryDocumentIndex(DocumentIndex):
         return UpsertResponse(succeeded=ok_ids, failed=[])
 
     @override
+    def update_metadata(
+        self,
+        ids: Sequence[str],
+        metadatas: Sequence[dict[str, Any]],
+        **kwargs: Any,
+    ) -> None:
+        """Update metadata for documents in the in-memory document index.
+
+        Args:
+            ids: Sequence of document IDs to update.
+            metadatas: Sequence of metadata dicts corresponding to the IDs.
+            **kwargs: Additional keyword arguments.
+
+        Raises:
+            ValueError: If the length of ids doesn't match the length of metadatas.
+        """
+        if len(ids) != len(metadatas):
+            msg = (
+                f"ids and metadatas must have the same length. "
+                f"Got {len(ids)} ids and {len(metadatas)} metadatas."
+            )
+            raise ValueError(msg)
+        for doc_id, metadata in zip(ids, metadatas, strict=False):
+            if doc_id in self.store:
+                self.store[doc_id] = self.store[doc_id].model_copy(
+                    update={"metadata": metadata}
+                )
+
+    @override
     def delete(self, ids: list[str] | None = None, **kwargs: Any) -> DeleteResponse:
         """Delete by IDs.
 

--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -290,6 +290,45 @@ class VectorStore(ABC):
 
         return await run_in_executor(None, self.add_documents, documents, **kwargs)
 
+    def update_metadata(
+        self,
+        ids: Sequence[str],
+        metadatas: Sequence[dict[str, Any]],
+        **kwargs: Any,
+    ) -> None:
+        """Update metadata for documents in the `VectorStore` without re-embedding.
+
+        Args:
+            ids: Sequence of document IDs to update.
+            metadatas: Sequence of metadata dicts corresponding to the IDs.
+            **kwargs: Additional keyword arguments.
+
+        Raises:
+            NotImplementedError: If the `VectorStore` does not support
+                updating metadata.
+        """
+        msg = f"{self.__class__.__name__} does not support update_metadata."
+        raise NotImplementedError(msg)
+
+    async def aupdate_metadata(
+        self,
+        ids: Sequence[str],
+        metadatas: Sequence[dict[str, Any]],
+        **kwargs: Any,
+    ) -> None:
+        """Async update metadata for documents in the `VectorStore`.
+
+        Avoids re-embedding when content is unchanged.
+
+        Args:
+            ids: Sequence of document IDs to update.
+            metadatas: Sequence of metadata dicts corresponding to the IDs.
+            **kwargs: Additional keyword arguments.
+        """
+        return await run_in_executor(
+            None, self.update_metadata, ids, metadatas, **kwargs
+        )
+
     def search(self, query: str, search_type: str, **kwargs: Any) -> list[Document]:
         """Return docs most similar to query using a specified search type.
 

--- a/libs/core/langchain_core/vectorstores/in_memory.py
+++ b/libs/core/langchain_core/vectorstores/in_memory.py
@@ -253,6 +253,33 @@ class InMemoryVectorStore(VectorStore):
         return ids_
 
     @override
+    def update_metadata(
+        self,
+        ids: Sequence[str],
+        metadatas: Sequence[dict[str, Any]],
+        **kwargs: Any,
+    ) -> None:
+        """Update metadata for documents in the in-memory vector store.
+
+        Args:
+            ids: Sequence of document IDs to update.
+            metadatas: Sequence of metadata dicts corresponding to the IDs.
+            **kwargs: Additional keyword arguments.
+
+        Raises:
+            ValueError: If the length of ids doesn't match the length of metadatas.
+        """
+        if len(ids) != len(metadatas):
+            msg = (
+                f"ids and metadatas must have the same length. "
+                f"Got {len(ids)} ids and {len(metadatas)} metadatas."
+            )
+            raise ValueError(msg)
+        for doc_id, metadata in zip(ids, metadatas, strict=False):
+            if doc_id in self.store:
+                self.store[doc_id]["metadata"] = metadata
+
+    @override
     def get_by_ids(self, ids: Sequence[str], /) -> list[Document]:
         """Get documents by their ids.
 

--- a/libs/core/tests/unit_tests/indexing/test_metadata_update.py
+++ b/libs/core/tests/unit_tests/indexing/test_metadata_update.py
@@ -1,0 +1,539 @@
+"""Tests for metadata-only updates in indexing API."""
+
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+from langchain_core.document_loaders.base import BaseLoader
+from langchain_core.documents import Document
+from langchain_core.embeddings import DeterministicFakeEmbedding
+from langchain_core.indexing import InMemoryRecordManager, aindex, index
+from langchain_core.indexing.in_memory import InMemoryDocumentIndex
+from langchain_core.vectorstores import InMemoryVectorStore, VectorStore
+
+
+class MockLoader(BaseLoader):
+    """A loader that returns a predefined list of documents."""
+
+    def __init__(self, documents: list[Document]) -> None:
+        """Initialize with documents."""
+        self.documents = documents
+
+    def lazy_load(self) -> Iterator[Document]:
+        yield from self.documents
+
+    async def alazy_load(self) -> AsyncIterator[Document]:
+        for document in self.documents:
+            yield document
+
+
+@pytest.fixture
+def record_manager() -> InMemoryRecordManager:
+    """Fixture for InMemoryRecordManager."""
+    rm = InMemoryRecordManager(namespace="test_meta")
+    rm.create_schema()
+    return rm
+
+
+@pytest_asyncio.fixture
+async def arecord_manager() -> InMemoryRecordManager:
+    """Async fixture for InMemoryRecordManager."""
+    rm = InMemoryRecordManager(namespace="test_meta_async")
+    await rm.acreate_schema()
+    return rm
+
+
+class CountingEmbedding(DeterministicFakeEmbedding):
+    """Embedding that counts calls to embed_documents."""
+
+    embed_call_count: int = 0
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        self.embed_call_count += len(texts)
+        return super().embed_documents(texts)
+
+
+class UnsupportedVectorStore(VectorStore):
+    """Vector store that implements delete and add_documents but not update_metadata."""
+
+    def delete(
+        self,
+        ids: list[str] | None = None,  # noqa: ARG002
+        **kwargs: Any,  # noqa: ARG002
+    ) -> bool | None:
+        return True
+
+    def add_documents(
+        self,
+        documents: list[Document],  # noqa: ARG002
+        **kwargs: Any,  # noqa: ARG002
+    ) -> list[str]:
+        return []
+
+    @classmethod
+    def from_texts(
+        cls,
+        texts: list[str],  # noqa: ARG003
+        embedding: Any,  # noqa: ARG003
+        metadatas: list[dict] | None = None,  # noqa: ARG003
+        **kwargs: Any,  # noqa: ARG003
+    ) -> "UnsupportedVectorStore":
+        return cls()
+
+    def similarity_search(
+        self,
+        query: str,  # noqa: ARG002
+        k: int = 4,  # noqa: ARG002
+        **kwargs: Any,  # noqa: ARG002
+    ) -> list[Document]:
+        return []
+
+
+@pytest.fixture
+def counting_vector_store() -> tuple[InMemoryVectorStore, CountingEmbedding]:
+    """Vector store with an embedding instance that counts embedding calls."""
+    embedder = CountingEmbedding(size=5)
+    return InMemoryVectorStore(embedder), embedder
+
+
+def test_in_memory_vector_store_update_metadata() -> None:
+    """Test InMemoryVectorStore.update_metadata directly."""
+    embeddings = DeterministicFakeEmbedding(size=5)
+    vs = InMemoryVectorStore(embeddings)
+    doc = Document(page_content="hello", metadata={"tag": "v1"})
+    ids = vs.add_documents([doc], ids=["id1"])
+    assert vs.store["id1"]["metadata"] == {"tag": "v1"}
+    orig_vector = list(vs.store["id1"]["vector"])
+
+    vs.update_metadata(ids, [{"tag": "v2", "new_field": True}])
+    assert vs.store["id1"]["metadata"] == {"tag": "v2", "new_field": True}
+    assert vs.store["id1"]["vector"] == orig_vector
+
+    with pytest.raises(ValueError, match="ids and metadatas must have the same length"):
+        vs.update_metadata(["id1", "id2"], [{"tag": "v3"}])
+
+
+def test_in_memory_document_index_update_metadata() -> None:
+    """Test InMemoryDocumentIndex.update_metadata directly."""
+    idx = InMemoryDocumentIndex()
+    doc = Document(id="id1", page_content="hello", metadata={"tag": "v1"})
+    idx.upsert([doc])
+    assert idx.store["id1"].metadata == {"tag": "v1"}
+
+    idx.update_metadata(["id1"], [{"tag": "v2"}])
+    assert idx.store["id1"].metadata == {"tag": "v2"}
+    assert idx.store["id1"].page_content == "hello"
+
+    with pytest.raises(ValueError, match="ids and metadatas must have the same length"):
+        idx.update_metadata(["id1"], [{"a": 1}, {"b": 2}])
+
+
+def test_index_metadata_update_avoid_reembedding(
+    record_manager: InMemoryRecordManager,
+    counting_vector_store: tuple[InMemoryVectorStore, CountingEmbedding],
+) -> None:
+    """Test that metadata_update=True updates metadata without re-embedding."""
+    vs, embedder = counting_vector_store
+    docs = [
+        Document(page_content="Document 1", metadata={"source": "1", "version": 1}),
+        Document(page_content="Document 2", metadata={"source": "2", "version": 1}),
+    ]
+
+    # First indexing: 2 documents added, embeddings calculated
+    res1 = index(
+        docs,
+        record_manager,
+        vs,
+        cleanup="incremental",
+        source_id_key="source",
+        metadata_update=True,
+    )
+    assert res1 == {
+        "num_added": 2,
+        "num_updated": 0,
+        "num_skipped": 0,
+        "num_deleted": 0,
+    }
+    assert embedder.embed_call_count == 2
+
+    # Second indexing: identical docs -> both skipped, 0 embeddings
+    res2 = index(
+        docs,
+        record_manager,
+        vs,
+        cleanup="incremental",
+        source_id_key="source",
+        metadata_update=True,
+    )
+    assert res2 == {
+        "num_added": 0,
+        "num_updated": 0,
+        "num_skipped": 2,
+        "num_deleted": 0,
+    }
+    assert embedder.embed_call_count == 2  # No new embeddings computed!
+
+    # Third indexing: doc 1 metadata updated, doc 2 unchanged
+    updated_docs = [
+        Document(page_content="Document 1", metadata={"source": "1", "version": 2}),
+        Document(page_content="Document 2", metadata={"source": "2", "version": 1}),
+    ]
+    res3 = index(
+        updated_docs,
+        record_manager,
+        vs,
+        cleanup="incremental",
+        source_id_key="source",
+        metadata_update=True,
+    )
+    assert res3 == {
+        "num_added": 0,
+        "num_updated": 1,
+        "num_skipped": 1,
+        "num_deleted": 0,
+    }
+    assert embedder.embed_call_count == 2  # Still 0 new embeddings!
+
+    # Verify vector store metadata was updated
+    for entry in vs.store.values():
+        if entry["text"] == "Document 1":
+            assert entry["metadata"]["version"] == 2
+        elif entry["text"] == "Document 2":
+            assert entry["metadata"]["version"] == 1
+
+
+def test_index_metadata_update_content_changed(
+    record_manager: InMemoryRecordManager,
+    counting_vector_store: tuple[InMemoryVectorStore, CountingEmbedding],
+) -> None:
+    """Test that content changes trigger normal re-embedding and deletion."""
+    vs, embedder = counting_vector_store
+    docs = [
+        Document(page_content="Original content", metadata={"source": "1", "v": 1}),
+    ]
+    index(
+        docs,
+        record_manager,
+        vs,
+        cleanup="incremental",
+        source_id_key="source",
+        metadata_update=True,
+    )
+    assert embedder.embed_call_count == 1
+
+    # Content changed -> must re-embed and delete old document
+    changed_docs = [
+        Document(page_content="New content", metadata={"source": "1", "v": 2}),
+    ]
+    res = index(
+        changed_docs,
+        record_manager,
+        vs,
+        cleanup="incremental",
+        source_id_key="source",
+        metadata_update=True,
+    )
+    assert res == {
+        "num_added": 1,
+        "num_updated": 0,
+        "num_skipped": 0,
+        "num_deleted": 1,
+    }
+    assert embedder.embed_call_count == 2
+
+
+def test_index_metadata_update_force_update(
+    record_manager: InMemoryRecordManager,
+    counting_vector_store: tuple[InMemoryVectorStore, CountingEmbedding],
+) -> None:
+    """Test that force_update=True forces re-embedding.
+
+    Should re-embed even with metadata_update=True.
+    """
+    vs, embedder = counting_vector_store
+    docs = [
+        Document(page_content="Doc 1", metadata={"source": "1"}),
+    ]
+    index(
+        docs,
+        record_manager,
+        vs,
+        cleanup="incremental",
+        source_id_key="source",
+        metadata_update=True,
+    )
+    assert embedder.embed_call_count == 1
+
+    res = index(
+        docs,
+        record_manager,
+        vs,
+        cleanup="incremental",
+        source_id_key="source",
+        force_update=True,
+        metadata_update=True,
+    )
+    assert res["num_updated"] == 1
+    assert embedder.embed_call_count == 2
+
+
+def test_index_metadata_update_with_full_cleanup(
+    record_manager: InMemoryRecordManager,
+    counting_vector_store: tuple[InMemoryVectorStore, CountingEmbedding],
+) -> None:
+    """Test metadata_update=True with cleanup='full'."""
+    vs, embedder = counting_vector_store
+    docs = [
+        Document(page_content="Doc 1", metadata={"source": "1", "v": 1}),
+        Document(page_content="Doc 2", metadata={"source": "2", "v": 1}),
+    ]
+    index(
+        docs,
+        record_manager,
+        vs,
+        cleanup="full",
+        metadata_update=True,
+    )
+
+    # In second run, Doc 2 is removed, Doc 1 metadata updated
+    run2_docs = [
+        Document(page_content="Doc 1", metadata={"source": "1", "v": 2}),
+    ]
+    res = index(
+        run2_docs,
+        record_manager,
+        vs,
+        cleanup="full",
+        metadata_update=True,
+    )
+    assert res == {
+        "num_added": 0,
+        "num_updated": 1,
+        "num_skipped": 0,
+        "num_deleted": 1,
+    }
+    assert embedder.embed_call_count == 2  # No new embeddings computed in run 2!
+    assert len(vs.store) == 1
+
+
+def test_index_metadata_update_document_index(
+    record_manager: InMemoryRecordManager,
+) -> None:
+    """Test metadata_update=True with DocumentIndex."""
+    doc_index = InMemoryDocumentIndex()
+    docs = [
+        Document(page_content="Test doc", metadata={"author": "Alice"}),
+    ]
+    res1 = index(
+        docs,
+        record_manager,
+        doc_index,
+        metadata_update=True,
+    )
+    assert res1["num_added"] == 1
+
+    # Update metadata
+    res2 = index(
+        [Document(page_content="Test doc", metadata={"author": "Bob"})],
+        record_manager,
+        doc_index,
+        metadata_update=True,
+    )
+    assert res2 == {
+        "num_added": 0,
+        "num_updated": 1,
+        "num_skipped": 0,
+        "num_deleted": 0,
+    }
+    stored_docs = list(doc_index.store.values())
+    assert stored_docs[0].metadata == {"author": "Bob"}
+
+
+def test_index_metadata_update_unsupported_destination(
+    record_manager: InMemoryRecordManager,
+) -> None:
+    """Test that a VectorStore without update_metadata raises ValueError."""
+    unsupported_vs = UnsupportedVectorStore()
+    with pytest.raises(
+        ValueError, match="has not implemented the update_metadata method"
+    ):
+        index(
+            [Document(page_content="hello", metadata={})],
+            record_manager,
+            unsupported_vs,
+            metadata_update=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_aindex_metadata_update_avoid_reembedding(
+    arecord_manager: InMemoryRecordManager,
+    counting_vector_store: tuple[InMemoryVectorStore, CountingEmbedding],
+) -> None:
+    """Test async aindex with metadata_update=True."""
+    vs, embedder = counting_vector_store
+    docs = [
+        Document(page_content="Async doc 1", metadata={"source": "1", "tag": "a"}),
+        Document(page_content="Async doc 2", metadata={"source": "2", "tag": "a"}),
+    ]
+
+    res1 = await aindex(
+        docs,
+        arecord_manager,
+        vs,
+        cleanup="incremental",
+        source_id_key="source",
+        metadata_update=True,
+    )
+    assert res1 == {
+        "num_added": 2,
+        "num_updated": 0,
+        "num_skipped": 0,
+        "num_deleted": 0,
+    }
+    assert embedder.embed_call_count == 2
+
+    # Skip when unchanged
+    res2 = await aindex(
+        docs,
+        arecord_manager,
+        vs,
+        cleanup="incremental",
+        source_id_key="source",
+        metadata_update=True,
+    )
+    assert res2 == {
+        "num_added": 0,
+        "num_updated": 0,
+        "num_skipped": 2,
+        "num_deleted": 0,
+    }
+    assert embedder.embed_call_count == 2
+
+    # Update metadata only
+    updated_docs = [
+        Document(page_content="Async doc 1", metadata={"source": "1", "tag": "b"}),
+        Document(page_content="Async doc 2", metadata={"source": "2", "tag": "a"}),
+    ]
+    res3 = await aindex(
+        updated_docs,
+        arecord_manager,
+        vs,
+        cleanup="incremental",
+        source_id_key="source",
+        metadata_update=True,
+    )
+    assert res3 == {
+        "num_added": 0,
+        "num_updated": 1,
+        "num_skipped": 1,
+        "num_deleted": 0,
+    }
+    assert embedder.embed_call_count == 2
+
+    for entry in vs.store.values():
+        if entry["text"] == "Async doc 1":
+            assert entry["metadata"]["tag"] == "b"
+        elif entry["text"] == "Async doc 2":
+            assert entry["metadata"]["tag"] == "a"
+
+
+def test_index_metadata_update_with_explicit_id(
+    record_manager: InMemoryRecordManager,
+    counting_vector_store: tuple[InMemoryVectorStore, CountingEmbedding],
+) -> None:
+    """Test metadata update when documents have explicit ids."""
+    vs, embedder = counting_vector_store
+    doc = Document(
+        id="custom-1", page_content="Hello world", metadata={"status": "draft"}
+    )
+
+    # First indexing
+    res1 = index([doc], record_manager, vs, metadata_update=True)
+    assert res1 == {
+        "num_added": 1,
+        "num_updated": 0,
+        "num_skipped": 0,
+        "num_deleted": 0,
+    }
+    assert embedder.embed_call_count == 1
+    assert vs.store["custom-1"]["metadata"] == {"status": "draft"}
+
+    # Update metadata only with same id
+    doc_updated = Document(
+        id="custom-1", page_content="Hello world", metadata={"status": "published"}
+    )
+    res2 = index([doc_updated], record_manager, vs, metadata_update=True)
+    assert res2 == {
+        "num_added": 0,
+        "num_updated": 1,
+        "num_skipped": 0,
+        "num_deleted": 0,
+    }
+    assert embedder.embed_call_count == 1  # 0 new embeddings
+    assert vs.store["custom-1"]["metadata"] == {"status": "published"}
+
+
+def test_index_metadata_update_scoped_full(
+    record_manager: InMemoryRecordManager,
+    counting_vector_store: tuple[InMemoryVectorStore, CountingEmbedding],
+) -> None:
+    """Test metadata update with cleanup='scoped_full'."""
+    vs, embedder = counting_vector_store
+    docs = [
+        Document(page_content="Doc 1", metadata={"source": "src1", "v": 1}),
+        Document(page_content="Doc 2", metadata={"source": "src1", "v": 1}),
+        Document(page_content="Doc 3", metadata={"source": "src2", "v": 1}),
+    ]
+    index(
+        docs,
+        record_manager,
+        vs,
+        cleanup="scoped_full",
+        source_id_key="source",
+        metadata_update=True,
+    )
+    assert embedder.embed_call_count == 3
+
+    # Only provide src1 docs: Doc 1 updated metadata, Doc 2 omitted (deleted)
+    # Doc 3 (src2) is NOT seen in this run, so scoped_full should NOT delete it!
+    run2_docs = [
+        Document(page_content="Doc 1", metadata={"source": "src1", "v": 2}),
+    ]
+    res = index(
+        run2_docs,
+        record_manager,
+        vs,
+        cleanup="scoped_full",
+        source_id_key="source",
+        metadata_update=True,
+    )
+    assert res == {
+        "num_added": 0,
+        "num_updated": 1,
+        "num_skipped": 0,
+        "num_deleted": 1,  # Doc 2 deleted
+    }
+    assert embedder.embed_call_count == 3  # No new embeddings computed in run 2!
+    # Doc 1 and Doc 3 still in vector store
+    assert len(vs.store) == 2
+
+
+@pytest.mark.asyncio
+async def test_aindex_metadata_update_unsupported_destination(
+    arecord_manager: InMemoryRecordManager,
+) -> None:
+    """Test that a VectorStore without aupdate_metadata raises ValueError in aindex."""
+    unsupported_vs = UnsupportedVectorStore()
+    with pytest.raises(
+        ValueError,
+        match="has not implemented the aupdate_metadata or update_metadata method",
+    ):
+        await aindex(
+            [Document(page_content="hello", metadata={})],
+            arecord_manager,
+            unsupported_vs,
+            metadata_update=True,
+        )


### PR DESCRIPTION
Fixes #40334

This change allows `index()` and `aindex()` to perform in-place metadata updates without re-embedding documents when their content is unchanged. When `metadata_update=True`, unchanged content with modified metadata invokes the destination's `update_metadata` method directly, saving embedding API costs and avoiding vector churn.

## Release note
- `langchain-core`: Added `metadata_update` parameter to `index()` and `aindex()` to update document metadata in-place in vector stores and document indexes without re-embedding when text content is unchanged.

## Verification
- Added comprehensive unit tests in `libs/core/tests/unit_tests/indexing/test_metadata_update.py` verifying unchanged docs are skipped (0 embedding calls), metadata-only updates do not invoke the embedding model, content changes trigger full re-embedding, and error handling works.
- Verified all 95 tests in `tests/unit_tests/indexing/` and all 63 tests in `tests/unit_tests/vectorstores/` pass.
- Verified `ruff check` and `ruff format` pass cleanly with 0 errors.
