### PR TITLE
feat(huggingface): support `endpoint_url` in `HuggingFaceEndpointEmbeddings`

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/_endpoint_utils.py
+++ b/libs/partners/huggingface/langchain_huggingface/_endpoint_utils.py
@@ -1,0 +1,17 @@
+"""Helpers shared by the Hugging Face inference endpoint integrations."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+
+def _is_huggingface_hosted_url(url: str | None) -> bool:
+    """True if url is HF-hosted (huggingface.co or hf.space)."""
+    if not url:
+        return False
+    hostname = (urlparse(url).hostname or "").lower()
+    return (
+        hostname == "huggingface.co"
+        or hostname == "hf.space"
+        or hostname.endswith((".huggingface.co", ".hf.space"))
+    )

--- a/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface_endpoint.py
+++ b/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface_endpoint.py
@@ -8,6 +8,8 @@ from langchain_core.utils import from_env
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from typing_extensions import Self
 
+from langchain_huggingface._endpoint_utils import _is_huggingface_hosted_url
+
 DEFAULT_MODEL = "sentence-transformers/all-mpnet-base-v2"
 VALID_TASKS = ("feature-extraction",)
 
@@ -30,6 +32,15 @@ class HuggingFaceEndpointEmbeddings(BaseModel, Embeddings):
             huggingfacehub_api_token="my-api-key",
         )
         ```
+
+    To reach a deployed Inference Endpoint or a self-hosted Text Embeddings
+    Inference server, pass its URL as `endpoint_url` instead of a repo ID:
+
+        ```python
+        hf = HuggingFaceEndpointEmbeddings(
+            endpoint_url="http://localhost:8081",
+        )
+        ```
     """
 
     client: Any = None
@@ -38,6 +49,16 @@ class HuggingFaceEndpointEmbeddings(BaseModel, Embeddings):
 
     model: str | None = None
     """Model name to use."""
