### PR TITLE
fix(text-splitters): accept non-heading header tags

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -173,7 +173,8 @@ class HTMLHeaderTextSplitter:
         """
         # Sort headers by their numeric level so that h1 < h2 < h3...
         self.headers_to_split_on = sorted(
-            headers_to_split_on, key=lambda x: int(x[0][1:])
+            headers_to_split_on,
+            key=lambda x: int(x[0][1:]) if x[0][1:].isdigit() else 9999,
         )
         self.header_mapping = dict(self.headers_to_split_on)
         self.header_tags = [tag for tag, _ in self.headers_to_split_on]

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -2637,6 +2637,16 @@ def html_header_splitter_splitter_factory() -> Callable[
     return _create_splitter
 
 
+def test_html_header_splitter_accepts_non_heading_tags() -> None:
+    splitter = HTMLHeaderTextSplitter(
+        headers_to_split_on=[("h1", "Title"), ("div", "Section")]
+    )
+
+    documents = splitter.split_text("<h1>Title</h1><div>Section</div>")
+
+    assert documents[1].metadata == {"Title": "Title", "Section": "Section"}
+
+
 @pytest.mark.parametrize(
     ("headers_to_split_on", "html_input", "expected_documents", "test_case"),
     [

--- a/libs/text-splitters/uv.lock
+++ b/libs/text-splitters/uv.lock
@@ -1279,7 +1279,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.6.1"
+version = "1.6.2"
 source = { editable = "../core" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

`HTMLHeaderTextSplitter` documents `headers_to_split_on` as accepting header tags, but sorting assumes every tag is `h1` through `h6`. Passing a supported non-heading tag such as `div` raises `ValueError` during initialization.

Use numeric ordering for heading tags and place other tags after them, matching the existing runtime fallback level.

## Tests

- `ruff check` on changed files
- Focused pytest (the test environment reports an unrelated missing `asyncio_mode` config plugin, but the targeted test is collected)

Closes #40341.
