### PR TITLE
fix(fireworks): surface reasoning_content in streaming chunks

### DIFF
--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -536,6 +536,8 @@ def _convert_chunk_to_message_chunk(
                         index=rtc.get("index"),
                     )
                 )
+    if reasoning_content := _dict.get("reasoning_content"):
+        additional_kwargs["reasoning_content"] = reasoning_content
     if role == "user" or default_class == HumanMessageChunk:
         return HumanMessageChunk(content=content)
     if role == "assistant" or default_class == AIMessageChunk:

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -1383,6 +1383,42 @@ class TestConvertChunkToMessageChunk:
             "input_token_details": {"cache_read": 6},
         }
 
+    def test_reasoning_content_surfaces_in_additional_kwargs(self) -> None:
+        """Streamed `reasoning_content` delta reaches `additional_kwargs`."""
+        chunk = {
+            "choices": [
+                {
+                    "delta": {
+                        "role": "assistant",
+                        "content": "",
+                        "reasoning_content": "Let me think about this...",
+                    }
+                }
+            ],
+        }
+        result = _convert_chunk_to_message_chunk(chunk, AIMessageChunk)
+        assert isinstance(result, AIMessageChunk)
+        assert (
+            result.additional_kwargs.get("reasoning_content")
+            == "Let me think about this..."
+        )
+
+    def test_no_reasoning_content_key_when_absent(self) -> None:
+        """Deltas without `reasoning_content` should not add the key at all."""
+        chunk = {
+            "choices": [
+                {
+                    "delta": {
+                        "role": "assistant",
+                        "content": "hello",
+                    }
+                }
+            ],
+        }
+        result = _convert_chunk_to_message_chunk(chunk, AIMessageChunk)
+        assert isinstance(result, AIMessageChunk)
+        assert "reasoning_content" not in result.additional_kwargs
+
 
 class TestCreateChatResult:
     """Tests for converting Fireworks responses into chat generations."""


### PR DESCRIPTION
Fixes #40367
Fixes the streaming-inbound half of #40367. 

`_convert_chunk_to_message_chunk` did not extract `reasoning_content` from streamed deltas, even though the non-streaming `_convert_dict_to_message` already did. This PR adds the same extraction to `additional_kwargs` for streaming, mirroring the existing pattern.

### Scope Note
This PR intentionally does **NOT** touch outbound forwarding (`_convert_message_to_dict`). That behavior was addressed in #39973, which deliberately strips `reasoning_content` on outbound requests to avoid wire-format rejections. Re-adding outbound forwarding would conflict with that change.

### Changes
* Updated `_convert_chunk_to_message_chunk` to extract `reasoning_content`.
* Added two unit tests covering cases where `reasoning_content` is present and absent in streamed deltas.