### PR TITLE
test(langchain): make the `MCPAdapter` local-script refusal test pass on Windows

### DIFF
--- a/libs/langchain_v1/tests/unit_tests/mcp/test_adapter.py
+++ b/libs/langchain_v1/tests/unit_tests/mcp/test_adapter.py
@@ -238,11 +238,20 @@ def test_url_strings_are_accepted() -> None:
 
 
 def test_a_string_naming_a_local_script_is_refused(tmp_path: Path) -> None:
-    """A string must not select subprocess execution just by existing on disk."""
+    """A string must not select subprocess execution just by existing on disk.
+
+    Which guard refuses it turns on the platform, so what is asserted is the
+    refusal rather than one wording. On POSIX an absolute path fails URL
+    validation outright. On Windows the same path parses as a URL whose scheme
+    is the drive letter, so the scheme pin refuses it instead, as covered by
+    `test_strings_parsing_as_non_http_urls_are_refused`. A `tmp_path` need not
+    sit on `C:`, which is why the drive letter is matched rather than spelled
+    out.
+    """
     script = tmp_path / "server.py"
     script.touch()
 
-    with pytest.raises(ValueError, match="not a valid URL"):
+    with pytest.raises(ValueError, match=r"not a valid URL|has scheme '[a-z]'"):
         MCPAdapter(str(script))
 
     # The same server, asked for explicitly, is still reachable.


### PR DESCRIPTION
Fixes #40396

---

Anyone running the `MCPAdapter` unit tests on Windows sees the test that checks a bare string naming a local script is refused fail, even though the target is refused there too. A `tmp_path` is an absolute path: on POSIX it fails URL validation and the refusal reads "is not a valid URL", while on Windows the same path parses as a URL whose scheme is the drive letter and the adapter's scheme pin refuses it instead, reading "has scheme 'c'".

The test now accepts either refusal and matches the drive letter rather than spelling out `c`, so it no longer depends on which drive the temporary directory sits on. The production guard and both of its messages are untouched, and the drive-letter case stays pinned by the existing scheme test.

Local run on macOS: 32 passed in the focused test file, with `ruff check`, `ruff format --check` and `mypy` clean.

AI assistance was used to prepare this change; I reviewed and verified it locally.
