### PR TITLE
fix(core): prevent parallel tool calls from colliding in v3 message streams

### DIFF
--- a/libs/core/langchain_core/language_models/_compat_bridge.py
+++ b/libs/core/langchain_core/language_models/_compat_bridge.py
@@ -203,7 +203,10 @@ def _iter_protocol_blocks(msg: BaseMessage) -> list[tuple[Any, CompatBlock]]:
             # `else` branch and clobbers the first. Same-type chunks
             # still share the bucket and merge cleanly, which is what
             # streaming text / reasoning relies on.
-            key: Any = ("__lc_no_index__", block.get("type"), i)
+            if block.get("type") == "tool_call" and block.get("id"):
+                key: Any = ("__lc_tool_call__", block["id"])
+            else:
+                key = ("__lc_no_index__", block.get("type"), i)
         else:
             key = explicit_idx
         result.append((key, dict(block)))


### PR DESCRIPTION
Fixes #40392

When streaming message chunks containing complete `tool_call` blocks that are not explicitly indexed, `_iter_protocol_blocks` previously fell back to a positional key based on the block's index within the chunk. For models like Gemini that stream parallel tool calls as separate chunks, each tool call gets position 0, causing a key collision. `_accumulate` then drops the earlier calls.

This PR updates the fallback logic to use the `id` of a `tool_call` block as its key if one is present, ensuring distinct parallel tool calls do not overwrite each other.