+
+    endpoint_url: str | None = None
+    """URL of the inference endpoint to send requests to.
+
+    Use this for a deployed Inference Endpoint or a self-hosted Hugging Face
+    compatible embedding server, such as Text Embeddings Inference. Mutually
+    exclusive with `model` and `repo_id`.
+
+    When the URL is not Hugging Face hosted, the configured token is not passed to
+    the underlying client, matching `HuggingFaceEndpoint`."""
 
     provider: str | None = None
     """Name of the provider to use for inference with the model specified in
@@ -68,8 +89,18 @@ class HuggingFaceEndpointEmbeddings(BaseModel, Embeddings):
         for field_name in ("model", "repo_id"):
             value = getattr(self, field_name)
             if value and value.startswith(("http://", "https://")):
-                msg = f"`{field_name}` must be a HuggingFace repo ID, not a URL."
+                msg = (
+                    f"`{field_name}` must be a HuggingFace repo ID, not a URL. "
+                    "Use `endpoint_url` for direct endpoints."
+                )
                 raise ValueError(msg)
+
+        if self.endpoint_url and (self.model or self.repo_id):
+            msg = (
+                "Please specify either an `endpoint_url` OR a `model`/`repo_id`, "
+                "not both."
+            )
+            raise ValueError(msg)
 
         huggingfacehub_api_token = self.huggingfacehub_api_token or os.getenv(
             "HF_TOKEN"
@@ -81,23 +112,36 @@ class HuggingFaceEndpointEmbeddings(BaseModel, Embeddings):
                 InferenceClient,
             )
 
-            if self.model:
+            if self.endpoint_url:
+                # `model` and `repo_id` stay unset: the endpoint identifies itself.
+                target = self.endpoint_url
+            elif self.model:
                 self.repo_id = self.model
+                target = self.model
             elif self.repo_id:
                 self.model = self.repo_id
+                target = self.repo_id
             else:
                 self.model = DEFAULT_MODEL
                 self.repo_id = DEFAULT_MODEL
+                target = DEFAULT_MODEL
+
+            # A custom endpoint is not necessarily operated by Hugging Face, so
+            # don't hand it a Hugging Face token.
+            if self.endpoint_url and not _is_huggingface_hosted_url(self.endpoint_url):
+                token: str | None = None
+            else:
+                token = huggingfacehub_api_token
 
             client = InferenceClient(
-                model=self.model,
-                token=huggingfacehub_api_token,
+                model=target,
+                token=token,
                 provider=self.provider,  # type: ignore[arg-type]
             )
 
             async_client = AsyncInferenceClient(
-                model=self.model,
-                token=huggingfacehub_api_token,
+                model=target,
+                token=token,
                 provider=self.provider,  # type: ignore[arg-type]
             )
 

--- a/libs/partners/huggingface/langchain_huggingface/llms/huggingface_endpoint.py
+++ b/libs/partners/huggingface/langchain_huggingface/llms/huggingface_endpoint.py
@@ -5,7 +5,6 @@ import logging
 import os
 from collections.abc import AsyncIterator, Iterator, Mapping
 from typing import Any
-from urllib.parse import urlparse
 
 from langchain_core.callbacks import (
     AsyncCallbackManagerForLLMRun,
@@ -17,21 +16,10 @@ from langchain_core.utils import from_env, get_pydantic_field_names
 from pydantic import ConfigDict, Field, model_validator
 from typing_extensions import Self
 
+from langchain_huggingface._endpoint_utils import _is_huggingface_hosted_url
 from langchain_huggingface._version import __version__
 
 logger = logging.getLogger(__name__)
-
-
-def _is_huggingface_hosted_url(url: str | None) -> bool:
-    """True if url is HF-hosted (huggingface.co or hf.space)."""
-    if not url:
-        return False
-    hostname = (urlparse(url).hostname or "").lower()
-    return (
-        hostname == "huggingface.co"
-        or hostname == "hf.space"
-        or hostname.endswith((".huggingface.co", ".hf.space"))
-    )
 
 
 VALID_TASKS = (

--- a/libs/partners/huggingface/tests/unit_tests/test_huggingface_endpoint_embeddings.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_huggingface_endpoint_embeddings.py
@@ -1,0 +1,173 @@
+"""Tests for `HuggingFaceEndpointEmbeddings` (no HF API calls)."""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from langchain_huggingface.embeddings.huggingface_endpoint import (
+    DEFAULT_MODEL,
+    HuggingFaceEndpointEmbeddings,
+)
+
+FAKE_TOKEN = "hf_xxx"  # noqa: S105
+
+
+@patch("huggingface_hub.AsyncInferenceClient")
+@patch("huggingface_hub.InferenceClient")
+def test_endpoint_url_is_used_for_both_clients(
+    mock_inference_client: MagicMock,
+    mock_async_client: MagicMock,
+) -> None:
+    """A self-hosted endpoint URL is what both clients talk to."""
+    endpoint_url = "http://localhost:8081"
+
+    embeddings = HuggingFaceEndpointEmbeddings(endpoint_url=endpoint_url)
+
+    assert mock_inference_client.call_args[1]["model"] == endpoint_url
+    assert mock_async_client.call_args[1]["model"] == endpoint_url
+
+    # The endpoint identifies itself, so no repo ID is invented for it.
+    assert embeddings.model is None
+    assert embeddings.repo_id is None
+
+
+@patch("huggingface_hub.AsyncInferenceClient")
+@patch("huggingface_hub.InferenceClient")
+def test_self_hosted_endpoint_is_not_given_the_configured_token(
+    mock_inference_client: MagicMock,
+    mock_async_client: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The configured token is not passed to the client for a non-HF host."""
+    monkeypatch.setenv("HF_TOKEN", "hf_from_env")
+
+    HuggingFaceEndpointEmbeddings(endpoint_url="http://localhost:8081")
+
+    assert mock_inference_client.call_args[1]["token"] is None
+    assert mock_async_client.call_args[1]["token"] is None
+
+
+@patch("huggingface_hub.AsyncInferenceClient")
+@patch("huggingface_hub.InferenceClient")
+def test_huggingface_hosted_endpoint_keeps_token(
+    mock_inference_client: MagicMock,
+    mock_async_client: MagicMock,
+) -> None:
+    """An HF-hosted endpoint URL still gets the configured token."""
+    HuggingFaceEndpointEmbeddings(
+        endpoint_url="https://abc.endpoints.huggingface.co",
+        huggingfacehub_api_token=FAKE_TOKEN,
+    )
+
+    assert mock_inference_client.call_args[1]["token"] == FAKE_TOKEN
+    assert mock_async_client.call_args[1]["token"] == FAKE_TOKEN
+
+
+@pytest.mark.parametrize(
+    "conflicting",
+    [
+        pytest.param({"model": DEFAULT_MODEL}, id="model"),
+        pytest.param({"repo_id": DEFAULT_MODEL}, id="repo_id"),
+    ],
+)
+@patch("huggingface_hub.AsyncInferenceClient")
+@patch("huggingface_hub.InferenceClient")
+def test_endpoint_url_conflicts_are_rejected(
+    mock_inference_client: MagicMock,
+    mock_async_client: MagicMock,
+    conflicting: dict[str, Any],
+) -> None:
+    """`endpoint_url` is mutually exclusive with `model` and `repo_id`."""
+    with pytest.raises(ValueError, match="not both"):
+        HuggingFaceEndpointEmbeddings(
+            endpoint_url="http://localhost:8081", **conflicting
+        )
+
+
+@pytest.mark.parametrize(
+    "url_kwargs",
+    [
+        pytest.param({"model": "http://localhost:8081"}, id="model"),
+        pytest.param({"repo_id": "http://localhost:8081"}, id="repo_id"),
+    ],
+)
+@patch("huggingface_hub.AsyncInferenceClient")
+@patch("huggingface_hub.InferenceClient")
+def test_url_in_repo_id_field_points_at_endpoint_url(
+    mock_inference_client: MagicMock,
+    mock_async_client: MagicMock,
+    url_kwargs: dict[str, Any],
+) -> None:
+    """Rejecting a URL should say which parameter to use instead."""
+    with pytest.raises(ValueError, match="endpoint_url"):
+        HuggingFaceEndpointEmbeddings(**url_kwargs)
+
+
+@patch("huggingface_hub.AsyncInferenceClient")
+@patch("huggingface_hub.InferenceClient")
+def test_defaults_are_unchanged_without_endpoint_url(
+    mock_inference_client: MagicMock,
+    mock_async_client: MagicMock,
+) -> None:
+    """Regression guard: the repo ID path is untouched by the new parameter."""
+    embeddings = HuggingFaceEndpointEmbeddings()
+
+    assert embeddings.model == DEFAULT_MODEL
+    assert embeddings.repo_id == DEFAULT_MODEL
+    assert mock_inference_client.call_args[1]["model"] == DEFAULT_MODEL
+
+
+@patch("huggingface_hub.AsyncInferenceClient")
+@patch("huggingface_hub.InferenceClient")
+def test_model_and_repo_id_together_still_accepted(
+    mock_inference_client: MagicMock,
+    mock_async_client: MagicMock,
+) -> None:
+    """Regression guard: passing both keeps working, with `model` taking priority."""
+    embeddings = HuggingFaceEndpointEmbeddings(
+        model="sentence-transformers/all-mpnet-base-v2",
+        repo_id="some/other-model",
+    )
+
+    assert embeddings.model == "sentence-transformers/all-mpnet-base-v2"
+    assert embeddings.repo_id == "sentence-transformers/all-mpnet-base-v2"
+
+
+@patch("huggingface_hub.AsyncInferenceClient")
+@patch("huggingface_hub.InferenceClient")
+def test_embed_query_uses_endpoint_client(
+    mock_inference_client: MagicMock,
+    mock_async_client: MagicMock,
+) -> None:
+    """Embedding calls go through the client built for the endpoint URL."""
+    response = MagicMock()
+    response.tolist.return_value = [[0.1, 0.2, 0.3]]
+    mock_inference_client.return_value.feature_extraction.return_value = response
+
+    embeddings = HuggingFaceEndpointEmbeddings(endpoint_url="http://localhost:8081")
+
+    assert embeddings.embed_query("hello") == [0.1, 0.2, 0.3]
+    mock_inference_client.return_value.feature_extraction.assert_called_once_with(
+        text=["hello"]
+    )
+
+
+@patch("huggingface_hub.AsyncInferenceClient")
+@patch("huggingface_hub.InferenceClient")
+async def test_aembed_query_uses_endpoint_client(
+    mock_inference_client: MagicMock,
+    mock_async_client: MagicMock,
+) -> None:
+    """The async client is wired to the endpoint URL too."""
+    response = MagicMock()
+    response.tolist.return_value = [[0.4, 0.5]]
+
+    async def fake_feature_extraction(**_kwargs: object) -> MagicMock:
+        return response
+
+    mock_async_client.return_value.feature_extraction = fake_feature_extraction
+
+    embeddings = HuggingFaceEndpointEmbeddings(endpoint_url="http://localhost:8081")
+
+    assert await embeddings.aembed_query("hello") == [0.4, 0.5]


