### PR TITLE
feat(openrouter,fireworks): support `response_format` on invoke and bind_tools

### DIFF
--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -132,6 +132,81 @@ def _get_default_model_profile(model_name: str) -> ModelProfile:
     return default.copy()
 
 
+def _convert_to_fireworks_response_format(
+    schema: dict[str, Any] | type | None, *, strict: bool | None = None
+) -> dict[str, Any] | None:
+    """Convert a schema into a Fireworks `response_format` dict.
+
+    Accepts the shapes `ProviderStrategy` produces (OpenAI-style
+    `{"type": "json_schema", "json_schema": {...}}`), raw Pydantic model
+    classes, `TypedDict` classes, dataclasses, and raw JSON schema dicts,
+    converting them into the `response_format` envelope Fireworks expects.
+
+    Args:
+        schema: The schema to convert. Dicts already carrying a
+            `response_format` `type` (e.g. `'json_object'`, `'json_schema'`,
+            or `'text'`) are passed through, with `json_schema` envelopes
+            normalized. Other schema-like values are converted to a JSON
+            schema and wrapped.
+        strict: Whether to request strict schema adherence. Only applied when
+            the caller explicitly provides a value and the schema does not
+            already specify one.
+
+    Returns:
+        The `response_format` dict, or `None` if `schema` is `None`.
+    """
+    if schema is None:
+        return None
+
+    spec: dict[str, Any]
+    envelope_type = schema.get("type") if isinstance(schema, dict) else None
+    if isinstance(schema, dict) and isinstance(envelope_type, str):
+        if envelope_type == "json_schema" and isinstance(
+            inner := schema.get("json_schema"), dict
+        ):
+            # OpenAI-style envelope (e.g. from `ProviderStrategy`)
+            spec = {
+                "name": inner.get("name", ""),
+                "schema": inner.get("schema", inner),
+            }
+            if "strict" in inner:
+                spec["strict"] = inner["strict"]
+            elif strict is not None:
+                spec["strict"] = strict
+            return {"type": "json_schema", "json_schema": spec}
+        if envelope_type in ("json_object", "json_schema", "text"):
+            # Already a `response_format` the API understands
+            return schema
+        if envelope_type == "object" and "title" not in schema:
+            # Raw JSON schema without a title: wrap it directly, since
+            # `convert_to_json_schema` needs a name to convert from
+            spec = {"name": "", "schema": schema}
+            if strict is not None:
+                spec["strict"] = strict
+            return {"type": "json_schema", "json_schema": spec}
+
+    json_schema = convert_to_json_schema(schema, strict=strict)
+    spec = {"name": json_schema.get("title", ""), "schema": json_schema}
+    if strict is not None:
+        spec["strict"] = strict
+    return {"type": "json_schema", "json_schema": spec}
+
+
+def _normalize_response_format_param(params: dict[str, Any]) -> None:
+    """Normalize a `response_format` param in-place for the Fireworks API.
+
+    Converts Pydantic model classes, `TypedDict` classes, dataclasses, and raw
+    JSON schema dicts into the `{"type": "json_schema", "json_schema": {...}}`
+    envelope Fireworks expects. Values already in envelope form are left as-is.
+    """
+    response_format = params.get("response_format")
+    if response_format is None:
+        return
+    converted = _convert_to_fireworks_response_format(response_format)
+    if converted is not None:
+        params["response_format"] = converted
+
+
 def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
     """Convert a dictionary to a LangChain message.
 
@@ -1166,6 +1241,7 @@ class ChatFireworks(BaseChatModel):
     ) -> Iterator[ChatGenerationChunk]:
         message_dicts, params = self._create_message_dicts(messages, stop)
         params = {**params, **kwargs, "stream": True}
+        _normalize_response_format_param(params)
         if self.stream_usage and "stream_options" not in params:
             params["stream_options"] = {"include_usage": True}
 
@@ -1224,6 +1300,7 @@ class ChatFireworks(BaseChatModel):
             **({"stream": stream} if stream is not None else {}),
             **kwargs,
         }
+        _normalize_response_format_param(params)
         try:
             response = _completion_with_retry(
                 self, run_manager=run_manager, messages=message_dicts, **params
@@ -1283,6 +1360,7 @@ class ChatFireworks(BaseChatModel):
     ) -> AsyncIterator[ChatGenerationChunk]:
         message_dicts, params = self._create_message_dicts(messages, stop)
         params = {**params, **kwargs, "stream": True}
+        _normalize_response_format_param(params)
         if self.stream_usage and "stream_options" not in params:
             params["stream_options"] = {"include_usage": True}
 
@@ -1344,6 +1422,7 @@ class ChatFireworks(BaseChatModel):
             **({"stream": stream} if stream is not None else {}),
             **kwargs,
         }
+        _normalize_response_format_param(params)
         try:
             response = await _acompletion_with_retry(
                 self, run_manager=run_manager, messages=message_dicts, **params
@@ -1380,6 +1459,7 @@ class ChatFireworks(BaseChatModel):
         tools: Sequence[dict[str, Any] | type[BaseModel] | Callable | BaseTool],
         *,
         tool_choice: dict | str | bool | None = None,
+        response_format: dict[str, Any] | type | None = None,
         **kwargs: Any,
     ) -> Runnable[LanguageModelInput, AIMessage]:
         """Bind tool-like objects to this chat model.
