### PR TITLE
fix(core): apply strict to OpenAI-formatted tool dicts and guard parameter-less functions

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -486,7 +486,11 @@ def convert_to_openai_function(
             )
             raise ValueError(msg)
         oai_function["strict"] = strict
-        if strict:
+        if (
+            strict
+            and "parameters" in oai_function
+            and isinstance(oai_function["parameters"], dict)
+        ):
             oai_function["parameters"] = _recursive_set_additional_properties_false(
                 oai_function["parameters"]
             )
@@ -556,6 +560,17 @@ def convert_to_openai_tool(
     from langchain_core.tools import Tool  # noqa: PLC0415
 
     if isinstance(tool, dict):
+        if tool.get("type") == "function" and "function" in tool:
+            if strict is not None:
+                fn_dict = convert_to_openai_function(tool["function"], strict=strict)
+                if isinstance(tool["function"], dict):
+                    fn_dict = {**tool["function"], **fn_dict}
+                return {
+                    **tool,
+                    "type": "function",
+                    "function": fn_dict,
+                }
+            return tool
         if tool.get("type") in _WellKnownOpenAITools:
             return tool
         # As of 03.12.25 can be "web_search_preview" or "web_search_preview_2025_03_11"

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -1502,3 +1502,80 @@ def test_convert_to_openai_function_without_tools_module_imported(
     result = convert_to_openai_function(my_func)
 
     assert result["name"] == "my_func"
+
+
+def test_convert_to_openai_tool_dict_strict() -> None:
+    """Test that convert_to_openai_tool properly applies strict to tool dicts."""
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get current weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"location": {"type": "string"}},
+                "required": ["location"],
+            },
+        },
+    }
+
+    # strict=True: sets strict=True and additionalProperties=False
+    res_true = convert_to_openai_tool(tool, strict=True)
+    assert res_true["type"] == "function"
+    assert res_true["function"]["strict"] is True
+    assert res_true["function"]["parameters"]["additionalProperties"] is False
+
+    # strict=False: sets strict=False without adding additionalProperties=False
+    res_false = convert_to_openai_tool(tool, strict=False)
+    assert res_false["type"] == "function"
+    assert res_false["function"]["strict"] is False
+    assert "additionalProperties" not in res_false["function"]["parameters"]
+
+    # strict=None: returns original tool dict unchanged
+    res_none = convert_to_openai_tool(tool, strict=None)
+    assert res_none is tool
+
+    # Preserves extra attributes like cache_control and top-level custom keys
+    tool_with_extra = {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "parameters": {"type": "object", "properties": {}},
+            "cache_control": {"type": "ephemeral"},
+        },
+        "custom_metadata": "kept",
+    }
+    res_extra = convert_to_openai_tool(tool_with_extra, strict=True)
+    assert res_extra["function"]["strict"] is True
+    assert res_extra["function"]["cache_control"] == {"type": "ephemeral"}
+    assert res_extra["custom_metadata"] == "kept"
+
+    # Conflicting strict raises ValueError
+    conflicting_tool = {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "strict": False,
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+    with pytest.raises(ValueError, match="different from the explicit `strict` arg"):
+        convert_to_openai_tool(conflicting_tool, strict=True)
+
+
+def test_convert_to_openai_function_and_tool_without_parameters_strict() -> None:
+    """Test strict conversion when function has no parameters key."""
+    fn_without_params = {"name": "get_time", "description": "Get current time"}
+    res_fn = convert_to_openai_function(fn_without_params, strict=True)
+    assert res_fn["name"] == "get_time"
+    assert res_fn["strict"] is True
+    assert "parameters" not in res_fn
+
+    tool_without_params = {
+        "type": "function",
+        "function": {"name": "get_time", "description": "Get current time"},
+    }
+    res_tool = convert_to_openai_tool(tool_without_params, strict=True)
+    assert res_tool["function"]["name"] == "get_time"
+    assert res_tool["function"]["strict"] is True
+    assert "parameters" not in res_tool["function"]


### PR DESCRIPTION
Fixes #40332

`convert_to_openai_tool` now respects `strict` when passed tools formatted as `{"type": "function", "function": ...}`, enabling Structured Outputs on OpenAI tool dicts, and safely handles parameter-less function definitions without raising `KeyError`.

## Release note
`convert_to_openai_tool` now applies `strict` to dictionaries formatted as OpenAI tools (`{"type": "function", "function": ...}`), and avoids `KeyError` when converting functions with no parameters in strict mode.

## How did you verify your code works?
- Added unit tests in `libs/core/tests/unit_tests/utils/test_function_calling.py` covering `strict=True`, `strict=False`, `strict=None`, metadata preservation (such as `cache_control`), conflicting strict check, and parameter-less function definitions.
- Ran pytest on `libs/core/tests/unit_tests/utils/test_function_calling.py` (47 passed, 1 xfailed, 1 xpassed).
- Ran full `libs/core/tests/unit_tests/utils/` test suite (265 passed, 3 xfailed, 1 xpassed).
- Ran `ruff check .` (all checks passed) and `ruff format --check .` (clean).
- Ran `mypy` on `langchain_core/utils/function_calling.py` (clean, 0 errors).