### PR TITLE
fix(langchain): preserve open MCP object arguments

### DIFF
--- a/libs/langchain_v1/langchain/mcp/tools.py
+++ b/libs/langchain_v1/langchain/mcp/tools.py
@@ -210,58 +210,24 @@ def _tool_metadata(tool: Tool, client: Client[Any] | None) -> dict[str, Any] | N
 
 
 def _normalize_mcp_schema(schema: dict[str, Any]) -> dict[str, Any]:
-    """Make open objects explicit unless evaluation annotations constrain them."""
-    nodes: list[dict[str, Any]] = []
-    normalized = _copy_mcp_schema(schema, nodes)
-    if any("unevaluatedProperties" in node for node in nodes):
-        return normalized
-    for node in nodes:
-        types = node.get("type", [])
-        if isinstance(types, str):
-            types = [types]
-        if isinstance(types, list) and "object" in types and node.get("properties", {}) == {}:
-            node.setdefault("additionalProperties", True)
-    return normalized
-
-
-def _copy_mcp_schema(schema: dict[str, Any], nodes: list[dict[str, Any]]) -> dict[str, Any]:
-    """Copy and collect schema positions without interpreting literal data."""
+    """Keep open object arguments open during provider schema conversion."""
     normalized = dict(schema)
-    nodes.append(normalized)
-    for key in (
-        "properties",
-        "$defs",
-        "definitions",
-        "patternProperties",
-        "dependentSchemas",
-        "dependencies",
-    ):
-        if isinstance(children := schema.get(key), dict):
-            normalized[key] = {
-                name: _copy_mcp_schema(child, nodes) if isinstance(child, dict) else child
-                for name, child in children.items()
-            }
-    for key in (
-        "items",
-        "additionalProperties",
-        "contains",
-        "not",
-        "if",
-        "then",
-        "else",
-        "additionalItems",
-        "unevaluatedItems",
-        "unevaluatedProperties",
-        "propertyNames",
-    ):
-        if isinstance(child := schema.get(key), dict):
-            normalized[key] = _copy_mcp_schema(child, nodes)
-    for key in ("anyOf", "oneOf", "allOf", "prefixItems", "items"):
-        if isinstance(children := schema.get(key), list):
-            normalized[key] = [
-                _copy_mcp_schema(child, nodes) if isinstance(child, dict) else child
-                for child in children
-            ]
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return normalized
+    normalized["properties"] = dict(properties)
+    for name, value in properties.items():
+        if not isinstance(value, dict):
+            continue
+        types = value.get("type")
+        is_object = types == "object" or (isinstance(types, list) and "object" in types)
+        if (
+            is_object
+            and not value.get("properties")
+            and "additionalProperties" not in value
+            and "unevaluatedProperties" not in value
+        ):
+            normalized["properties"][name] = {**value, "additionalProperties": True}
     return normalized
 
 

--- a/libs/langchain_v1/langchain/mcp/tools.py
+++ b/libs/langchain_v1/langchain/mcp/tools.py
@@ -209,6 +209,62 @@ def _tool_metadata(tool: Tool, client: Client[Any] | None) -> dict[str, Any] | N
     return {"mcp": mcp} if mcp else None
 
 
