### PR TITLE
fix(core): apply strict to pre-wrapped {type:function} dicts in convert_to_openai_tool

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -557,6 +557,15 @@ def convert_to_openai_tool(
 
     if isinstance(tool, dict):
         if tool.get("type") in _WellKnownOpenAITools:
+            # For `{"type": "function", "function": {...}}` dicts, honour an explicit
+            # `strict` argument: pass the inner function definition through
+            # `convert_to_openai_function` so that `strict` is applied and validated
+            # (including raising `ValueError` on a conflicting existing `strict` key).
+            # Built-in tools (file_search, computer, etc.) have no function schema to
+            # make strict, so they are returned unchanged regardless of `strict`.
+            if strict is not None and tool.get("type") == "function" and "function" in tool:
+                oai_function = convert_to_openai_function(tool["function"], strict=strict)
+                return {**tool, "function": oai_function}
             return tool
         # As of 03.12.25 can be "web_search_preview" or "web_search_preview_2025_03_11"
         if (tool.get("type") or "").startswith("web_search_preview"):

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -1502,3 +1502,66 @@ def test_convert_to_openai_function_without_tools_module_imported(
     result = convert_to_openai_function(my_func)
 
     assert result["name"] == "my_func"
+
+
+def test_convert_to_openai_tool_wrapped_function_strict() -> None:
+    """A wrapped ``{"type": "function", "function": {...}}`` dict honours ``strict=True``.
+
+    Regression test for #40332: an already-wrapped tool was returned unchanged,
+    silently discarding the ``strict`` argument.
+    """
+    function_def = {
+        "name": "lookup",
+        "description": "Lookup data",
+        "parameters": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+        },
+    }
+    wrapped = convert_to_openai_tool(
+        {"type": "function", "function": function_def}, strict=True
+    )
+    assert wrapped["function"].get("strict") is True
+    assert wrapped["function"]["parameters"].get("additionalProperties") is False
+
+
+def test_convert_to_openai_tool_wrapped_function_strict_conflict() -> None:
+    """A conflicting ``strict`` value on a wrapped dict raises ``ValueError``."""
+    function_def = {
+        "name": "lookup",
+        "strict": False,
+        "parameters": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+        },
+    }
+    with pytest.raises(ValueError, match="strict"):
+        convert_to_openai_tool(
+            {"type": "function", "function": function_def}, strict=True
+        )
+
+
+def test_convert_to_openai_tool_builtin_ignores_strict() -> None:
+    """Built-in tools (no nested ``function`` key) are returned unchanged even when
+    ``strict`` is passed; they have no schema to make strict."""
+    computer_tool = {
+        "type": "computer",
+        "display_width": 1024,
+        "display_height": 768,
+        "environment": "browser",
+    }
+    result = convert_to_openai_tool(computer_tool, strict=True)
+    assert result == computer_tool
+
+
+def test_convert_to_openai_tool_wrapped_function_strict_none_unchanged() -> None:
+    """When ``strict=None`` (the default), a wrapped tool is returned unchanged."""
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "lookup",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+    result = convert_to_openai_tool(tool)
+    assert result is tool


### PR DESCRIPTION
## Summary

Fixes #40332.

When a caller passes a dict already in the `{"type": "function", "function": {...}}` form together with `strict=True`, the early `_WellKnownOpenAITools` return silently discarded the `strict` argument. The same function definition wrapped vs. unwrapped produced different output:

| Input | `function.strict` | `additionalProperties` |
|---|---|---|
| `{"name": ..., "parameters": ...}` (bare) | `True` | `False` |
| `{"type": "function", "function": {...}}` (wrapped) | absent | absent |

## Fix

When `strict is not None` and the tool is `{"type": "function", "function": {...}}`, pass the inner `function` definition through `convert_to_openai_function(strict=strict)`:

- `strict` is written onto the schema
- `_recursive_set_additional_properties_false` is applied
- A conflicting existing `strict` key raises `ValueError` (matching the unwrapped path)

Built-in tools (`computer`, `file_search`, `code_interpreter`, etc.) have no nested `function` key, so they are still returned unchanged regardless of `strict`.

When `strict=None` (the default), a pre-wrapped tool is returned unchanged — same behavior as before.

## Tests

Four new tests in `test_function_calling.py`:
- `test_convert_to_openai_tool_wrapped_function_strict` — strict applied to wrapped tool
- `test_convert_to_openai_tool_wrapped_function_strict_conflict` — conflicting strict raises ValueError
- `test_convert_to_openai_tool_builtin_ignores_strict` — built-in tools unchanged with strict
- `test_convert_to_openai_tool_wrapped_function_strict_none_unchanged` — strict=None returns tool as-is