### PR TITLE
feat(text-splitters): add `length_function` to `RecursiveJsonSplitter`

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/json.py
+++ b/libs/text-splitters/langchain_text_splitters/json.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import copy
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from langchain_core.documents import Document
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class RecursiveJsonSplitter:
@@ -27,7 +30,11 @@ class RecursiveJsonSplitter:
     """
 
     def __init__(
-        self, max_chunk_size: int = 2000, min_chunk_size: int | None = None
+        self,
+        max_chunk_size: int = 2000,
+        min_chunk_size: int | None = None,
+        *,
+        length_function: Callable[[dict[str, Any]], int] | None = None,
     ) -> None:
         """Initialize the chunk size configuration for text processing.
 
@@ -41,6 +48,11 @@ class RecursiveJsonSplitter:
 
                 If `None`, defaults to the maximum chunk size minus 200, with a lower
                 bound of 50.
+            length_function: Function that measures the size of a chunk.
+
+                If `None`, chunks are measured by the length of their serialized JSON
+                representation. Pass a custom callable to measure chunks in different
+                units, such as tokens.
         """
         super().__init__()
         self.max_chunk_size = max_chunk_size
@@ -48,6 +60,9 @@ class RecursiveJsonSplitter:
             min_chunk_size
             if min_chunk_size is not None
             else max(max_chunk_size - 200, 50)
+        )
+        self._length_function: Callable[[dict[str, Any]], int] = (
+            length_function if length_function is not None else self._json_size
         )
 
     @staticmethod
@@ -82,6 +97,52 @@ class RecursiveJsonSplitter:
         # Base case: the item is neither a dict nor a list, so return it unchanged
         return data
 
+    def _try_set_nested_dict(
+        self,
+        chunk: dict[str, Any],
+        path: list[str],
+        value: Any,  # noqa: ANN401
+    ) -> bool:
+        """Add a value to a chunk, keeping the chunk within `max_chunk_size`.
+
+        The candidate chunk is measured *after* the value has been inserted rather
+        than by adding the size of the value to the size of the chunk. Sizes are not
+        necessarily additive: serialized JSON shares the punctuation and the path
+        prefixes of the keys it already holds, and tokenizers may merge or split
+        tokens at the join. Measuring the merged chunk keeps the size limit accurate
+        for any `length_function`.
+
+        Args:
+            chunk: The chunk to add the value to. Mutated only when the value fits.
+            path: The path of keys at which to place the value.
+            value: The value to place at `path`.
+
+        Returns:
+            `True` if the value was added, `False` if it would overflow the chunk,
+            in which case `chunk` is left unchanged.
+        """
+        node = chunk
+        # The shallowest container created by this insertion, if any. Discarding it
+        # is enough to undo the whole insertion.
+        created: tuple[dict[str, Any], str] | None = None
+        for key in path[:-1]:
+            if key not in node:
+                if created is None:
+                    created = (node, key)
+                node[key] = {}
+            node = node[key]
+        node[path[-1]] = value
+
+        if self._length_function(chunk) <= self.max_chunk_size:
+            return True
+
+        if created is not None:
+            parent, key = created
+            del parent[key]
+        else:
+            del node[path[-1]]
+        return False
+
     def _json_split(
         self,
         data: Any,  # noqa: ANN401
@@ -94,22 +155,24 @@ class RecursiveJsonSplitter:
         if isinstance(data, dict) and data:
             for key, value in data.items():
                 new_path = [*current_path, key]
-                chunk_size = self._json_size(chunks[-1])
-                size = self._json_size({key: value})
-                remaining = self.max_chunk_size - chunk_size
+                if self._try_set_nested_dict(chunks[-1], new_path, value):
+                    continue
 
-                if size < remaining:
-                    # Add item to current chunk
-                    self._set_nested_dict(chunks[-1], new_path, value)
-                else:
-                    if chunk_size >= self.min_chunk_size:
-                        # Chunk is big enough, start a new chunk
-                        chunks.append({})
+                if self._length_function(chunks[-1]) >= self.min_chunk_size:
+                    # Chunk is big enough, start a new chunk
+                    chunks.append({})
 
-                    # Iterate
-                    self._json_split(value, new_path, chunks)
+                # Iterate
+                self._json_split(value, new_path, chunks)
         # Handle leaf values and empty dicts
-        elif current_path:
+        elif current_path and not self._try_set_nested_dict(
+            chunks[-1], current_path, data
+        ):
+            # The value cannot be split any further. Give it a fresh chunk so it only
+            # overflows on its own, rather than pushing a partially filled chunk over
+            # the limit.
+            if chunks[-1]:
+                chunks.append({})
             self._set_nested_dict(chunks[-1], current_path, data)
         return chunks
 

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -3563,6 +3563,146 @@ def test_split_json_convert_lists_true_non_list_no_misleading_hint() -> None:
     assert "convert_lists" not in str(exc_info.value)
 
 
+def _count_leaves(chunk: dict[str, Any]) -> int:
+    """Measure a chunk by how many leaf values it holds."""
+    total = 0
+    for value in chunk.values():
+        total += _count_leaves(value) if isinstance(value, dict) else 1
+    return total
+
+
+def _deep_merge(target: dict[str, Any], source: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge `source` into `target` so chunks can be recombined."""
+    for key, value in source.items():
+        existing = target.get(key)
+        if isinstance(value, dict) and isinstance(existing, dict):
+            _deep_merge(existing, value)
+        else:
+            target[key] = value
+    return target
+
+
+def test_split_json_length_function_is_keyword_only() -> None:
+    """`length_function` must not be positional, to keep the signature stable."""
+    with pytest.raises(TypeError):
+        RecursiveJsonSplitter(100, 50, _count_leaves)  # ty: ignore[too-many-positional-arguments]
+
+
+def test_split_json_custom_length_function_governs_chunk_size() -> None:
+    """Chunks are bounded by the custom measure, not by serialized length."""
+    max_leaves = 3
+    splitter = RecursiveJsonSplitter(
+        max_chunk_size=max_leaves,
+        min_chunk_size=1,
+        length_function=_count_leaves,
+    )
+
+    data: dict[str, Any] = {
+        "alpha": {"a1": 1, "a2": 2, "a3": 3},
+        "beta": {"b1": 4, "b2": 5},
+        "gamma": 6,
+    }
+    chunks = splitter.split_json(data)
+
+    assert chunks
+    for chunk in chunks:
+        assert _count_leaves(chunk) <= max_leaves
+
+
+def test_split_json_custom_length_function_preserves_all_data() -> None:
+    """Splitting with a custom measure must not lose or duplicate values."""
+    splitter = RecursiveJsonSplitter(
+        max_chunk_size=4, min_chunk_size=1, length_function=_count_leaves
+    )
+
+    data: dict[str, Any] = {
+        "config": {"retries": 3, "timeout": 30, "nested": {"deep": "value"}},
+        "items": {f"item{i}": f"value{i}" for i in range(10)},
+        "name": "example",
+    }
+    chunks = splitter.split_json(data)
+
+    merged: dict[str, Any] = {}
+    for chunk in chunks:
+        _deep_merge(merged, chunk)
+
+    assert merged == data
+
+
+def test_split_json_length_function_measures_merged_chunk() -> None:
+    """Sizes are measured on the merged chunk, not summed across its parts.
+
+    A super-additive measure exposes the difference: adding the size of an item to
+    the size of a chunk badly underestimates the size of the two combined.
+    """
+
+    def squared_size(chunk: dict[str, Any]) -> int:
+        return len(json.dumps(chunk)) ** 2
+
+    max_chunk = 40_000
+    splitter = RecursiveJsonSplitter(
+        max_chunk_size=max_chunk, min_chunk_size=1, length_function=squared_size
+    )
+
+    data: dict[str, Any] = {f"k{i}": f"v{i}" for i in range(25)}
+    chunks = splitter.split_json(data)
+
+    assert chunks
+    for chunk in chunks:
+        assert squared_size(chunk) <= max_chunk
+
+    merged: dict[str, Any] = {}
+    for chunk in chunks:
+        _deep_merge(merged, chunk)
+    assert merged == data
+
+
+def test_split_json_default_respects_max_chunk_size_for_deep_paths() -> None:
+    """Deeply nested keys must not push a chunk past `max_chunk_size`.
+
+    The size of an entry was previously estimated without the nested path it is
+    stored under, so long key paths could overflow the limit.
+    """
+    max_chunk = 800
+
+    def build(depth: int, breadth: int) -> dict[str, Any] | str:
+        if depth == 0:
+            return "x" * 40
+        return {
+            f"a_very_long_section_key_{i}": build(depth - 1, breadth)
+            for i in range(breadth)
+        }
+
+    data = build(4, 3)
+    assert isinstance(data, dict)
+
+    splitter = RecursiveJsonSplitter(max_chunk_size=max_chunk)
+    texts = splitter.split_text(json_data=data)
+
+    assert texts
+    for text in texts:
+        assert len(text) <= max_chunk
+
+
+def test_split_json_oversized_leaf_does_not_overflow_partial_chunk() -> None:
+    """A leaf too large to fit anywhere gets its own chunk."""
+    max_chunk = 100
+    splitter = RecursiveJsonSplitter(max_chunk_size=max_chunk, min_chunk_size=10)
+
+    data: dict[str, Any] = {"small": "a", "huge": "b" * 500, "other": "c"}
+    chunks = splitter.split_json(data)
+
+    merged: dict[str, Any] = {}
+    for chunk in chunks:
+        _deep_merge(merged, chunk)
+    assert merged == data
+
+    for chunk in chunks:
+        if len(json.dumps(chunk)) > max_chunk:
+            # Only the unsplittable value itself may exceed the limit.
+            assert chunk == {"huge": "b" * 500}
+
+
 def test_powershell_code_splitter_short_code() -> None:
     splitter = RecursiveCharacterTextSplitter.from_language(
         Language.POWERSHELL, chunk_size=60, chunk_overlap=0


### PR DESCRIPTION
Closes #39128

---

`RecursiveJsonSplitter` measures a chunk one way only: the character length of its serialized JSON. People who split JSON to fit a model's context window think in tokens, and `TextSplitter` has accepted a `length_function` for exactly that reason for a long time. This brings the JSON splitter in line.

```python
splitter = RecursiveJsonSplitter(
    max_chunk_size=512,
    length_function=lambda chunk: len(encoding.encode(json.dumps(chunk))),
)
```

The parameter is keyword-only and defaults to the existing behavior.

## Why this needed an algorithm change too

As @chadsr pointed out on the issue, `length_function` cannot simply be swapped in. Every sizing decision compared `max_chunk_size` against the size of the current chunk *plus* the size of the entry being placed. That arithmetic is only valid if size is additive, and a tokenizer is not — so a splitter that trusted it would emit chunks over the limit as soon as a custom measure was supplied.

The same estimate was already inaccurate for the default measure. An entry was sized on its own, without the nested path it actually gets stored under, so data with long key paths could overflow `max_chunk_size` — which is why the existing test for this allowed 5% of slack.

Each placement is now tentatively applied and the resulting chunk measured, then reverted if it overflows. That is accurate for any measure, additive or not. A value too large to fit anywhere now also starts its own chunk instead of overflowing a partially filled one.

Concretely: a four-level nested document split with `max_chunk_size=800` produced an 812-character chunk before this change, and stays within the limit after it.

## Areas worth a careful look

- Chunk boundaries for the default measure can shift, since placements the old pessimistic estimate rejected may now fit. Chunks stay within `max_chunk_size`, and the existing tests — including the one with 5% slack — pass unchanged.
- `min_chunk_size` behavior is otherwise untouched; the one exception is that an unsplittable oversized value now closes the current chunk early rather than overflowing it.

## Release note

`RecursiveJsonSplitter` accepts a `length_function` for measuring chunks in units other than serialized JSON characters, such as tokens. Chunk sizes are now measured on the merged chunk, so entries stored under long key paths no longer push a chunk past `max_chunk_size`.

---

This contribution was prepared with AI-agent assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
