### PR TITLE
docs(qdrant): add missing await in asimilarity_search example

### DIFF
--- a/libs/partners/qdrant/langchain_qdrant/qdrant.py
+++ b/libs/partners/qdrant/langchain_qdrant/qdrant.py
@@ -167,7 +167,7 @@ class QdrantVectorStore(VectorStore):
         # await vector_store.adelete(ids=["3"])
 
         # search
-        # results = vector_store.asimilarity_search(query="thud",k=1)
+        # results = await vector_store.asimilarity_search(query="thud", k=1)
 
         # search with score
         results = await vector_store.asimilarity_search_with_score(query="qux", k=1)


### PR DESCRIPTION
## Summary
Fixes #37058.

The async docstring example for `asimilarity_search` was missing `await`, unlike the neighboring async examples.

## Change
- Add `await` to the `asimilarity_search` example in `langchain_qdrant.qdrant`

## Test plan
- [x] Docs/example-only change