@@ -1396,10 +1476,22 @@ class ChatFireworks(BaseChatModel):
                 with the option to not call any function, `'any'` to enforce that some
                 function is called, or a dict of the form:
                 `{"type": "function", "function": {"name": <<tool_name>>}}`.
+            response_format: Optional schema to enforce a structured output
+                shape. Accepts a Pydantic model class, `TypedDict` class,
+                dataclass, JSON schema dict, or an OpenAI-style
+                `{"type": "json_schema", "json_schema": {...}}` envelope.
+
+                !!! version-added "Added in `langchain-fireworks` 1.6.2"
             **kwargs: Any additional parameters to pass to
                 `langchain_fireworks.chat_models.ChatFireworks.bind`
         """  # noqa: E501
         strict = kwargs.pop("strict", None)
+        if response_format is not None:
+            converted = _convert_to_fireworks_response_format(
+                response_format, strict=strict
+            )
+            if converted is not None:
+                kwargs["response_format"] = converted
         formatted_tools = [
             convert_to_openai_tool(tool, strict=strict) for tool in tools
         ]

--- a/libs/partners/fireworks/tests/integration_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/integration_tests/test_chat_models.py
@@ -30,7 +30,7 @@ def test_tool_choice_bool(strict: bool | None) -> None:  # noqa: FBT001
         name: str
         age: int
 
-    kwargs = {"tool_choice": True}
+    kwargs: dict[str, Any] = {"tool_choice": True}
     if strict is not None:
         kwargs["strict"] = strict
     with_tool = llm.bind_tools([MyTool], **kwargs)

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -40,6 +40,9 @@ from langchain_core.messages import (
     SystemMessage,
     ToolMessage,
 )
+from langchain_core.runnables import RunnableBinding
+from pydantic import BaseModel
+from typing_extensions import TypedDict
 
 from langchain_fireworks import ChatFireworks
 from langchain_fireworks.chat_models import (
@@ -51,6 +54,7 @@ from langchain_fireworks.chat_models import (
     _convert_chunk_to_message_chunk,
     _convert_dict_to_message,
     _convert_message_to_dict,
+    _convert_to_fireworks_response_format,
     _format_message_content,
     _sanitize_chat_completions_content,
     _update_token_usage,
@@ -1667,6 +1671,114 @@ class TestReasoningEffort:
         model.invoke("Hello", reasoning_effort="high")
         call_kwargs = model.client.create.call_args[1]
         assert call_kwargs["reasoning_effort"] == "high"
+
+
+class TestResponseFormatKwarg:
+    """Tests for `response_format` supplied outside `with_structured_output`."""
+
+    @staticmethod
+    def _mock_structured_model() -> ChatFireworks:
+        model = _make_model()
+        model.client = MagicMock()
+        model.client.create.return_value = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": '{"location": "SF"}',
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+        return model
+
+    class GetWeather(BaseModel):
+        """Get the current weather in a given location."""
+
+        location: str
+
+    def test_invoke_converts_schema_to_json_schema(self) -> None:
+        """Pydantic schemas are converted into a `json_schema` envelope."""
+        model = self._mock_structured_model()
+        model.invoke("weather in SF", response_format=self.GetWeather)
+        rf = model.client.create.call_args[1]["response_format"]
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["name"] == "GetWeather"
+        assert rf["json_schema"]["schema"]["properties"]["location"]
+
+    def test_invoke_converts_typeddict_to_json_schema(self) -> None:
+        """`TypedDict` schemas are converted into a `json_schema` envelope."""
+
+        class GetWeatherTypedDict(TypedDict):
+            location: str
+
+        model = self._mock_structured_model()
+        model.invoke("weather in SF", response_format=GetWeatherTypedDict)
+        rf = model.client.create.call_args[1]["response_format"]
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["name"] == "GetWeatherTypedDict"
+        assert rf["json_schema"]["schema"]["properties"]["location"]
+
+    def test_invoke_passes_through_provider_strategy_envelope(self) -> None:
+        """`ProviderStrategy` sends an OpenAI-style envelope, preserved as-is."""
+        model = self._mock_structured_model()
+        model.invoke(
+            "weather in SF",
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "GetWeather",
+                    "schema": {"type": "object", "properties": {}},
+                    "strict": True,
+                },
+            },
+        )
+        rf = model.client.create.call_args[1]["response_format"]
+        assert rf == {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "GetWeather",
+                "schema": {"type": "object", "properties": {}},
+                "strict": True,
+            },
+        }
+
+    def test_invoke_passes_through_json_mode(self) -> None:
+        """A `json_object` response format is left untouched."""
+        model = self._mock_structured_model()
+        model.invoke("weather in SF", response_format={"type": "json_object"})
+        rf = model.client.create.call_args[1]["response_format"]
+        assert rf == {"type": "json_object"}
+
+    def test_bind_tools_converts_response_format(self) -> None:
+        """`bind_tools` converts a schema into a `json_schema` envelope."""
+        model = _make_model()
+        bound = model.bind_tools([], response_format=self.GetWeather)
+        assert isinstance(bound, RunnableBinding)
+        rf = bound.kwargs["response_format"]
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["name"] == "GetWeather"
+
+    def test_bind_tools_forwards_strict(self) -> None:
+        """`strict` is forwarded onto the converted `response_format`."""
+        model = _make_model()
+        bound = model.bind_tools([], response_format=self.GetWeather, strict=True)
+        assert isinstance(bound, RunnableBinding)
+        assert bound.kwargs["response_format"]["json_schema"]["strict"] is True
+
+    def test_raw_json_schema_without_title_is_wrapped(self) -> None:
+        """A titleless JSON schema is wrapped rather than raising."""
+        schema = {"type": "object", "properties": {"location": {"type": "string"}}}
+        assert _convert_to_fireworks_response_format(schema) == {
+            "type": "json_schema",
+            "json_schema": {"name": "", "schema": schema},
+        }
+
+    def test_none_returns_none(self) -> None:
+        """No schema means no `response_format`."""
+        assert _convert_to_fireworks_response_format(None) is None
 
 
 class TestServiceTier:

--- a/libs/partners/fireworks/uv.lock
+++ b/libs/partners/fireworks/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.6.1"
+version = "1.6.2"
 source = { editable = "../../core" }
 dependencies = [
     { name = "httpx" },
@@ -986,7 +986,7 @@ requires-dist = [
     { name = "pytest-codspeed" },
     { name = "pytest-recording" },
     { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
-    { name = "syrupy", specifier = ">=5.0.0,<6.0.0" },
+    { name = "syrupy", specifier = ">=5.0.0,<7.0.0" },
     { name = "vcrpy", specifier = ">=8.2.1,<9.0.0" },
 ]
 

--- a/libs/partners/openrouter/langchain_openrouter/chat_models.py
+++ b/libs/partners/openrouter/langchain_openrouter/chat_models.py
@@ -568,6 +568,7 @@ class ChatOpenRouter(BaseChatModel):
             return generate_from_stream(stream_iter)
         message_dicts, params = self._create_message_dicts(messages, stop)
         params = {**params, **kwargs}
+        _normalize_response_format_param(params)
         _strip_internal_kwargs(params)
         response = self.client.chat.send(messages=message_dicts, **params)
         return self._create_chat_result(response)
@@ -586,6 +587,7 @@ class ChatOpenRouter(BaseChatModel):
             return await agenerate_from_stream(stream_iter)
         message_dicts, params = self._create_message_dicts(messages, stop)
         params = {**params, **kwargs}
+        _normalize_response_format_param(params)
         _strip_internal_kwargs(params)
         response = await self.client.chat.send_async(messages=message_dicts, **params)
         return self._create_chat_result(response)
@@ -599,6 +601,7 @@ class ChatOpenRouter(BaseChatModel):
     ) -> Iterator[ChatGenerationChunk]:
         message_dicts, params = self._create_message_dicts(messages, stop)
         params = {**params, **kwargs, "stream": True}
+        _normalize_response_format_param(params)
         if self.stream_usage:
             params["stream_options"] = {"include_usage": True}
         _strip_internal_kwargs(params)
@@ -689,6 +692,7 @@ class ChatOpenRouter(BaseChatModel):
     ) -> AsyncIterator[ChatGenerationChunk]:
         message_dicts, params = self._create_message_dicts(messages, stop)
         params = {**params, **kwargs, "stream": True}
+        _normalize_response_format_param(params)
         if self.stream_usage:
             params["stream_options"] = {"include_usage": True}
         _strip_internal_kwargs(params)
@@ -903,6 +907,7 @@ class ChatOpenRouter(BaseChatModel):
         tool_choice: dict | str | bool | None = None,
         strict: bool | None = None,
         parallel_tool_calls: bool | None = None,
+        response_format: dict[str, Any] | type | None = None,
         **kwargs: Any,
     ) -> Runnable[LanguageModelInput, AIMessage]:
         """Bind tool-like objects to this chat model.
