### PR TITLE
fix(openai): route `gpt-6-astra` to responses API

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -698,6 +698,7 @@ _RESPONSES_API_ONLY_PREFIXES = (
     "gpt-5.4-pro",
     "gpt-5.5-pro",
     "gpt-5.6-sol",
+    "gpt-6-astra",
 )
 
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4646,7 +4646,7 @@ def test_gpt_5_1_temperature_with_reasoning_effort_none(
 
 
 def test_model_prefers_responses_api() -> None:
-    # Pro and Sol models (with and without date snapshots): Responses API only
+    # Pro, Sol, and Astra models (with and without date snapshots): Responses API only
     assert _model_prefers_responses_api("gpt-5-pro")
     assert _model_prefers_responses_api("gpt-5-pro-2025-10-06")
     assert _model_prefers_responses_api("gpt-5.2-pro")
@@ -4655,6 +4655,8 @@ def test_model_prefers_responses_api() -> None:
     assert _model_prefers_responses_api("gpt-5.4-pro-2026-03-05")
     assert _model_prefers_responses_api("gpt-5.6-sol")
     assert _model_prefers_responses_api("gpt-5.6-sol-2026-09-01")
+    assert _model_prefers_responses_api("gpt-6-astra")
+    assert _model_prefers_responses_api("gpt-6-astra-2026-09-04")
     # Codex models: Responses API only
     assert _model_prefers_responses_api("gpt-5.3-codex")
     assert _model_prefers_responses_api("gpt-5.3-codex")


### PR DESCRIPTION
Fixes #40346

`ChatOpenAI(model="gpt-6-astra")` with function tools was routed to Chat Completions by default, where OpenAI rejects function tools with reasoning. This adds `gpt-6-astra` to `_RESPONSES_API_ONLY_PREFIXES`, following the existing `gpt-5.6-sol` routing in #40133, with coverage for the base model name and a dated-snapshot-style name.

## Release note

`ChatOpenAI` now routes `gpt-6-astra` to the Responses API by default, allowing function tools to work without explicitly setting `use_responses_api=True`.

## Tests

`make format`, `make lint`, and `make test` all pass.