### PR TITLE
fix(text-splitters): fix HTMLHeaderTextSplitter ValueError on non-heading tags

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -172,8 +172,11 @@ class HTMLHeaderTextSplitter:
                 fewer `Document` objects.
         """
         # Sort headers by their numeric level so that h1 < h2 < h3...
+        # If the tag is not a standard numbered heading (e.g., div, section),
+        # fallback to a large level so it sorts below all numbered headings.
         self.headers_to_split_on = sorted(
-            headers_to_split_on, key=lambda x: int(x[0][1:])
+            headers_to_split_on,
+            key=lambda x: int(x[0][1:]) if x[0][1:].isdigit() else 9999,
         )
         self.header_mapping = dict(self.headers_to_split_on)
         self.header_tags = [tag for tag, _ in self.headers_to_split_on]


### PR DESCRIPTION
Fixes #40341

HTMLHeaderTextSplitter previously threw a ValueError at initialization if passed a non-numeric heading tag like `div` or `p` (which is explicitly supported by the underlying splitting engine). 

The issue was a `key=lambda x: int(x[0][1:])` used to sort the headers. This PR adds a fallback to level 9999 if the tag suffix isn't numeric, mirroring exactly what the splitting logic does later on in `_generate_documents`.