### PR TITLE
fix(core): stop `UsageMetadataCallbackHandler` from dropping usage without `model_name`

### DIFF
--- a/libs/core/langchain_core/callbacks/usage.py
+++ b/libs/core/langchain_core/callbacks/usage.py
@@ -67,13 +67,14 @@ class UsageMetadataCallbackHandler(BaseCallbackHandler):
                 pass
 
         # update shared state behind lock
-        if usage_metadata and model_name:
+        if usage_metadata:
+            key = model_name or "unknown"
             with self._lock:
-                if model_name not in self.usage_metadata:
-                    self.usage_metadata[model_name] = usage_metadata
+                if key not in self.usage_metadata:
+                    self.usage_metadata[key] = usage_metadata
                 else:
-                    self.usage_metadata[model_name] = add_usage(
-                        self.usage_metadata[model_name], usage_metadata
+                    self.usage_metadata[key] = add_usage(
+                        self.usage_metadata[key], usage_metadata
                     )
 
 

--- a/libs/core/tests/unit_tests/callbacks/test_usage_callback.py
+++ b/libs/core/tests/unit_tests/callbacks/test_usage_callback.py
@@ -123,6 +123,21 @@ async def test_usage_callback_async() -> None:
     assert callback.usage_metadata == {"test_model": total_1_2}
 
 
+def test_usage_callback_missing_model_name() -> None:
+    """Usage must still be tracked when response_metadata lacks model_name."""
+    fresh_messages = [
+        AIMessage("Response 1", usage_metadata=usage1),
+        AIMessage("Response 2", usage_metadata=usage2),
+    ]
+    llm = GenericFakeChatModel(messages=iter(fresh_messages))
+
+    with get_usage_metadata_callback() as cb:
+        _ = llm.invoke("Message 1")
+        _ = llm.invoke("Message 2")
+        total_1_2 = add_usage(usage1, usage2)
+        assert cb.usage_metadata == {"unknown": total_1_2}
+
+
 def test_usage_callback_clears_on_exception() -> None:
     """Callback must stop tracking after with-block exits via exception (#38989)."""
     llm = FakeChatModelWithResponseMetadata(messages=iter(messages), model_name="fake")


### PR DESCRIPTION
`UsageMetadataCallbackHandler.on_llm_end` only recorded token usage when the response's `response_metadata` contained a `model_name` key:

```python
if usage_metadata and model_name:
    ...
```

Any chat model (custom subclasses, or third-party integrations that populate `usage_metadata` but don't set `response_metadata["model_name"]`) silently lost all usage tracking, with no warning and no error — `callback.usage_metadata` simply stayed empty. Since the whole purpose of this callback is tracking usage, this defeats it for anyone whose model doesn't happen to set that one key.

This changes the condition to only require `usage_metadata`, and buckets entries with no `model_name` under `"unknown"` instead of dropping them. Existing behavior for models that do set `model_name` is unchanged (all existing tests still pass, no key names or public signatures changed).

## Release note

Fixed `UsageMetadataCallbackHandler` (and `get_usage_metadata_callback`) silently dropping `usage_metadata` for chat model responses whose `response_metadata` doesn't include a `model_name` key; such usage is now recorded under an `"unknown"` key instead of being lost.

---

AI disclosure: this fix (root-cause investigation, patch, and regression test) was developed with an AI coding assistant (Claude Code) and reviewed before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vKFf7FdkUrBfjM2H7qLnY