### PR DESCRIPTION
Closes #39072

---

`HuggingFaceEndpointEmbeddings` can only be pointed at a Hub repo ID — it explicitly rejects a URL passed as `model` or `repo_id`. Anyone running a self-hosted Text Embeddings Inference server, or a deployed Inference Endpoint reached by URL, currently has to drop down to `huggingface_hub` or write their own `Embeddings` wrapper.

`HuggingFaceEndpoint` already solves this on the text generation side, so this mirrors it rather than inventing a second convention:

```python
embeddings = HuggingFaceEndpointEmbeddings(endpoint_url="http://localhost:8081")
embeddings.embed_query("Hello world")
```

- `endpoint_url` is mutually exclusive with `model` and `repo_id`.
- Both the sync and async inference clients are built against it.
- When the URL is not Hugging Face hosted, the configured token is not passed to the client — the same guard `HuggingFaceEndpoint` applies.
- The URL check behind that guard now lives in one place instead of being duplicated across the two integrations.

Nothing changes unless `endpoint_url` is passed. The error raised for a URL in `model` or `repo_id` now names the parameter to use instead.

## Areas worth a careful look

Exclusivity is only enforced between `endpoint_url` and the other two. Passing both `model` and `repo_id` has always been accepted, with `model` winning, and still is — tightening that would be a breaking change unrelated to this issue. `HuggingFaceEndpoint` does reject that combination, so the difference is deliberate; happy to align them if you'd prefer.

Worth flagging separately: withholding the token does not by itself guarantee that no token is sent. `huggingface_hub` builds request headers with `build_hf_headers`, which falls back to a locally saved or environment token when none is supplied. That is pre-existing behavior which `HuggingFaceEndpoint` shares, so this PR does not change it, and the new docstring is deliberately limited to what this integration controls. Glad to follow up on that for both classes if it's worth addressing.

## Release note

`HuggingFaceEndpointEmbeddings` accepts an `endpoint_url` for deployed Inference Endpoints and self-hosted Hugging Face compatible embedding servers, such as Text Embeddings Inference. It is mutually exclusive with `model` and `repo_id`, and is used by both the sync and async clients.

---

This contribution was prepared with AI-agent assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
