### PR TITLE
fix(text-splitters): handle non-heading tags in HTMLHeaderTextSplitte…

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -172,9 +172,16 @@ class HTMLHeaderTextSplitter:
                 fewer `Document` objects.
         """
         # Sort headers by their numeric level so that h1 < h2 < h3...
-        self.headers_to_split_on = sorted(
-            headers_to_split_on, key=lambda x: int(x[0][1:])
-        )
+        # Non-heading tags (not matching h[1-6]) are placed at the end in their
+        # original order to maintain backward compatibility.
+        def _sort_key(header_tuple: tuple[str, str]) -> tuple[int, int]:
+            tag = header_tuple[0]
+            if tag.startswith("h") and tag[1:].isdigit():
+                level = int(tag[1:])
+                return (0, level)
+            return (1, 0)
+
+        self.headers_to_split_on = sorted(headers_to_split_on, key=_sort_key)
         self.header_mapping = dict(self.headers_to_split_on)
         self.header_tags = [tag for tag, _ in self.headers_to_split_on]
         self.return_each_element = return_each_element


### PR DESCRIPTION
Fixes #40341

## Summary

The \HTMLHeaderTextSplitter\ constructor assumed all tags follow the \h[1-6]\ pattern and tried to extract the numeric level with \int(tag[1:])\. This raised a \ValueError\ for semantic HTML5 tags like \section\, \rticle\, \side\, \
av\, etc.

## Changes

- Added a robust sorting key that:
  - Sorts \h1\-\h6\ tags by their numeric level (1-6)
  - Places non-heading tags at the end, maintaining their original relative order

This allows users to use semantic HTML5 sectioning elements alongside traditional heading tags without encountering a \ValueError\ on initialization.

## Testing

- All existing tests pass (149 passed, 4 skipped)
- Verified the fix works with various semantic HTML5 tags: \section\, \rticle\, \side\, \
av\, \header\, \ooter\, \main\
- Verified backward compatibility with existing h1-h6 tag usage