### PR TITLE
test: Fix MCPAdapter test assertion failure on Windows

### DIFF
--- a/libs/langchain_v1/tests/unit_tests/mcp/test_adapter.py
+++ b/libs/langchain_v1/tests/unit_tests/mcp/test_adapter.py
@@ -242,7 +242,7 @@ def test_a_string_naming_a_local_script_is_refused(tmp_path: Path) -> None:
     script = tmp_path / "server.py"
     script.touch()
 
-    with pytest.raises(ValueError, match="not a valid URL"):
+    with pytest.raises(ValueError, match=r"not a valid URL|has scheme"):
         MCPAdapter(str(script))
 
     # The same server, asked for explicitly, is still reachable.


### PR DESCRIPTION
Fixes #40354.

**The Issue:**
The test `test_a_string_naming_a_local_script_is_refused` strictly asserted a POSIX-specific error message (`not a valid URL`). On Windows, `pydantic.AnyUrl` parses absolute paths as URLs with a drive letter scheme (e.g., `c`), which correctly triggers the guard but throws a different error message (`has scheme 'c'`). 

**The Fix:**
This PR updates the test's `pytest.raises` regex to match either error message (`not a valid URL|has scheme`). This allows the test to pass correctly across all platforms while keeping the intended security property fully intact.
