### PR TITLE
fix(openai): classify provider errors delivered in a 200 response body

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -45,6 +45,7 @@ from typing import (
 from urllib.parse import urlparse
 
 import certifi
+import httpx2
 import openai
 import tiktoken
 from langchain_core.callbacks import (
@@ -674,7 +675,114 @@ def _handle_openai_api_error(e: openai.APIError) -> None:
         raise OpenAITimeoutError(e.request) from e
     if isinstance(e, openai.APIConnectionError):
         raise OpenAIConnectionError(message=e.message, request=e.request) from e
+    status_code = _status_from_error_body(e.body)
+    error_class = (
+        _model_error_class_for_status(status_code) if status_code is not None else None
+    )
+    if status_code is not None and error_class is not None:
+        # Status carried in the body (e.g. a gateway error event) instead of on
+        # the response line, so the SDK raised an unclassified APIError.
+        raise _classified_body_error(e.body, error_class, status_code, e.request) from e
     raise
+
+
+def _status_from_error_body(body: Any) -> int | None:
+    """Extract an HTTP status code from an error delivered in a 200 body.
+
+    OpenAI-compatible gateways report upstream faults with payloads such as
+    `{"code": 502, "message": "..."}`. Symbolic codes (e.g.
+    `"rate_limit_exceeded"`) carry no status information and yield `None`.
+
+    Args:
+        body: The raw error payload attached to the response or exception.
+
+    Returns:
+        The status code, or `None` when the payload carries no usable one.
+    """
+    if not isinstance(body, dict):
+        return None
+    code = body.get("code")
+    if isinstance(code, int) and not isinstance(code, bool):
+        return code
+    if isinstance(code, str) and code.isdigit():
+        return int(code)
+    return None
+
+
+def _model_error_class_for_status(
+    status_code: int,
+) -> type[openai.APIStatusError] | None:
+    """Map a status code to the dual-inheritance error class raised for it.
+
+    Args:
+        status_code: The HTTP status reported by the provider.
+
+    Returns:
+        The matching exception class, or `None` for statuses without one.
+    """
+    if status_code == 401:
+        return OpenAIAuthenticationError
+    if status_code == 403:
+        return OpenAIPermissionDeniedError
+    if status_code == 404:
+        return OpenAIModelNotFoundError
+    if status_code == 429:
+        return OpenAIRateLimitError
+    if status_code >= 500:
+        return OpenAIAPIError
+    if status_code in (400, 422):
+        return OpenAIInvalidRequestError
+    return None
+
+
+def _classified_body_error(
+    body: Any,
+    error_class: type[openai.APIStatusError],
+    status_code: int,
+    request: httpx2.Request | None,
+) -> openai.APIStatusError:
+    """Build the error a failing status line would have produced.
+
+    Args:
+        body: The raw error payload from the response body.
+        error_class: The classified exception type for `status_code`.
+        status_code: The status the provider reported in the payload.
+        request: The request the error relates to, if known.
+
+    Returns:
+        An exception that is both the OpenAI SDK type and the `ModelError`
+        subtype for `status_code`, carrying a reconstructed response.
+    """
+    message = body.get("message") if isinstance(body, dict) else None
+    if not isinstance(message, str) or not message:
+        message = str(body)
+    if request is None:
+        request = httpx2.Request("POST", "https://api.openai.com/v1")
+    return error_class(
+        message=message,
+        response=httpx2.Response(status_code=status_code, request=request),
+        body=body,
+    )
+
+
+def _raise_error_from_body(body: Any, request: httpx2.Request | None = None) -> None:
+    """Raise a classified error for a provider fault reported in a 200 body.
+
+    The OpenAI SDK raises nothing in this case, so without this the caller
+    receives an unclassified `ValueError`. Payloads without a usable status
+    code keep the historical `ValueError` behavior.
+
+    Args:
+        body: The raw error payload from the response body.
+        request: The request the error relates to, if known.
+    """
+    status_code = _status_from_error_body(body)
+    error_class = (
+        _model_error_class_for_status(status_code) if status_code is not None else None
+    )
+    if error_class is None or status_code is None:
+        raise ValueError(body)
+    raise _classified_body_error(body, error_class, status_code, request)
 
 
 def _add_gateway_metadata(generation_info: dict[str, Any], raw_response: Any) -> None:
@@ -2001,7 +2109,16 @@ class BaseChatOpenAI(BaseChatModel):
         # typically followed by a null value for `choices`, which we raise for
         # separately below).
         if response_dict.get("error"):
-            raise ValueError(response_dict.get("error"))
+            _raise_error_from_body(
+                response_dict["error"],
+                request=httpx2.Request(
+                    "POST",
+                    str(
+                        getattr(self.root_client, "base_url", None)
+                        or "https://api.openai.com/v1"
+                    ),
+                ),
+            )
 
         # Raise informative error messages for non-OpenAI chat completions APIs
         # that return malformed responses.
@@ -5020,7 +5137,7 @@ def _construct_lc_result_from_responses_api(
 ) -> ChatResult:
     """Construct `ChatResponse` from OpenAI Response API response."""
     if response.error:
-        raise ValueError(response.error)
+        _raise_error_from_body(response.error)
 
     if output_version is None:
         # Sentinel value of None lets us know if output_version is set explicitly.

--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -25,6 +25,7 @@ requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.6.2,<2.0.0",
     "certifi>=2024.6.2",
+    "httpx2>=2.7.0,<3.0.0",
     "openai>=2.45.0,<4.0.0",
     "tiktoken>=0.7.0,<1.0.0",
 ]

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -88,6 +88,12 @@ from langchain_openai.chat_models._compat import (
     _convert_to_v03_ai_message,
 )
 from langchain_openai.chat_models.base import (
+    OpenAIAPIError,
+    OpenAIAuthenticationError,
+    OpenAIInvalidRequestError,
+    OpenAIModelNotFoundError,
+    OpenAIPermissionDeniedError,
+    OpenAIRateLimitError,
     OpenAIRefusalError,
     _construct_lc_result_from_responses_api,
     _construct_responses_api_input,
@@ -4966,6 +4972,91 @@ def test_openai_transport_error_classification() -> None:
 
         assert isinstance(exc_info.value, model_error_type)
         assert exc_info.value.is_retryable is True
+
+
+class _FakeRawResponse:
+    """Stand-in for the SDK raw-response wrapper holding a parsed payload."""
+
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+
+    def parse(self) -> Any:
+        return self._payload
+
+
+@pytest.mark.parametrize(
+    ("status_code", "error_class", "is_retryable"),
+    [
+        (400, OpenAIInvalidRequestError, False),
+        (401, OpenAIAuthenticationError, False),
+        (403, OpenAIPermissionDeniedError, False),
+        (404, OpenAIModelNotFoundError, False),
+        (429, OpenAIRateLimitError, True),
+        (502, OpenAIAPIError, True),
+    ],
+)
+def test_error_in_200_body_classified(
+    status_code: int,
+    error_class: type[openai.APIStatusError],
+    *,
+    is_retryable: bool,
+) -> None:
+    """Errors reported in a 200 body raise the same types as status errors."""
+    model = ChatOpenAI(api_key=SecretStr("test"))
+    error_payload = {"code": status_code, "message": "upstream provider fault"}
+
+    with patch.object(model.client, "with_raw_response") as mock_client:
+        mock_client.create.return_value = _FakeRawResponse({"error": error_payload})
+        with pytest.raises(error_class) as exc_info:
+            model.invoke("test")
+
+    assert exc_info.value.status_code == status_code
+    assert isinstance(exc_info.value, ModelError)
+    assert exc_info.value.is_retryable is is_retryable
+    assert exc_info.value.body == error_payload
+
+
+def test_error_in_200_body_without_status_keeps_value_error() -> None:
+    """Payloads without a usable status keep the historical `ValueError`."""
+    model = ChatOpenAI(api_key=SecretStr("test"))
+    error_payload = {"code": "rate_limit_exceeded", "message": "slow down"}
+
+    with patch.object(model.client, "with_raw_response") as mock_client:
+        mock_client.create.return_value = _FakeRawResponse({"error": error_payload})
+        with pytest.raises(ValueError, match="rate_limit_exceeded"):
+            model.invoke("test")
+
+
+def test_streaming_error_in_body_classified() -> None:
+    """SSE error events carrying a status raise the classified error type."""
+    model = ChatOpenAI(api_key=SecretStr("test"))
+    request = httpx2.Request("POST", "https://api.openai.com/v1/chat/completions")
+    sdk_error = openai.APIError(
+        "upstream provider fault",
+        request=request,
+        body={"code": 502, "message": "upstream provider fault"},
+    )
+
+    with (  # noqa: PT012
+        patch.object(model.client, "create") as mock_create,
+        pytest.raises(OpenAIAPIError) as exc_info,
+    ):
+        mock_create.side_effect = sdk_error
+        next(model.stream("test"))
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.is_retryable is True
+
+
+def test_responses_api_error_in_body_classified() -> None:
+    """Errors on Responses API objects raise the classified error type."""
+    response = MagicMock()
+    response.error = {"code": 502, "message": "upstream provider fault"}
+
+    with pytest.raises(OpenAIAPIError) as exc_info:
+        _construct_lc_result_from_responses_api(response)
+
+    assert exc_info.value.is_retryable is True
 
 
 def test_metadata_versions() -> None:

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -391,7 +391,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -446,8 +446,8 @@ name = "httpcore2"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
+    { name = "h11", marker = "python_full_version != '3.12.*' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version != '3.12.*' or sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
@@ -771,6 +771,7 @@ version = "1.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },
+    { name = "httpx2" },
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
@@ -811,6 +812,7 @@ typing = [
 [package.metadata]
 requires-dist = [
     { name = "certifi", specifier = ">=2024.6.2" },
+    { name = "httpx2", specifier = ">=2.7.0,<3.0.0" },
     { name = "langchain-core", editable = "../../core" },
     { name = "openai", specifier = ">=2.45.0,<4.0.0" },
     { name = "tiktoken", specifier = ">=0.7.0,<1.0.0" },


### PR DESCRIPTION
## Description

OpenAI-compatible gateways (OpenRouter is the reported case) may answer with **HTTP 200 and an error object in the body** - `{"error": {"code": 502, "message": ...}}` - instead of a failing status line. The SDK then raises nothing, and the package's own error handling (`_handle_openai_api_error`, reached only from `except openai.APIError` blocks) is bypassed. Today callers get three different unclassified results:

| Path | Today | With this PR |
|---|---|---|
| `invoke` (chat completions) | `ValueError({'code': 502, ...})` | `OpenAIAPIError` (`is_retryable=True`, `status_code=502`) |
| `stream` (SSE `error` event) | bare `openai.APIError` with no status | same classified type, raised from it |
| Responses API (`response.error`) | `ValueError(ResponseError(...))` | same classified type |

This PR extracts the status from the error payload (numeric or numeric-string `code`) and raises the exact dual-inheritance exception that a failing status line would have produced - e.g. 401 -> `OpenAIAuthenticationError`, 429 -> `OpenAIRateLimitError`, 5xx -> `OpenAIAPIError` - constructed with a reconstructed `httpx2.Response` carrying that status. Callers can therefore catch either the SDK type or the langchain-core `ModelError` type and rely on `is_retryable`, which is the point of the #39538 error hierarchy. An `openai.APIError` whose `body` carries the status (the SDK's streaming error-event shape) is classified the same way at the end of `_handle_openai_api_error`.

Payloads without a usable status (symbolic codes like `"rate_limit_exceeded"`) keep the historical `ValueError` on the 200-body paths, and the existing behavior of `_handle_openai_api_error` is untouched for every status the SDK classifies itself.

`httpx2` is now declared as a direct dependency since the module imports it; it was already a hard requirement of `openai>=2.45`.

Fixes #40362

## Test plan

- `test_error_in_200_body_classified` (parametrized over 400/401/403/404/429/502): invoke with an error-in-200 response raises the matching SDK+`ModelError` type with the reconstructed `status_code`, `is_retryable`, and `body`.
- `test_error_in_200_body_without_status_keeps_value_error`: symbolic codes keep the historical `ValueError`.
- `test_streaming_error_in_body_classified`: an SSE-error `openai.APIError` with `body={"code": 502}` is re-raised as `OpenAIAPIError` with `is_retryable=True`.
- `test_responses_api_error_in_body_classified`: `response.error` with a numeric code raises the classified type.
- Existing `test__construct_lc_result_from_responses_api_error_handling` (symbolic `server_error` code) still passes unchanged.
- Full `tests/unit_tests/chat_models/test_base.py`: 274 passed; `ruff check`, `ruff format`, and `mypy` clean on touched files.