+def _normalize_mcp_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Make open objects explicit unless evaluation annotations constrain them."""
+    nodes: list[dict[str, Any]] = []
+    normalized = _copy_mcp_schema(schema, nodes)
+    if any("unevaluatedProperties" in node for node in nodes):
+        return normalized
+    for node in nodes:
+        types = node.get("type", [])
+        if isinstance(types, str):
+            types = [types]
+        if isinstance(types, list) and "object" in types and node.get("properties", {}) == {}:
+            node.setdefault("additionalProperties", True)
+    return normalized
+
+
+def _copy_mcp_schema(schema: dict[str, Any], nodes: list[dict[str, Any]]) -> dict[str, Any]:
+    """Copy and collect schema positions without interpreting literal data."""
+    normalized = dict(schema)
+    nodes.append(normalized)
+    for key in (
+        "properties",
+        "$defs",
+        "definitions",
+        "patternProperties",
+        "dependentSchemas",
+        "dependencies",
+    ):
+        if isinstance(children := schema.get(key), dict):
+            normalized[key] = {
+                name: _copy_mcp_schema(child, nodes) if isinstance(child, dict) else child
+                for name, child in children.items()
+            }
+    for key in (
+        "items",
+        "additionalProperties",
+        "contains",
+        "not",
+        "if",
+        "then",
+        "else",
+        "additionalItems",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+        "propertyNames",
+    ):
+        if isinstance(child := schema.get(key), dict):
+            normalized[key] = _copy_mcp_schema(child, nodes)
+    for key in ("anyOf", "oneOf", "allOf", "prefixItems", "items"):
+        if isinstance(children := schema.get(key), list):
+            normalized[key] = [
+                _copy_mcp_schema(child, nodes) if isinstance(child, dict) else child
+                for child in children
+            ]
+    return normalized
+
+
 async def as_langchain_tool(
     tool: Tool,
     client: Client[Any] | ClientGroup,
@@ -274,7 +330,7 @@ async def as_langchain_tool(
     return StructuredTool(
         name=tool.name,
         description=tool.description or "",
-        args_schema=tool.input_schema,
+        args_schema=_normalize_mcp_schema(tool.input_schema),
         coroutine=call_tool,
         response_format="content_and_artifact",
         metadata=_tool_metadata(tool, requesting_client),

--- a/libs/langchain_v1/tests/unit_tests/mcp/test_schema.py
+++ b/libs/langchain_v1/tests/unit_tests/mcp/test_schema.py
@@ -1,0 +1,96 @@
+"""Schema compatibility at the MCP tool conversion boundary."""
+
+from copy import deepcopy
+from typing import Any
+
+import pytest
+from fastmcp import Client, FastMCP
+from langchain_core.utils.function_calling import convert_to_openai_tool
+from mcp.types import Tool
+
+from langchain.mcp import as_langchain_tool
+from langchain.mcp.tools import _normalize_mcp_schema
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"type": "object", "properties": {}},
+        {"type": "object"},
+        {"type": ["object", "null"], "properties": {}},
+    ],
+)
+async def test_open_payload_survives_provider_conversion(payload: dict[str, Any]) -> None:
+    schema = {
+        "type": "object",
+        "properties": {"payload": payload},
+        "required": ["payload"],
+    }
+    original = deepcopy(schema)
+    mcp_tool = Tool(name="call_operation", input_schema=schema)
+    server: FastMCP[None] = FastMCP("test")
+    client: Client[Any] = Client(server)
+    tool = await as_langchain_tool(mcp_tool, client)
+    parameters = convert_to_openai_tool(tool)["function"]["parameters"]
+    assert parameters["properties"]["payload"]["additionalProperties"] is True
+    assert parameters["properties"]["payload"]["type"] == payload["type"]
+    assert parameters["required"] == ["payload"]
+    assert mcp_tool.input_schema == original
+    assert schema == original
+
+
+@pytest.mark.parametrize("additional", [False, True, {"type": "string"}])
+def test_explicit_constraints_are_preserved(additional: object) -> None:
+    schema = {"type": "object", "properties": {}, "additionalProperties": additional}
+    assert _normalize_mcp_schema(schema) == schema
+
+
+def test_nested_schemas_preserve_literal_data() -> None:
+    empty = {"type": "object", "properties": {}}
+    schema = {
+        "$defs": {"payload": empty},
+        "type": "array",
+        "items": {"anyOf": [empty, {"type": "null"}]},
+        "default": empty,
+        "examples": [empty],
+    }
+    normalized = _normalize_mcp_schema(schema)
+    assert normalized["$defs"]["payload"]["additionalProperties"] is True
+    assert normalized["items"]["anyOf"][0]["additionalProperties"] is True
+    assert normalized["default"] == empty
+    assert normalized["examples"] == [empty]
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {"type": "object", "properties": {}, "unevaluatedProperties": False},
+        {
+            "allOf": [{"type": "object", "properties": {}}],
+            "unevaluatedProperties": False,
+        },
+        {
+            "$defs": {"payload": {"type": "object", "properties": {}}},
+            "$ref": "#/$defs/payload",
+            "unevaluatedProperties": {"type": "string"},
+        },
+    ],
+)
+async def test_unevaluated_properties_constraints_are_preserved(
+    schema: dict[str, Any],
+) -> None:
+    server: FastMCP[None] = FastMCP("test")
+    client: Client[Any] = Client(server)
+    tool = await as_langchain_tool(Tool(name="restricted", input_schema=schema), client)
+    assert tool.args_schema == schema
+
+
+def test_literal_unevaluated_properties_do_not_disable_normalization() -> None:
+    schema = {
+        "type": "object",
+        "properties": {},
+        "default": {"unevaluatedProperties": False},
+    }
+    normalized = _normalize_mcp_schema(schema)
+    assert normalized["additionalProperties"] is True
+    assert normalized["default"] == schema["default"]

--- a/libs/langchain_v1/tests/unit_tests/mcp/test_schema.py
+++ b/libs/langchain_v1/tests/unit_tests/mcp/test_schema.py
@@ -39,58 +39,15 @@ async def test_open_payload_survives_provider_conversion(payload: dict[str, Any]
     assert schema == original
 
 
-@pytest.mark.parametrize("additional", [False, True, {"type": "string"}])
-def test_explicit_constraints_are_preserved(additional: object) -> None:
-    schema = {"type": "object", "properties": {}, "additionalProperties": additional}
-    assert _normalize_mcp_schema(schema) == schema
-
-
-def test_nested_schemas_preserve_literal_data() -> None:
-    empty = {"type": "object", "properties": {}}
-    schema = {
-        "$defs": {"payload": empty},
-        "type": "array",
-        "items": {"anyOf": [empty, {"type": "null"}]},
-        "default": empty,
-        "examples": [empty],
-    }
-    normalized = _normalize_mcp_schema(schema)
-    assert normalized["$defs"]["payload"]["additionalProperties"] is True
-    assert normalized["items"]["anyOf"][0]["additionalProperties"] is True
-    assert normalized["default"] == empty
-    assert normalized["examples"] == [empty]
-
-
 @pytest.mark.parametrize(
-    "schema",
+    "constraint",
     [
-        {"type": "object", "properties": {}, "unevaluatedProperties": False},
-        {
-            "allOf": [{"type": "object", "properties": {}}],
-            "unevaluatedProperties": False,
-        },
-        {
-            "$defs": {"payload": {"type": "object", "properties": {}}},
-            "$ref": "#/$defs/payload",
-            "unevaluatedProperties": {"type": "string"},
-        },
+        {"additionalProperties": False},
+        {"additionalProperties": {"type": "string"}},
+        {"unevaluatedProperties": False},
     ],
 )
-async def test_unevaluated_properties_constraints_are_preserved(
-    schema: dict[str, Any],
-) -> None:
-    server: FastMCP[None] = FastMCP("test")
-    client: Client[Any] = Client(server)
-    tool = await as_langchain_tool(Tool(name="restricted", input_schema=schema), client)
-    assert tool.args_schema == schema
-
-
-def test_literal_unevaluated_properties_do_not_disable_normalization() -> None:
-    schema = {
-        "type": "object",
-        "properties": {},
-        "default": {"unevaluatedProperties": False},
-    }
-    normalized = _normalize_mcp_schema(schema)
-    assert normalized["additionalProperties"] is True
-    assert normalized["default"] == schema["default"]
+def test_explicit_constraints_are_preserved(constraint: dict[str, Any]) -> None:
+    payload = {"type": "object", **constraint}
+    schema = {"type": "object", "properties": {"payload": payload}}
+    assert _normalize_mcp_schema(schema)["properties"]["payload"] == payload


### PR DESCRIPTION
Some MCP servers expose a small set of gateway tools—such as list, describe, and call—instead of one tool per operation. Their call tool accepts a free-form object, but provider conversion can accidentally turn that argument into an object that accepts no fields.

This change marks those direct free-form object arguments explicitly with `additionalProperties: true`, so models can send operation-specific keys through the gateway. It preserves constraints supplied by the MCP server and does not mutate the original schema.

The normalization is intentionally narrow: it only examines direct tool properties rather than recursively walking every JSON Schema keyword.

Six focused MCP schema tests pass; Ruff formatting/lint and mypy pass. No new dependencies or public API changes.

Made by [Open SWE](https://openswe.vercel.app/agents/3165441c-7638-5635-ae33-7d39299acb38) · openai:gpt-5.6-sol (high)