@@ -921,6 +926,12 @@ class ChatOpenRouter(BaseChatModel):
             parallel_tool_calls: Set to `False` to disable parallel tool use.
                 Defaults to `None` (no specification, which allows parallel
                 tool use).
+            response_format: Optional schema to enforce a structured output
+                shape. Accepts a Pydantic model class, `TypedDict` class,
+                dataclass, JSON schema dict, or an OpenAI-style
+                `{"type": "json_schema", "json_schema": {...}}` envelope.
+
+                !!! version-added "Added in `langchain-openrouter` 0.2.9"
             **kwargs: Any additional parameters.
         """
         if parallel_tool_calls is not None:
@@ -948,6 +959,12 @@ class ChatOpenRouter(BaseChatModel):
                     "function": {"name": tool_name},
                 }
             kwargs["tool_choice"] = tool_choice
+        if response_format is not None:
+            converted = _convert_to_openrouter_response_format(
+                response_format, strict=strict
+            )
+            if converted is not None:
+                kwargs["response_format"] = converted
         return super().bind(tools=formatted_tools, **kwargs)
 
     def with_structured_output(  # type: ignore[override]
@@ -1069,10 +1086,85 @@ def _is_pydantic_class(obj: Any) -> bool:
     return isinstance(obj, type) and is_basemodel_subclass(obj)
 
 
+def _convert_to_openrouter_response_format(
+    schema: dict[str, Any] | type | None, *, strict: bool | None = None
+) -> dict[str, Any] | None:
+    """Convert a schema into an OpenRouter `response_format` dict.
+
+    Accepts the shapes `ProviderStrategy` produces (OpenAI-style
+    `{"type": "json_schema", "json_schema": {...}}`), raw Pydantic model
+    classes, `TypedDict` classes, dataclasses, and raw JSON schema dicts,
+    converting them into the `response_format` envelope OpenRouter expects.
+
+    Args:
+        schema: The schema to convert. Dicts already carrying a
+            `response_format` `type` (e.g. `'json_object'`, `'json_schema'`,
+            or `'text'`) are passed through, with `json_schema` envelopes
+            normalized. Other schema-like values are converted to a JSON
+            schema and wrapped.
+        strict: Whether to request strict schema adherence. Only applied when
+            the caller explicitly provides a value and the schema does not
+            already specify one.
+
+    Returns:
+        The `response_format` dict, or `None` if `schema` is `None`.
+    """
+    if schema is None:
+        return None
+
+    spec: dict[str, Any]
+    envelope_type = schema.get("type") if isinstance(schema, dict) else None
+    if isinstance(schema, dict) and isinstance(envelope_type, str):
+        if envelope_type == "json_schema" and isinstance(
+            inner := schema.get("json_schema"), dict
+        ):
+            # OpenAI-style envelope (e.g. from `ProviderStrategy`)
+            spec = {
+                "name": inner.get("name", ""),
+                "schema": inner.get("schema", inner),
+            }
+            if "strict" in inner:
+                spec["strict"] = inner["strict"]
+            elif strict is not None:
+                spec["strict"] = strict
+            return {"type": "json_schema", "json_schema": spec}
+        if envelope_type in ("json_object", "json_schema", "text"):
+            # Already a `response_format` the API understands
+            return schema
+        if envelope_type == "object" and "title" not in schema:
+            # Raw JSON schema without a title: wrap it directly, since
+            # `convert_to_json_schema` needs a name to convert from
+            spec = {"name": "", "schema": schema}
+            if strict is not None:
+                spec["strict"] = strict
+            return {"type": "json_schema", "json_schema": spec}
+
+    json_schema = convert_to_json_schema(schema, strict=strict)
+    spec = {"name": json_schema.get("title", ""), "schema": json_schema}
+    if strict is not None:
+        spec["strict"] = strict
+    return {"type": "json_schema", "json_schema": spec}
+
+
 def _strip_internal_kwargs(params: dict[str, Any]) -> None:
     """Remove LangChain-internal keys that the SDK does not accept."""
     for key in _INTERNAL_KWARGS:
         params.pop(key, None)
+
+
+def _normalize_response_format_param(params: dict[str, Any]) -> None:
+    """Normalize a `response_format` param in-place for the OpenRouter API.
+
+    Converts Pydantic model classes, `TypedDict` classes, dataclasses, and raw
+    JSON schema dicts into the `{"type": "json_schema", "json_schema": {...}}`
+    envelope OpenRouter expects. Values already in envelope form are left as-is.
+    """
+    response_format = params.get("response_format")
+    if response_format is None:
+        return
+    converted = _convert_to_openrouter_response_format(response_format)
+    if converted is not None:
+        params["response_format"] = converted
 
 
 #

--- a/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
@@ -21,6 +21,7 @@ from langchain_core.messages import (
 )
 from langchain_core.runnables import RunnableBinding
 from pydantic import BaseModel, Field, SecretStr
+from typing_extensions import TypedDict
 
 from langchain_openrouter.chat_models import (
     ChatOpenRouter,
@@ -28,6 +29,7 @@ from langchain_openrouter.chat_models import (
     _convert_dict_to_message,
     _convert_file_block_to_openrouter,
     _convert_message_to_dict,
+    _convert_to_openrouter_response_format,
     _convert_video_block_to_openrouter,
     _create_stream_generation_info,
     _create_usage_metadata,
@@ -3349,6 +3351,116 @@ class TestStructuredOutputIntegration:
         assert result["parsed"] is None
         # parsing_error should capture the validation exception
         assert result["parsing_error"] is not None
+
+
+# ===========================================================================
+# `response_format` passed directly to invoke / bind_tools
+# ===========================================================================
+
+
+class GetWeatherTypedDict(TypedDict):
+    """Get the current weather in a given location."""
+
+    location: str
+
+
+class TestResponseFormatKwarg:
+    """Tests for `response_format` supplied outside `with_structured_output`."""
+
+    @staticmethod
+    def _mock_structured_model() -> ChatOpenRouter:
+        model = _make_model()
+        model.client = MagicMock()
+        model.client.chat.send.return_value = _make_sdk_response(
+            {
+                **_SIMPLE_RESPONSE_DICT,
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": '{"location": "SF"}',
+                        },
+                        "finish_reason": "stop",
+                        "index": 0,
+                    }
+                ],
+            }
+        )
+        return model
+
+    @pytest.mark.parametrize(
+        ("schema", "expected_name"),
+        [(GetWeather, "GetWeather"), (GetWeatherTypedDict, "GetWeatherTypedDict")],
+    )
+    def test_invoke_converts_schema_to_json_schema(
+        self, schema: Any, expected_name: str
+    ) -> None:
+        """Pydantic and `TypedDict` schemas are converted for the API."""
+        model = self._mock_structured_model()
+        model.invoke("weather in SF", response_format=schema)
+        rf = model.client.chat.send.call_args[1]["response_format"]
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["name"] == expected_name
+        assert rf["json_schema"]["schema"]["properties"]["location"]
+
+    def test_invoke_passes_through_provider_strategy_envelope(self) -> None:
+        """`ProviderStrategy` sends an OpenAI-style envelope, preserved as-is."""
+        model = self._mock_structured_model()
+        model.invoke(
+            "weather in SF",
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "GetWeather",
+                    "schema": {"type": "object", "properties": {}},
+                    "strict": True,
+                },
+            },
+        )
+        rf = model.client.chat.send.call_args[1]["response_format"]
+        assert rf == {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "GetWeather",
+                "schema": {"type": "object", "properties": {}},
+                "strict": True,
+            },
+        }
+
+    def test_invoke_passes_through_json_mode(self) -> None:
+        """A `json_object` response format is left untouched."""
+        model = self._mock_structured_model()
+        model.invoke("weather in SF", response_format={"type": "json_object"})
+        rf = model.client.chat.send.call_args[1]["response_format"]
+        assert rf == {"type": "json_object"}
+
+    def test_bind_tools_converts_response_format(self) -> None:
+        """`bind_tools` converts a schema into a `json_schema` envelope."""
+        model = _make_model()
+        bound = model.bind_tools([], response_format=GetWeather)
+        assert isinstance(bound, RunnableBinding)
+        rf = bound.kwargs["response_format"]
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["name"] == "GetWeather"
+
+    def test_bind_tools_forwards_strict(self) -> None:
+        """`strict` is forwarded onto the converted `response_format`."""
+        model = _make_model()
+        bound = model.bind_tools([], response_format=GetWeather, strict=True)
+        assert isinstance(bound, RunnableBinding)
+        assert bound.kwargs["response_format"]["json_schema"]["strict"] is True
+
+    def test_raw_json_schema_without_title_is_wrapped(self) -> None:
+        """A titleless JSON schema is wrapped rather than raising."""
+        schema = {"type": "object", "properties": {"location": {"type": "string"}}}
+        assert _convert_to_openrouter_response_format(schema) == {
+            "type": "json_schema",
+            "json_schema": {"name": "", "schema": schema},
+        }
+
+    def test_none_returns_none(self) -> None:
+        """No schema means no `response_format`."""
+        assert _convert_to_openrouter_response_format(None) is None
 
 
 # ===========================================================================

--- a/libs/partners/openrouter/uv.lock
+++ b/libs/partners/openrouter/uv.lock
@@ -293,7 +293,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -396,7 +396,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.5.5"
+version = "1.6.2"
 source = { editable = "../../core" }
 dependencies = [
     { name = "httpx" },
@@ -444,7 +444,7 @@ test = [
     { name = "pytest-benchmark" },
     { name = "pytest-codspeed" },
     { name = "pytest-mock", specifier = ">=3.10.0,<4.0.0" },
-    { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
+    { name = "pytest-socket", specifier = ">=0.7.0,<0.8.0" },
     { name = "pytest-watcher", specifier = ">=0.3.4,<1.0.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
     { name = "responses", specifier = ">=0.25.0,<1.0.0" },
@@ -548,7 +548,7 @@ requires-dist = [
     { name = "pytest-codspeed" },
     { name = "pytest-recording" },
     { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
-    { name = "syrupy", specifier = ">=5.0.0,<6.0.0" },
+    { name = "syrupy", specifier = ">=5.0.0,<7.0.0" },
     { name = "vcrpy", specifier = ">=8.2.1,<9.0.0" },
 ]
 


### PR DESCRIPTION
`ChatOpenRouter` and `ChatFireworks` now accept `response_format` as a Pydantic model class, `TypedDict` class, dataclass, JSON schema dict, or an OpenAI-style `{"type": "json_schema", "json_schema": {...}}` envelope — on both `invoke(..., response_format=...)` and `bind_tools(response_format=...)`.

- Why: `create_agent`'s `ProviderStrategy` binds this envelope shape, so `create_agent(response_format=MySchema)` silently failed to enforce structured output on OpenRouter and Fireworks. Direct schema support also simplifies structured output flows (e.g. deepagents) that previously had to route through `with_structured_output`.
- The converters normalize any supported schema shape into the provider's `json_schema` envelope and pass existing `json_object`/`text` envelopes through untouched. `strict` is forwarded when explicitly provided.
- `ChatOpenAI`, `ChatAnthropic` (via `output_config.format`), and `ChatOllama` (via `format`) already handled these shapes; this brings OpenRouter and Fireworks to parity.

## Release note

`langchain-openrouter` and `langchain-fireworks` chat models now support `response_format` (Pydantic model, `TypedDict`, dataclass, JSON schema, or OpenAI-style `json_schema` envelope) when passed directly to `invoke`/`bind_tools`, enabling native structured output through `create_agent`'s `ProviderStrategy`.

_AI-agent involvement: this contribution was prepared collaboratively with Open SWE; a human reviewer should verify the schema-conversion edge cases._

Made by [Open SWE](https://openswe.vercel.app/agents/53776ff5-6f18-5e52-9460-8c2a64a954a0) · openai:gpt-5.6-sol (high)